### PR TITLE
doc: update wording in rowiterator docstrings to reduce confusion

### DIFF
--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -1498,8 +1498,9 @@ class RowIterator(HTTPIterator):
                 This method requires the ``pyarrow`` and
                 ``google-cloud-bigquery-storage`` libraries.
 
-                Reading from a specific partition or snapshot is not
-                currently supported by this method.
+                This method only  exposes a subset of the capabilities of the
+                BigQuery Storage API.  For full access to all features
+                (projections, filters, snapshots) use the Storage API directly.
             create_bqstorage_client (bool):
                 **Beta Feature** Optional. If ``True``, create a BigQuery
                 Storage API client using the default API settings. The
@@ -1583,8 +1584,9 @@ class RowIterator(HTTPIterator):
                 This method requires the ``pyarrow`` and
                 ``google-cloud-bigquery-storage`` libraries.
 
-                Reading from a specific partition or snapshot is not
-                currently supported by this method.
+                This method only  exposes a subset of the capabilities of the
+                BigQuery Storage API.  For full access to all features
+                (projections, filters, snapshots) use the Storage API directly.
 
                 **Caution**: There is a known issue reading small anonymous
                 query result tables with the BQ Storage API. When a problem
@@ -1652,8 +1654,9 @@ class RowIterator(HTTPIterator):
                 This method requires the ``pyarrow`` and
                 ``google-cloud-bigquery-storage`` libraries.
 
-                Reading from a specific partition or snapshot is not
-                currently supported by this method.
+                This method only  exposes a subset of the capabilities of the
+                BigQuery Storage API.  For full access to all features
+                (projections, filters, snapshots) use the Storage API directly.
 
                 **Caution**: There is a known issue reading small anonymous
                 query result tables with the BQ Storage API. When a problem


### PR DESCRIPTION
Talking about partition filtration can be problematic, so refer
to Storage API capabilities more obliquely.  Particularly, partition
filtration is possible via a query or a direct storage API read, so
don't use as severe of language when describing helper mechanisms such
as to_dataframe() on row iterators.

Fixes: https://github.com/googleapis/python-bigquery-storage/issues/22