### PR TITLE
chore: restrict `rsa` version to <=4.0 for Python 2.7 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ dependencies = [
     "google-resumable-media >= 0.5.0, < 0.6dev",
     "protobuf >= 3.6.0",
     "six >=1.13.0,< 2.0.0dev",
+    "rsa <= 4.0",  # rsa 4.0 is the last release compatible with Python 2.7
 ]
 extras = {
     "bqstorage": [

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,10 @@ dependencies = [
     "google-resumable-media >= 0.5.0, < 0.6dev",
     "protobuf >= 3.6.0",
     "six >=1.13.0,< 2.0.0dev",
-    "rsa <= 4.0",  # rsa 4.0 is the last release compatible with Python 2.7
+    # rsa >= 4.1 is not compatible with Python 2
+    # https://github.com/sybrenstuvel/python-rsa/issues/152
+    'rsa <4.1; python_version < "3"',
+    'rsa >=3.1.4, <5; python_version >= "3"',
 ]
 extras = {
     "bqstorage": [


### PR DESCRIPTION
Fixes #134.

This PR assures that too new a version of the `rsa` dependency does not break the library's Python 2.7 compatibility.

That version is already two years old, though, and it represents a yet another reason to start dropping Python 2.7 (and 3.5) support, too.

### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


