### PR TITLE
docs: explain the limitation of IPython magic dict arguments

### DIFF
--- a/google/cloud/bigquery/magics.py
+++ b/google/cloud/bigquery/magics.py
@@ -65,6 +65,14 @@
           serializable. The variable reference is indicated by a ``$`` before
           the variable name (ex. ``$my_dict_var``). See ``In[6]`` and ``In[7]``
           in the Examples section below.
+
+        .. note::
+
+            Due to the way IPython argument parser works, negative numbers in
+            dictionaries are incorrectly "recognized" as additional arguments,
+            resulting in an error ("unrecognized arguments"). To get around this,
+            pass such dictionary as a JSON string variable.
+
     * ``<query>`` (required, cell argument):
         SQL query to run. If the query does not contain any whitespace (aside
         from leading and trailing whitespace), it is assumed to represent a


### PR DESCRIPTION
Closes #108.

This PR clarifies the limitation of passing a dictionary argument to IPython cell magic, and documents a workaround.

Fixing the root cause is outside of BigQuery's scope, as it would require modifications to IPython's own argument parsing logic.

### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


