### PR TITLE
tests: avoid use of systest envvars in unit tests

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -221,7 +221,7 @@ class TestClient(unittest.TestCase):
         from concurrent.futures import TimeoutError
         from google.cloud.bigquery.retry import DEFAULT_RETRY
 
-        client = self._make_one()
+        client = self._make_one(project=self.PROJECT)
 
         api_request_patcher = mock.patch.object(
             client._connection, "api_request", side_effect=[TimeoutError, "result"],
@@ -674,7 +674,7 @@ class TestClient(unittest.TestCase):
         mock_client.assert_called_once_with(credentials=creds)
 
     def test_create_bqstorage_client_missing_dependency(self):
-        client = self._make_one()
+        client = self._make_one(project=self.PROJECT)
 
         def fail_bqstorage_import(name, globals, locals, fromlist, level):
             # NOTE: *very* simplified, assuming a straightforward absolute import

--- a/tests/unit/test_magics.py
+++ b/tests/unit/test_magics.py
@@ -772,9 +772,16 @@ def test_bigquery_magic_w_missing_query():
     ip.extension_manager.load_extension("google.cloud.bigquery")
     magics.context._project = None
 
+    credentials_mock = mock.create_autospec(
+        google.auth.credentials.Credentials, instance=True
+    )
+    default_patch = mock.patch(
+        "google.auth.default", return_value=(credentials_mock, "general-project")
+    )
+
     cell_body = "   \n    \n   \t\t  \n  "
 
-    with io.capture_output() as captured_io:
+    with io.capture_output() as captured_io, default_patch:
         ip.run_cell_magic("bigquery", "df", cell_body)
 
     output = captured_io.stderr


### PR DESCRIPTION
Fixes #194
