### PR TITLE
chore: declare full Python 3.8 support

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -43,14 +43,6 @@ def default(session):
     # serialization, though.
     dev_install = ".[all,fastparquet]"
 
-    # There is no pyarrow or fastparquet wheel for Python 3.8.
-    if session.python == "3.8":
-        # Since many tests are skipped due to missing dependencies, test
-        # coverage is much lower in Python 3.8. Remove once we can test with
-        # pyarrow.
-        coverage_fail_under = "--cov-fail-under=91"
-        dev_install = ".[pandas,tqdm]"
-
     session.install("-e", dev_install)
 
     # IPython does not support Python 2 after version 5.x

--- a/noxfile.py
+++ b/noxfile.py
@@ -72,7 +72,7 @@ def unit(session):
     default(session)
 
 
-@nox.session(python=["2.7", "3.7"])
+@nox.session(python=["2.7", "3.8"])
 def system(session):
     """Run the system test suite."""
 
@@ -102,7 +102,7 @@ def system(session):
     )
 
 
-@nox.session(python=["2.7", "3.7"])
+@nox.session(python=["2.7", "3.8"])
 def snippets(session):
     """Run the snippets test suite."""
 
@@ -122,7 +122,7 @@ def snippets(session):
     session.run("py.test", "samples", *session.posargs)
 
 
-@nox.session(python="3.7")
+@nox.session(python="3.8")
 def cover(session):
     """Run the final coverage report.
 
@@ -134,7 +134,7 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python="3.7")
+@nox.session(python="3.8")
 def lint(session):
     """Run linters.
 
@@ -151,7 +151,7 @@ def lint(session):
     session.run("black", "--check", *BLACK_PATHS)
 
 
-@nox.session(python="3.7")
+@nox.session(python="3.8")
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
 
@@ -172,7 +172,7 @@ def blacken(session):
     session.run("black", *BLACK_PATHS)
 
 
-@nox.session(python="3.7")
+@nox.session(python="3.8")
 def docs(session):
     """Build the docs."""
 

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Operating System :: OS Independent",
         "Topic :: Internet",
     ],


### PR DESCRIPTION
Fixes #12.

This PR declares full support for Python 3.8 and uses/includes the latter to run various nox sessions.

### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


