### PR TITLE
chore: remove workarounds for BQ Storage issue with small result sets

### DIFF
--- a/google/cloud/bigquery/dbapi/connection.py
+++ b/google/cloud/bigquery/dbapi/connection.py
@@ -36,7 +36,7 @@ class Connection(object):
             BigQuery. If not passed, it is created using the same credentials
             as ``client`` (provided that BigQuery Storage dependencies are installed).
 
-            If both clients are availalbe, ``bqstorage_client`` is used for
+            If both clients are available, ``bqstorage_client`` is used for
             fetching query results.
     """
 
@@ -106,7 +106,7 @@ def connect(client=None, bqstorage_client=None):
             BigQuery. If not passed, it is created using the same credentials
             as ``client`` (provided that BigQuery Storage dependencies are installed).
 
-            If both clients are availalbe, ``bqstorage_client`` is used for
+            If both clients are available, ``bqstorage_client`` is used for
             fetching query results.
 
     Returns:

--- a/google/cloud/bigquery/dbapi/connection.py
+++ b/google/cloud/bigquery/dbapi/connection.py
@@ -34,16 +34,10 @@ class Connection(object):
         ):
             A client that uses the faster BigQuery Storage API to fetch rows from
             BigQuery. If not passed, it is created using the same credentials
-            as ``client``.
+            as ``client`` (provided that BigQuery Storage dependencies are installed).
 
-            When fetching query results, ``bqstorage_client`` is used first, with
-            a fallback on ``client``, if necessary.
-
-            .. note::
-                There is a known issue with the BigQuery Storage API with small
-                anonymous result sets, which results in such fallback.
-
-                https://github.com/googleapis/python-bigquery-storage/issues/2
+            If both clients are availalbe, ``bqstorage_client`` is used for
+            fetching query results.
     """
 
     def __init__(self, client=None, bqstorage_client=None):
@@ -110,16 +104,10 @@ def connect(client=None, bqstorage_client=None):
         ):
             A client that uses the faster BigQuery Storage API to fetch rows from
             BigQuery. If not passed, it is created using the same credentials
-            as ``client``.
+            as ``client`` (provided that BigQuery Storage dependencies are installed).
 
-            When fetching query results, ``bqstorage_client`` is used first, with
-            a fallback on ``client``, if necessary.
-
-            .. note::
-                There is a known issue with the BigQuery Storage API with small
-                anonymous result sets, which results in such fallback.
-
-                https://github.com/googleapis/python-bigquery-storage/issues/2
+            If both clients are availalbe, ``bqstorage_client`` is used for
+            fetching query results.
 
     Returns:
         google.cloud.bigquery.dbapi.Connection: A new DB-API connection to BigQuery.

--- a/google/cloud/bigquery/dbapi/cursor.py
+++ b/google/cloud/bigquery/dbapi/cursor.py
@@ -224,26 +224,9 @@ class Cursor(object):
             bqstorage_client = self.connection._bqstorage_client
 
             if bqstorage_client is not None:
-                try:
-                    rows_iterable = self._bqstorage_fetch(bqstorage_client)
-                    self._query_data = _helpers.to_bq_table_rows(rows_iterable)
-                    return
-                except google.api_core.exceptions.GoogleAPICallError as exc:
-                    # NOTE: Forbidden is a subclass of GoogleAPICallError
-                    if isinstance(exc, google.api_core.exceptions.Forbidden):
-                        # Don't hide errors such as insufficient permissions to create
-                        # a read session, or the API is not enabled. Both of those are
-                        # clearly problems if the developer has explicitly asked for
-                        # BigQuery Storage API support.
-                        raise
-
-                    # There is an issue with reading from small anonymous
-                    # query results tables. If such an error occurs, we silence
-                    # it in order to try again with the tabledata.list API.
-                    _LOGGER.debug(
-                        "Error fetching data with BigQuery Storage API, "
-                        "falling back to tabledata.list API."
-                    )
+                rows_iterable = self._bqstorage_fetch(bqstorage_client)
+                self._query_data = _helpers.to_bq_table_rows(rows_iterable)
+                return
 
             rows_iter = client.list_rows(
                 self._query_job.destination,

--- a/google/cloud/bigquery/job.py
+++ b/google/cloud/bigquery/job.py
@@ -3335,9 +3335,6 @@ class QueryJob(_AsyncJob):
                 Reading from a specific partition or snapshot is not
                 currently supported by this method.
 
-                **Caution**: There is a known issue reading small anonymous
-                query result tables with the BQ Storage API. Write your query
-                results to a destination table to work around this issue.
             dtypes (Map[str, Union[str, pandas.Series.dtype]]):
                 Optional. A dictionary of column names pandas ``dtype``s. The
                 provided ``dtype`` is used when constructing the series for

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -1431,30 +1431,10 @@ class RowIterator(HTTPIterator):
         self, bqstorage_download, tabledata_list_download, bqstorage_client=None
     ):
         if bqstorage_client is not None:
-            try:
-                # Iterate over the stream so that read errors are raised (and
-                # the method can then fallback to tabledata.list).
-                for item in bqstorage_download():
-                    yield item
-                return
-            except google.api_core.exceptions.Forbidden:
-                # Don't hide errors such as insufficient permissions to create
-                # a read session, or the API is not enabled. Both of those are
-                # clearly problems if the developer has explicitly asked for
-                # BigQuery Storage API support.
-                raise
-            except google.api_core.exceptions.GoogleAPICallError:
-                # There is a known issue with reading from small anonymous
-                # query results tables, so some errors are expected. Rather
-                # than throw those errors, try reading the DataFrame again, but
-                # with the tabledata.list API.
-                pass
+            for item in bqstorage_download():
+                yield item
+            return
 
-        _LOGGER.debug(
-            "Started reading table '{}.{}.{}' with tabledata.list.".format(
-                self._table.project, self._table.dataset_id, self._table.table_id
-            )
-        )
         for item in tabledata_list_download():
             yield item
 
@@ -1599,14 +1579,10 @@ class RowIterator(HTTPIterator):
                 This method requires the ``pyarrow`` and
                 ``google-cloud-bigquery-storage`` libraries.
 
-                This method only  exposes a subset of the capabilities of the
-                BigQuery Storage API.  For full access to all features
+                This method only exposes a subset of the capabilities of the
+                BigQuery Storage API. For full access to all features
                 (projections, filters, snapshots) use the Storage API directly.
 
-                **Caution**: There is a known issue reading small anonymous
-                query result tables with the BQ Storage API. When a problem
-                is encountered reading a table, the tabledata.list method
-                from the BigQuery API is used, instead.
             dtypes (Map[str, Union[str, pandas.Series.dtype]]):
                 Optional. A dictionary of column names pandas ``dtype``s. The
                 provided ``dtype`` is used when constructing the series for
@@ -1668,14 +1644,10 @@ class RowIterator(HTTPIterator):
                 This method requires the ``pyarrow`` and
                 ``google-cloud-bigquery-storage`` libraries.
 
-                This method only  exposes a subset of the capabilities of the
-                BigQuery Storage API.  For full access to all features
+                This method only exposes a subset of the capabilities of the
+                BigQuery Storage API. For full access to all features
                 (projections, filters, snapshots) use the Storage API directly.
 
-                **Caution**: There is a known issue reading small anonymous
-                query result tables with the BQ Storage API. When a problem
-                is encountered reading a table, the tabledata.list method
-                from the BigQuery API is used, instead.
             dtypes (Map[str, Union[str, pandas.Series.dtype]]):
                 Optional. A dictionary of column names pandas ``dtype``s. The
                 provided ``dtype`` is used when constructing the series for

--- a/tests/unit/test_dbapi_cursor.py
+++ b/tests/unit/test_dbapi_cursor.py
@@ -434,62 +434,6 @@ class TestCursor(unittest.TestCase):
         # the default client was not used
         mock_client.list_rows.assert_not_called()
 
-    @unittest.skipIf(
-        bigquery_storage_v1 is None, "Requires `google-cloud-bigquery-storage`"
-    )
-    def test_fetchall_w_bqstorage_client_fetch_error_fallback_on_client(self):
-        from google.cloud.bigquery import dbapi
-        from google.cloud.bigquery import table
-
-        # use unordered data to also test any non-determenistic key order in dicts
-        row_data = [
-            table.Row([1.4, 1.1, 1.3, 1.2], {"bar": 3, "baz": 2, "foo": 1, "quux": 0}),
-            table.Row([2.4, 2.1, 2.3, 2.2], {"bar": 3, "baz": 2, "foo": 1, "quux": 0}),
-        ]
-        bqstorage_streamed_rows = [
-            {"bar": 1.2, "foo": 1.1, "quux": 1.4, "baz": 1.3},
-            {"bar": 2.2, "foo": 2.1, "quux": 2.4, "baz": 2.3},
-        ]
-
-        mock_client = self._mock_client(rows=row_data)
-        mock_bqstorage_client = self._mock_bqstorage_client(
-            stream_count=1, rows=bqstorage_streamed_rows,
-        )
-        request_error = exceptions.BadRequest("BQ storage what??")
-        mock_bqstorage_client.create_read_session.side_effect = request_error
-
-        connection = dbapi.connect(
-            client=mock_client, bqstorage_client=mock_bqstorage_client,
-        )
-        cursor = connection.cursor()
-        cursor.execute("SELECT foo, bar FROM some_table")
-
-        logger_patcher = mock.patch("google.cloud.bigquery.dbapi.cursor._LOGGER")
-        with logger_patcher as mock_logger:
-            rows = cursor.fetchall()
-
-        # both client were used
-        mock_bqstorage_client.create_read_session.assert_called()
-        mock_client.list_rows.assert_called()
-
-        # fallback to default API should have been logged
-        relevant_calls = [
-            call
-            for call in mock_logger.debug.call_args_list
-            if call.args and "tabledata.list API" in call.args[0]
-        ]
-        self.assertTrue(relevant_calls)
-
-        # check the data returned
-        field_value = op.itemgetter(1)
-        sorted_row_data = [sorted(row.items(), key=field_value) for row in rows]
-        expected_row_data = [
-            [("foo", 1.1), ("bar", 1.2), ("baz", 1.3), ("quux", 1.4)],
-            [("foo", 2.1), ("bar", 2.2), ("baz", 2.3), ("quux", 2.4)],
-        ]
-
-        self.assertEqual(sorted_row_data, expected_row_data)
-
     def test_execute_custom_job_id(self):
         from google.cloud.bigquery.dbapi import connect
 

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -5344,7 +5344,7 @@ class TestQueryJob(unittest.TestCase, _Base):
         client = _make_client(project=self.PROJECT, connection=connection)
         job = self._make_one(self.JOB_ID, self.QUERY, client)
 
-        tbl = job.to_arrow()
+        tbl = job.to_arrow(create_bqstorage_client=False)
 
         self.assertIsInstance(tbl, pyarrow.Table)
         self.assertEqual(tbl.num_rows, 2)
@@ -5412,7 +5412,7 @@ class TestQueryJob(unittest.TestCase, _Base):
         client = _make_client(project=self.PROJECT, connection=connection)
         job = self._make_one(self.JOB_ID, self.QUERY, client)
 
-        df = job.to_dataframe()
+        df = job.to_dataframe(create_bqstorage_client=False)
 
         self.assertIsInstance(df, pandas.DataFrame)
         self.assertEqual(len(df), 4)  # verify the number of rows
@@ -5518,7 +5518,7 @@ class TestQueryJob(unittest.TestCase, _Base):
         client = _make_client(project=self.PROJECT, connection=connection)
         job = self._make_one(self.JOB_ID, self.QUERY, client)
 
-        df = job.to_dataframe(dtypes={"km": "float16"})
+        df = job.to_dataframe(dtypes={"km": "float16"}, create_bqstorage_client=False)
 
         self.assertIsInstance(df, pandas.DataFrame)
         self.assertEqual(len(df), 3)  # verify the number of rows
@@ -5558,10 +5558,10 @@ class TestQueryJob(unittest.TestCase, _Base):
         client = _make_client(project=self.PROJECT, connection=connection)
         job = self._make_one(self.JOB_ID, self.QUERY, client)
 
-        job.to_dataframe(progress_bar_type=None)
+        job.to_dataframe(progress_bar_type=None, create_bqstorage_client=False)
         tqdm_mock.assert_not_called()
 
-        job.to_dataframe(progress_bar_type="tqdm")
+        job.to_dataframe(progress_bar_type="tqdm", create_bqstorage_client=False)
         tqdm_mock.assert_called()
 
     def test_iter(self):


### PR DESCRIPTION
Closes #106.

This PR removes workarounds the BQ Storage bug with small anonymous result sets that has been fixed recently, rendering those workarounds obsolete.

### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
