### PR TITLE
fix: dry run queries with DB API cursor

### DIFF
--- a/google/cloud/bigquery/dbapi/cursor.py
+++ b/google/cloud/bigquery/dbapi/cursor.py
@@ -28,8 +28,6 @@ import logging
 import six
 
 from google.cloud.bigquery import job
-from google.cloud.bigquery import schema
-from google.cloud.bigquery import table
 from google.cloud.bigquery.dbapi import _helpers
 from google.cloud.bigquery.dbapi import exceptions
 import google.cloud.exceptions
@@ -188,11 +186,8 @@ class Cursor(object):
         )
 
         if self._query_job.dry_run:
-            schema_field = schema.SchemaField(
-                name="estimated_bytes", field_type="INTEGER", mode="REQUIRED",
-            )
-            self._set_description(schema=[schema_field])
-            self.rowcount = 1
+            self._set_description(schema=None)
+            self.rowcount = 0
             return
 
         # Wait for the query to finish.
@@ -228,9 +223,7 @@ class Cursor(object):
             )
 
         if self._query_job.dry_run:
-            estimated_bytes = self._query_job.total_bytes_processed
-            row = table.Row((estimated_bytes,), {"estimated_bytes": 0})
-            self._query_data = iter([row])
+            self._query_data = iter([])
             return
 
         is_dml = (
@@ -347,9 +340,7 @@ class Cursor(object):
         """Fetch a single row from the results of the last ``execute*()`` call.
 
         .. note::
-            If a dry run query was executed, a row with a single value is
-            returned representing the estimated number of bytes that would be
-            processed by the query.
+            If a dry run query was executed, no rows are returned.
 
         Returns:
             Tuple:
@@ -369,9 +360,7 @@ class Cursor(object):
         """Fetch multiple results from the last ``execute*()`` call.
 
         .. note::
-            If a dry run query was executed, a row with a single value is
-            returned representing the estimated number of bytes that would be
-            processed by the query.
+            If a dry run query was executed, no rows are returned.
 
         .. note::
             The size parameter is not used for the request/response size.
@@ -410,9 +399,7 @@ class Cursor(object):
         """Fetch all remaining results from the last ``execute*()`` call.
 
         .. note::
-            If a dry run query was executed, a row with a single value is
-            returned representing the estimated number of bytes that would be
-            processed by the query.
+            If a dry run query was executed, no rows are returned.
 
         Returns:
             List[Tuple]: A list of all the rows in the results.

--- a/tests/system.py
+++ b/tests/system.py
@@ -1844,13 +1844,11 @@ class TestBigQuery(unittest.TestCase):
         """
 
         Config.CURSOR.execute(query, job_config=QueryJobConfig(dry_run=True))
-        self.assertEqual(Config.CURSOR.rowcount, 1, "expected a single row")
+        self.assertEqual(Config.CURSOR.rowcount, 0, "expected no rows")
 
         rows = Config.CURSOR.fetchall()
 
-        row_tuples = [r.values() for r in rows]
-        expected = [(3473,)]
-        self.assertEqual(row_tuples, expected)
+        self.assertEqual(list(rows), [])
 
     @unittest.skipIf(
         bigquery_storage_v1 is None, "Requires `google-cloud-bigquery-storage`"

--- a/tests/system.py
+++ b/tests/system.py
@@ -1782,6 +1782,24 @@ class TestBigQuery(unittest.TestCase):
         ]
         self.assertEqual(fetched_data, expected_data)
 
+    def test_dbapi_dry_run_query(self):
+        from google.cloud.bigquery.job import QueryJobConfig
+
+        query = """
+            SELECT country_name
+            FROM `bigquery-public-data.utility_us.country_code_iso`
+            WHERE country_name LIKE 'U%'
+        """
+
+        Config.CURSOR.execute(query, job_config=QueryJobConfig(dry_run=True))
+        self.assertEqual(Config.CURSOR.rowcount, 1, "expected a single row")
+
+        rows = Config.CURSOR.fetchall()
+
+        row_tuples = [r.values() for r in rows]
+        expected = [(3473,)]
+        self.assertEqual(row_tuples, expected)
+
     def _load_table_for_dml(self, rows, dataset_id, table_id):
         from google.cloud._testing import _NamedTemporaryFile
         from google.cloud.bigquery.job import CreateDisposition

--- a/tests/unit/test_dbapi_cursor.py
+++ b/tests/unit/test_dbapi_cursor.py
@@ -662,27 +662,10 @@ class TestCursor(unittest.TestCase):
             job_config=QueryJobConfig(dry_run=True),
         )
 
-        expected_description = (
-            dbapi.cursor.Column(
-                name="estimated_bytes",
-                type_code="INTEGER",
-                display_size=None,
-                internal_size=None,
-                precision=None,
-                scale=None,
-                null_ok=False,
-            ),
-        )
-        self.assertEqual(cursor.description, expected_description)
-        self.assertEqual(cursor.rowcount, 1)
-
+        self.assertEqual(cursor.rowcount, 0)
+        self.assertIsNone(cursor.description)
         rows = cursor.fetchall()
-
-        # We expect a single row with one column - the estimated numbe of bytes
-        # that will be processed by the query.
-        self.assertEqual(len(rows), 1)
-        self.assertEqual(len(rows[0]), 1)
-        self.assertEqual(rows[0][0], 12345)
+        self.assertEqual(list(rows), [])
 
     def test_execute_raises_if_result_raises(self):
         import google.cloud.exceptions


### PR DESCRIPTION
Fixes #118.

This PR fixes the error in DB API cursor if a dry run query is run.

As a side effect, it also fixes handling the client's default query job config in DB API (the default config, if any, has been ignored to date).

### PR checklist:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


