### PR TITLE
test: make `_AsyncJob` tests mock at a lower layer

### DIFF
--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -625,7 +625,6 @@ class Client(ClientWithProject):
     def _call_api(
         self, retry, span_name=None, span_attributes=None, job_ref=None, **kwargs
     ):
-
         call = functools.partial(self._connection.api_request, **kwargs)
         if retry:
             call = retry(call)

--- a/google/cloud/bigquery/job.py
+++ b/google/cloud/bigquery/job.py
@@ -529,9 +529,8 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
             Optional[str]:
                 the state (None until set from the server).
         """
-        status = self._properties.get("status")
-        if status is not None:
-            return status.get("state")
+        status = self._properties.get("status", {})
+        return status.get("state")
 
     def _set_properties(self, api_response):
         """Update properties from resource in body of ``api_response``
@@ -588,7 +587,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
 
     def to_api_repr(self):
         """Generate a resource for the job."""
-        raise NotImplementedError("Abstract")
+        return copy.deepcopy(self._properties)
 
     _build_resource = to_api_repr  # backward-compatibility alias
 


### PR DESCRIPTION
This is intented to make the `_AsyncJob` tests more robust
to changes in retry behavior. It also more explicitly tests
the retry behavior by observing API calls rather than calls
to certain methods.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #339 🦕
