### PR TITLE
fix: allow partial streaming_buffer statistics

### DIFF
--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -1139,12 +1139,12 @@ class StreamingBuffer(object):
     """
 
     def __init__(self, resource):
-        if resource["estimatedBytes"]:
+        if "estimatedBytes" in resource:
             self.estimated_bytes = int(resource["estimatedBytes"])
-        if resource["estimatedRows"]:
+        if "estimatedRows" in resource:
             self.estimated_rows = int(resource["estimatedRows"])
         # time is in milliseconds since the epoch.
-        if resource["oldestEntryTime"]:
+        if "oldestEntryTime" in resource:
             self.oldest_entry_time = google.cloud._helpers._datetime_from_microseconds(
                 1000.0 * int(resource["oldestEntryTime"])
             )

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -1139,11 +1139,13 @@ class StreamingBuffer(object):
     """
 
     def __init__(self, resource):
+        self.estimated_bytes = None
         if "estimatedBytes" in resource:
             self.estimated_bytes = int(resource["estimatedBytes"])
+        self.estimated_rows = None
         if "estimatedRows" in resource:
             self.estimated_rows = int(resource["estimatedRows"])
-        # time is in milliseconds since the epoch.
+        self.oldest_entry_time = None
         if "oldestEntryTime" in resource:
             self.oldest_entry_time = google.cloud._helpers._datetime_from_microseconds(
                 1000.0 * int(resource["oldestEntryTime"])

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -1139,11 +1139,14 @@ class StreamingBuffer(object):
     """
 
     def __init__(self, resource):
-        self.estimated_bytes = int(resource["estimatedBytes"])
-        self.estimated_rows = int(resource["estimatedRows"])
+        if resource["estimatedBytes"]:
+          self.estimated_bytes = int(resource["estimatedBytes"])
+        if resource["estimatedRows"]:
+          self.estimated_rows = int(resource["estimatedRows"])
         # time is in milliseconds since the epoch.
-        self.oldest_entry_time = google.cloud._helpers._datetime_from_microseconds(
-            1000.0 * int(resource["oldestEntryTime"])
+        if resource["oldestEntryTime"]:
+            self.oldest_entry_time = google.cloud._helpers._datetime_from_microseconds(
+                1000.0 * int(resource["oldestEntryTime"])
         )
 
 

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -1140,14 +1140,14 @@ class StreamingBuffer(object):
 
     def __init__(self, resource):
         if resource["estimatedBytes"]:
-          self.estimated_bytes = int(resource["estimatedBytes"])
+            self.estimated_bytes = int(resource["estimatedBytes"])
         if resource["estimatedRows"]:
-          self.estimated_rows = int(resource["estimatedRows"])
+            self.estimated_rows = int(resource["estimatedRows"])
         # time is in milliseconds since the epoch.
         if resource["oldestEntryTime"]:
             self.oldest_entry_time = google.cloud._helpers._datetime_from_microseconds(
                 1000.0 * int(resource["oldestEntryTime"])
-        )
+            )
 
 
 class Row(object):

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -855,6 +855,21 @@ class TestTable(unittest.TestCase, _SchemaBase):
         table = klass.from_api_repr(RESOURCE)
         self._verifyResourceProperties(table, RESOURCE)
 
+    def test_from_api_repr_w_partial_streamingbuffer(self):
+        import datetime
+        from google.cloud._helpers import UTC
+        from google.cloud._helpers import _millis
+
+        RESOURCE = self._make_resource()
+        self.OLDEST_TIME = datetime.datetime(2015, 8, 1, 23, 59, 59, tzinfo=UTC)
+        RESOURCE["streamingBuffer"] = {"oldestEntryTime": _millis(self.OLDEST_TIME)}
+        klass = self._get_target_class()
+        table = klass.from_api_repr(RESOURCE)
+        self.assertIsNotNone(table.streaming_buffer)
+        self.assertIsNone(table.streaming_buffer.estimated_rows)
+        self.assertIsNone(table.streaming_buffer.estimated_bytes)
+        self.assertEqual(table.streaming_buffer.oldest_entry_time, self.OLDEST_TIME)
+
     def test_from_api_with_encryption(self):
         self._setUpConstants()
         RESOURCE = {

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -869,6 +869,14 @@ class TestTable(unittest.TestCase, _SchemaBase):
         self.assertIsNone(table.streaming_buffer.estimated_rows)
         self.assertIsNone(table.streaming_buffer.estimated_bytes)
         self.assertEqual(table.streaming_buffer.oldest_entry_time, self.OLDEST_TIME)
+        # Another partial construction
+        RESOURCE["streamingBuffer"] = {"estimatedRows": 1}
+        klass = self._get_target_class()
+        table = klass.from_api_repr(RESOURCE)
+        self.assertIsNotNone(table.streaming_buffer)
+        self.assertIsEqual(table.streaming_buffer.estimated_rows, 1)
+        self.assertIsNone(table.streaming_buffer.estimated_bytes)
+        self.assertIsNone(table.streaming_buffer.oldest_entry_time)
 
     def test_from_api_with_encryption(self):
         self._setUpConstants()

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -874,7 +874,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         klass = self._get_target_class()
         table = klass.from_api_repr(RESOURCE)
         self.assertIsNotNone(table.streaming_buffer)
-        self.assertIsEqual(table.streaming_buffer.estimated_rows, 1)
+        self.assertEqual(table.streaming_buffer.estimated_rows, 1)
         self.assertIsNone(table.streaming_buffer.estimated_bytes)
         self.assertIsNone(table.streaming_buffer.oldest_entry_time)
 


### PR DESCRIPTION
Previously, the BQ backend would supply all fields of the
streamingBuffer statistics or none.  This is no longer the
case, so we relax construction to not depend on all values
being present.

Related: internal issue b/148720220