### PR TITLE
docs: fix generation warnings in new Sphinx version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
+    "recommonmark",
 ]
 
 # autodoc/autosummary flags
@@ -48,10 +49,6 @@ autosummary_generate = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
-
-# Allow markdown includes (so releases.md can include CHANGLEOG.md)
-# http://www.sphinx-doc.org/en/master/markdown.html
-source_parsers = {".md": "recommonmark.parser.CommonMarkParser"}
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:

--- a/docs/gapic/v2/types.rst
+++ b/docs/gapic/v2/types.rst
@@ -3,3 +3,4 @@ Types for BigQuery API Client
 
 .. automodule:: google.cloud.bigquery_v2.types
     :members:
+    :noindex:


### PR DESCRIPTION
Fixes #75.

This PR fixes adds a workaround to the docs generation error that started occurring recently by restricting Sphinx to older versions.

To test, try generating the docs with and without the change. Without the change, generating the docs failed due to the warning mentioned in the issue description.

### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


