### PR TITLE
docs(bigquery): fix the broken docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ extensions = [
 
 # autodoc/autosummary flags
 autoclass_content = "both"
-autodoc_default_flags = ["members", "inherited-members"]
+autodoc_default_options = {"members": True, "inherited-members": True}
 autosummary_generate = True
 
 

--- a/google/cloud/bigquery/dataset.py
+++ b/google/cloud/bigquery/dataset.py
@@ -84,7 +84,7 @@ class AccessEntry(object):
 
     See https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets.
 
-    Attributes:
+    Args:
         role (str):
             Role granted to the entity. The following string values are
             supported: `'READER'`, `'WRITER'`, `'OWNER'`. It may also be

--- a/synth.py
+++ b/synth.py
@@ -61,4 +61,10 @@ s.replace("google/cloud/bigquery_v2/proto/*.py", "[“”]", '``')
 templated_files = common.py_library(cov_level=100)
 s.move(templated_files, excludes=["noxfile.py"])
 
+s.replace(
+    "docs/conf.py",
+    r'\{"members": True\}',
+    '{"members": True, "inherited-members": True}'
+)
+
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)


### PR DESCRIPTION
Fixes #138 

-> I know conf.py file generated by synthtool ,this is temporary patch for bigquery.

-> new release of sphinx 3.1.1 Consider duplicate docstring of  `Attributes:` docstring and `property` docstring and raised an error of duplicate description so change the docstring from  `Attributes:` to `Args` for more specific info refer this issue : https://github.com/sphinx-doc/sphinx/issues/7817 
