### PR TITLE
chore: restrict llvmlite version for Python 2.7/3.5 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,14 @@ extras = {
         "pyarrow>=0.4.1, != 0.14.0"
     ],
     "tqdm": ["tqdm >= 4.0.0, <5.0.0dev"],
-    "fastparquet": ["fastparquet", "python-snappy"],
+    "fastparquet": [
+        "fastparquet",
+        "python-snappy",
+        # llvmlite >= 0.32.0 cannot be installed on Python 3.5 and below
+        # (building the wheel fails), thus needs to be restricted.
+        # See: https://github.com/googleapis/python-bigquery/issues/78
+        "llvmlite <= 0.31.0",
+    ],
 }
 
 all_extras = []


### PR DESCRIPTION
Fixes #78. 🦕

This PR restricts the version of a problematic dependency that causes problems when installing on Python 2.7 and 3.5, since we still need to support these two Python versions at the time of writing.

### PR checklist

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


