### PR TITLE
fix: tweak pyarrow extra to soothe PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,11 @@ extras = {
     ],
     "pandas": ["pandas>=0.17.1"],
     # Exclude PyArrow dependency from Windows Python 2.7.
-    'pyarrow: platform_system != "Windows" or python_version >= "3.5"': [
-        "pyarrow>=1.0.0, <2.0dev; python_version>='3.4'",
+    'pyarrow: platform_system == "Windows"': [
+        "pyarrow>=1.0.0, <2.0dev; python_version>='3.5'",
+    ],
+    'pyarrow: platform_system != "Windows"': [
+        "pyarrow>=1.0.0, <2.0dev; python_version>='3.5'",
         # Pyarrow >= 0.17.0 is not compatible with Python 2 anymore.
         "pyarrow < 0.17.0; python_version < '3.0'",
     ],


### PR DESCRIPTION
Release-As: 1.27.1

Trying to work around PyPI's rejection of the 1.27.0 release:

```
Uploading google_cloud_bigquery-1.27.0-py2.py3-none-any.whl

  0%|          | 0.00/180k [00:00<?, ?B/s]
  4%|▍         | 8.00k/180k [00:00<00:04, 36.6kB/s]
 53%|█████▎    | 96.0k/180k [00:00<00:01, 51.2kB/s]
100%|██████████| 180k/180k [00:00<00:00, 222kB/s]  
NOTE: Try --verbose to see response content.
HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
Invalid value for requires_dist. Error: Invalid requirement: 'pyarrow (<0.17.0) ; ( platform_system != "Windows" or python_version >= "3.5":python_version < "3.0") and extra == \'pyarrow\''.
```