### PR TITLE
refactor: noxfile exclusion from synth changes

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -14,8 +14,6 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
-
 import synthtool as s
 from synthtool import gcp
 
@@ -63,8 +61,6 @@ s.replace("google/cloud/bigquery_v2/proto/*.py", "[“”]", '``')
 # Add templated files
 # ----------------------------------------------------------------------------
 templated_files = common.py_library(cov_level=100)
-# we do not want to override the custom noxfile with the generated one
-os.remove(os.path.join(templated_files, "noxfile.py"))
-s.move(templated_files)
+s.move(templated_files, excludes=["noxfile.py"])
 
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)


### PR DESCRIPTION
Closes #29.

This PR simplifies the logic in synth file that prevent the `synthtool` from overriding the custom noxfile in this library.

### How to test

Install and run the [synthtool](https://github.com/googleapis/synthtool). `noxfile.py` should be (still) left intact by the `synthtool`, as it was before this change, too.

### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
