### PR TITLE
docs: include details of inherited class members

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ extensions = [
 
 # autodoc/autosummary flags
 autoclass_content = "both"
-autodoc_default_flags = ["members"]
+autodoc_default_flags = ["members", "inherited-members"]
 autosummary_generate = True
 
 

--- a/google/cloud/bigquery/job.py
+++ b/google/cloud/bigquery/job.py
@@ -3168,6 +3168,9 @@ class QueryJob(_AsyncJob):
                 set** (this is distinct from the total number of rows in the
                 current page: ``iterator.page.num_items``).
 
+                If the query is a special query that produces no results, e.g.
+                a DDL query, an ``_EmptyRowIterator`` instance is returned.
+
         Raises:
             google.cloud.exceptions.GoogleCloudError:
                 If the job failed.


### PR DESCRIPTION
Fixes #5.

This PR fixes the docs for inherited class members, their details are no longer omitted. To test, generate the docs locally and verify that e.g. `LoadJob.result()` details are now actually present.

### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


