### PR TITLE
docs: add limitation note for loading REPEATED fields

### DIFF
--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -1712,6 +1712,14 @@ class Client(ClientWithProject):
         Similar to :meth:`load_table_from_uri`, this method creates, starts and
         returns a :class:`~google.cloud.bigquery.job.LoadJob`.
 
+        .. note::
+
+            Due to the way REPEATED fields are encoded in the ``parquet`` file
+            format, a mismatch with the existing table schema can occur, and
+            100% compatibility cannot be guaranteed for REPEATED fields.
+
+            https://github.com/googleapis/python-bigquery/issues/17
+
         Arguments:
             dataframe (pandas.DataFrame):
                 A :class:`~pandas.DataFrame` containing the data to load.


### PR DESCRIPTION
Closes #17.

This PR adds a limitation note about uploading REPEATED (i.e. array) fields with the `load_table_from_dataframe()` method.

It appears that REPEATED fields in parquet files (used for uploading the data) are encoded in a way that is not always compatible with the table schema definition on the backend.

### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


