### PR TITLE
fix: improve cell magic error message on missing query

### DIFF
--- a/google/cloud/bigquery/magics.py
+++ b/google/cloud/bigquery/magics.py
@@ -68,8 +68,7 @@
     * ``<query>`` (required, cell argument):
         SQL query to run. If the query does not contain any whitespace (aside
         from leading and trailing whitespace), it is assumed to represent a
-        fully-qualified table ID, and the latter's data will be fetched and
-        returned as ``pandas.DataFrame``.
+        fully-qualified table ID, and the latter's data will be fetched.
 
     Returns:
         A :class:`pandas.DataFrame` with the query results.

--- a/google/cloud/bigquery/magics.py
+++ b/google/cloud/bigquery/magics.py
@@ -66,7 +66,10 @@
           the variable name (ex. ``$my_dict_var``). See ``In[6]`` and ``In[7]``
           in the Examples section below.
     * ``<query>`` (required, cell argument):
-        SQL query to run.
+        SQL query to run. If the query does not contain any whitespace (aside
+        from leading and trailing whitespace), it is assumed to represent a
+        fully-qualified table ID, and the latter's data will be fetched and
+        returned as ``pandas.DataFrame``.
 
     Returns:
         A :class:`pandas.DataFrame` with the query results.
@@ -505,6 +508,11 @@ def _cell_magic(line, query):
             max_results = None
 
         query = query.strip()
+
+        if not query:
+            error = ValueError("Query is missing.")
+            _handle_error(error, args.destination_var)
+            return
 
         # Any query that does not contain whitespace (aside from leading and trailing whitespace)
         # is assumed to be a table id

--- a/tests/unit/test_magics.py
+++ b/tests/unit/test_magics.py
@@ -800,6 +800,22 @@ def test_bigquery_magic_w_table_id_invalid():
     assert "Traceback (most recent call last)" not in output
 
 
+def test_bigquery_magic_w_missing_query():
+    ip = IPython.get_ipython()
+    ip.extension_manager.load_extension("google.cloud.bigquery")
+    magics.context._project = None
+
+    cell_body = "   \n    \n   \t\t  \n  "
+
+    with io.capture_output() as captured_io:
+        ip.run_cell_magic("bigquery", "df", cell_body)
+
+    output = captured_io.stderr
+    assert "Could not save output to variable" in output
+    assert "Query is missing" in output
+    assert "Traceback (most recent call last)" not in output
+
+
 @pytest.mark.usefixtures("ipython_interactive")
 @pytest.mark.skipif(pandas is None, reason="Requires `pandas`")
 def test_bigquery_magic_w_table_id_and_destination_var():


### PR DESCRIPTION
Fixes #57.

This PR fixes the Jupyter cell magic error message if query is missing. The steps to reproduce/verify the fix are in the issue description.

### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
