### PR TITLE
perf: use `jobs.getQueryResults` to download result sets

### DIFF
--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -80,12 +80,12 @@ _DEFAULT_CHUNKSIZE = 1048576  # 1024 * 1024 B = 1 MB
 _MAX_MULTIPART_SIZE = 5 * 1024 * 1024
 _DEFAULT_NUM_RETRIES = 6
 _BASE_UPLOAD_TEMPLATE = (
-    u"https://bigquery.googleapis.com/upload/bigquery/v2/projects/"
-    u"{project}/jobs?uploadType="
+    "https://bigquery.googleapis.com/upload/bigquery/v2/projects/"
+    "{project}/jobs?uploadType="
 )
-_MULTIPART_URL_TEMPLATE = _BASE_UPLOAD_TEMPLATE + u"multipart"
-_RESUMABLE_URL_TEMPLATE = _BASE_UPLOAD_TEMPLATE + u"resumable"
-_GENERIC_CONTENT_TYPE = u"*/*"
+_MULTIPART_URL_TEMPLATE = _BASE_UPLOAD_TEMPLATE + "multipart"
+_RESUMABLE_URL_TEMPLATE = _BASE_UPLOAD_TEMPLATE + "resumable"
+_GENERIC_CONTENT_TYPE = "*/*"
 _READ_LESS_THAN_SIZE = (
     "Size {:d} was specified but the file-like object only had " "{:d} bytes remaining."
 )
@@ -293,7 +293,7 @@ class Client(ClientWithProject):
                 span_attributes=span_attributes,
                 *args,
                 timeout=timeout,
-                **kwargs
+                **kwargs,
             )
 
         return page_iterator.HTTPIterator(
@@ -371,7 +371,7 @@ class Client(ClientWithProject):
                 span_attributes=span_attributes,
                 *args,
                 timeout=timeout,
-                **kwargs
+                **kwargs,
             )
 
         return page_iterator.HTTPIterator(
@@ -1129,7 +1129,7 @@ class Client(ClientWithProject):
                 span_attributes=span_attributes,
                 *args,
                 timeout=timeout,
-                **kwargs
+                **kwargs,
             )
 
         result = page_iterator.HTTPIterator(
@@ -1207,7 +1207,7 @@ class Client(ClientWithProject):
                 span_attributes=span_attributes,
                 *args,
                 timeout=timeout,
-                **kwargs
+                **kwargs,
             )
 
         result = page_iterator.HTTPIterator(
@@ -1284,7 +1284,7 @@ class Client(ClientWithProject):
                 span_attributes=span_attributes,
                 *args,
                 timeout=timeout,
-                **kwargs
+                **kwargs,
             )
 
         result = page_iterator.HTTPIterator(
@@ -1510,7 +1510,15 @@ class Client(ClientWithProject):
                 raise
 
     def _get_query_results(
-        self, job_id, retry, project=None, timeout_ms=None, location=None, timeout=None
+        self,
+        job_id,
+        retry,
+        project=None,
+        timeout_ms=None,
+        location=None,
+        timeout=None,
+        max_results=None,
+        start_index=None,
     ):
         """Get the query results object for a query job.
 
@@ -1527,13 +1535,18 @@ class Client(ClientWithProject):
             timeout (Optional[float]):
                 The number of seconds to wait for the underlying HTTP transport
                 before using ``retry``.
+            max_results (Optional[int]):
+                The maximum number of records to fetch per response page.
+                Defaults to unspecified (API default).
+            start_index (Optional[int]):
+                The zero-based index of the starting row to read.
 
         Returns:
             google.cloud.bigquery.query._QueryResults:
                 A new ``_QueryResults`` instance.
         """
 
-        extra_params = {"maxResults": 0}
+        extra_params = {}
 
         if project is None:
             project = self.project
@@ -1546,6 +1559,12 @@ class Client(ClientWithProject):
 
         if location is not None:
             extra_params["location"] = location
+
+        if max_results is not None:
+            extra_params["maxResults"] = max_results
+
+        if start_index is not None:
+            extra_params["startIndex"] = start_index
 
         path = "/projects/{}/queries/{}".format(project, job_id)
 
@@ -1890,7 +1909,7 @@ class Client(ClientWithProject):
                 span_attributes=span_attributes,
                 *args,
                 timeout=timeout,
-                **kwargs
+                **kwargs,
             )
 
         return page_iterator.HTTPIterator(
@@ -2374,7 +2393,7 @@ class Client(ClientWithProject):
 
         destination = _table_arg_to_table_ref(destination, default_project=self.project)
 
-        data_str = u"\n".join(json.dumps(item) for item in json_rows)
+        data_str = "\n".join(json.dumps(item) for item in json_rows)
         encoded_str = data_str.encode()
         data_file = io.BytesIO(encoded_str)
         return self.load_table_from_file(
@@ -3169,6 +3188,64 @@ class Client(ClientWithProject):
             # Pass in selected_fields separately from schema so that full
             # tables can be fetched without a column filter.
             selected_fields=selected_fields,
+        )
+        return row_iterator
+
+    def _list_rows_from_query_results(
+        self,
+        query_results,
+        table,
+        max_results=None,
+        page_size=None,
+        retry=DEFAULT_RETRY,
+        timeout=None,
+    ):
+        """List the rows of a completed query.
+
+        See
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/getQueryResults
+
+        Args:
+            query_results (google.cloud.bigquery.query._QueryResults):
+                A ``_QueryResults`` instance containing the first page of
+                results.
+            table (Union[ \
+                google.cloud.bigquery.table.Table, \
+                google.cloud.bigquery.table.TableListItem, \
+                google.cloud.bigquery.table.TableReference, \
+                str, \
+            ]):
+                DEPRECATED: The table to list, or a reference to it.
+
+                To be removed in a future update, where the QueryJob class is
+                not reloaded by `result()` or `to_dataframe()`.
+            max_results (Optional[int]):
+                Maximum number of rows to return across the whole iterator.
+            page_size (Optional[int]):
+                The maximum number of rows in each page of results from this request.
+                Non-positive values are ignored. Defaults to a sensible value set by the API.
+            retry (Optional[google.api_core.retry.Retry]):
+                How to retry the RPC.
+            timeout (Optional[float]):
+                The number of seconds to wait for the underlying HTTP transport
+                before using ``retry``.
+                If multiple requests are made under the hood, ``timeout``
+                applies to each individual request.
+
+        Returns:
+            google.cloud.bigquery.table.RowIterator:
+                Iterator of row data
+                :class:`~google.cloud.bigquery.table.Row`-s.
+        """
+        row_iterator = RowIterator(
+            client=self,
+            api_request=functools.partial(self._call_api, retry, timeout=timeout),
+            path=f"/projects/{query_results.project}/queries/{query_results.job_id}",
+            schema=query_results.schema,
+            max_results=max_results,
+            page_size=page_size,
+            table=table,
+            first_page_response=query_results._properties,
         )
         return row_iterator
 

--- a/google/cloud/bigquery/dbapi/cursor.py
+++ b/google/cloud/bigquery/dbapi/cursor.py
@@ -190,7 +190,7 @@ class Cursor(object):
         except google.cloud.exceptions.GoogleCloudError as exc:
             raise exceptions.DatabaseError(exc)
 
-        query_results = self._query_job._query_results
+        query_results = self._query_job._thread_local._query_results
         self._set_rowcount(query_results)
         self._set_description(query_results.schema)
 
@@ -239,7 +239,7 @@ class Cursor(object):
 
             rows_iter = client.list_rows(
                 self._query_job.destination,
-                selected_fields=self._query_job._query_results.schema,
+                selected_fields=self._query_job._thread_local._query_results.schema,
                 page_size=self.arraysize,
             )
             self._query_data = iter(rows_iter)

--- a/google/cloud/bigquery/job.py
+++ b/google/cloud/bigquery/job.py
@@ -3121,9 +3121,14 @@ class QueryJob(_AsyncJob):
 
         # If an explicit timeout is not given, fall back to the transport timeout
         # stored in _blocking_poll() in the process of polling for job completion.
-        transport_timeout = timeout if timeout is not None else self._thread_local._transport_timeout
+        transport_timeout = (
+            timeout if timeout is not None else self._thread_local._transport_timeout
+        )
 
-        if not self._thread_local._query_results or not self._thread_local._query_results.complete:
+        if (
+            not self._thread_local._query_results
+            or not self._thread_local._query_results.complete
+        ):
             self._thread_local._query_results = self._client._get_query_results(
                 self.job_id,
                 retry,

--- a/tests/system.py
+++ b/tests/system.py
@@ -1688,7 +1688,6 @@ class TestBigQuery(unittest.TestCase):
         result1 = query_job.result(start_index=start_index)
         total_rows = result1.total_rows
 
-        self.assertEqual(result1.extra_params["startIndex"], start_index)
         self.assertEqual(len(list(result1)), total_rows - start_index)
 
     def test_query_statistics(self):

--- a/tests/unit/test__pandas_helpers.py
+++ b/tests/unit/test__pandas_helpers.py
@@ -1202,7 +1202,7 @@ def test_dataframe_to_parquet_dict_sequence_schema(module_under_test):
 
 
 @pytest.mark.skipif(isinstance(pyarrow, mock.Mock), reason="Requires `pyarrow`")
-def test_download_arrow_tabledata_list_unknown_field_type(module_under_test):
+def test_download_arrow_row_iterator_unknown_field_type(module_under_test):
     fake_page = api_core.page_iterator.Page(
         parent=mock.Mock(),
         items=[{"page_data": "foo"}],
@@ -1216,7 +1216,7 @@ def test_download_arrow_tabledata_list_unknown_field_type(module_under_test):
         schema.SchemaField("alien_field", "ALIEN_FLOAT_TYPE"),
     ]
 
-    results_gen = module_under_test.download_arrow_tabledata_list(pages, bq_schema)
+    results_gen = module_under_test.download_arrow_row_iterator(pages, bq_schema)
 
     with warnings.catch_warnings(record=True) as warned:
         result = next(results_gen)
@@ -1238,7 +1238,7 @@ def test_download_arrow_tabledata_list_unknown_field_type(module_under_test):
 
 
 @pytest.mark.skipif(isinstance(pyarrow, mock.Mock), reason="Requires `pyarrow`")
-def test_download_arrow_tabledata_list_known_field_type(module_under_test):
+def test_download_arrow_row_iterator_known_field_type(module_under_test):
     fake_page = api_core.page_iterator.Page(
         parent=mock.Mock(),
         items=[{"page_data": "foo"}],
@@ -1252,7 +1252,7 @@ def test_download_arrow_tabledata_list_known_field_type(module_under_test):
         schema.SchemaField("non_alien_field", "STRING"),
     ]
 
-    results_gen = module_under_test.download_arrow_tabledata_list(pages, bq_schema)
+    results_gen = module_under_test.download_arrow_row_iterator(pages, bq_schema)
     with warnings.catch_warnings(record=True) as warned:
         result = next(results_gen)
 
@@ -1273,7 +1273,7 @@ def test_download_arrow_tabledata_list_known_field_type(module_under_test):
 
 
 @pytest.mark.skipif(isinstance(pyarrow, mock.Mock), reason="Requires `pyarrow`")
-def test_download_arrow_tabledata_list_dict_sequence_schema(module_under_test):
+def test_download_arrow_row_iterator_dict_sequence_schema(module_under_test):
     fake_page = api_core.page_iterator.Page(
         parent=mock.Mock(),
         items=[{"page_data": "foo"}],
@@ -1287,7 +1287,7 @@ def test_download_arrow_tabledata_list_dict_sequence_schema(module_under_test):
         {"name": "non_alien_field", "type": "STRING", "mode": "NULLABLE"},
     ]
 
-    results_gen = module_under_test.download_arrow_tabledata_list(pages, dict_schema)
+    results_gen = module_under_test.download_arrow_row_iterator(pages, dict_schema)
     result = next(results_gen)
 
     assert len(result.columns) == 2
@@ -1301,7 +1301,7 @@ def test_download_arrow_tabledata_list_dict_sequence_schema(module_under_test):
 
 @pytest.mark.skipif(pandas is None, reason="Requires `pandas`")
 @pytest.mark.skipif(isinstance(pyarrow, mock.Mock), reason="Requires `pyarrow`")
-def test_download_dataframe_tabledata_list_dict_sequence_schema(module_under_test):
+def test_download_dataframe_row_iterator_dict_sequence_schema(module_under_test):
     fake_page = api_core.page_iterator.Page(
         parent=mock.Mock(),
         items=[{"page_data": "foo"}],
@@ -1315,7 +1315,7 @@ def test_download_dataframe_tabledata_list_dict_sequence_schema(module_under_tes
         {"name": "non_alien_field", "type": "STRING", "mode": "NULLABLE"},
     ]
 
-    results_gen = module_under_test.download_dataframe_tabledata_list(
+    results_gen = module_under_test.download_dataframe_row_iterator(
         pages, dict_schema, dtypes={}
     )
     result = next(results_gen)
@@ -1335,5 +1335,5 @@ def test_download_dataframe_tabledata_list_dict_sequence_schema(module_under_tes
 
 
 def test_table_data_listpage_to_dataframe_skips_stop_iteration(module_under_test):
-    dataframe = module_under_test._tabledata_list_page_to_dataframe([], [], {})
+    dataframe = module_under_test._row_iterator_page_to_dataframe([], [], {})
     assert isinstance(dataframe, pandas.DataFrame)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -319,7 +319,7 @@ class TestClient(unittest.TestCase):
         conn.api_request.assert_called_once_with(
             method="GET",
             path=path,
-            query_params={"maxResults": 0, "timeoutMs": 500, "location": self.LOCATION},
+            query_params={"timeoutMs": 500, "location": self.LOCATION},
             timeout=42,
         )
 
@@ -336,7 +336,7 @@ class TestClient(unittest.TestCase):
         conn.api_request.assert_called_once_with(
             method="GET",
             path="/projects/PROJECT/queries/nothere",
-            query_params={"maxResults": 0, "location": self.LOCATION},
+            query_params={"location": self.LOCATION},
             timeout=None,
         )
 

--- a/tests/unit/test_dbapi_cursor.py
+++ b/tests/unit/test_dbapi_cursor.py
@@ -60,7 +60,9 @@ class TestCursor(unittest.TestCase):
             total_rows = len(rows)
 
         mock_client = mock.create_autospec(client.Client)
+        mock_client.project = "test-project"
         mock_client.query.return_value = self._mock_job(
+            mock_client,
             total_rows=total_rows,
             schema=schema,
             num_dml_affected_rows=num_dml_affected_rows,
@@ -97,6 +99,7 @@ class TestCursor(unittest.TestCase):
 
     def _mock_job(
         self,
+        client,
         total_rows=0,
         schema=None,
         num_dml_affected_rows=None,
@@ -105,7 +108,8 @@ class TestCursor(unittest.TestCase):
     ):
         from google.cloud.bigquery import job
 
-        mock_job = mock.create_autospec(job.QueryJob)
+        job_template = job.QueryJob("some-id", "SELECT * FROM dataset.table", client)
+        mock_job = mock.create_autospec(job_template)
         mock_job.error_result = None
         mock_job.state = "DONE"
         mock_job.dry_run = dry_run

--- a/tests/unit/test_dbapi_cursor.py
+++ b/tests/unit/test_dbapi_cursor.py
@@ -115,7 +115,7 @@ class TestCursor(unittest.TestCase):
             mock_job.total_bytes_processed = total_bytes_processed
         else:
             mock_job.result.return_value = mock_job
-            mock_job._query_results = self._mock_results(
+            mock_job._thread_local._query_results = self._mock_results(
                 total_rows=total_rows,
                 schema=schema,
                 num_dml_affected_rows=num_dml_affected_rows,

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -4209,7 +4209,7 @@ class TestQueryJob(unittest.TestCase, _Base):
         client = _make_client(project=self.PROJECT)
         resource = self._make_resource(ended=True)
         job = self._get_target_class().from_api_repr(resource, client)
-        job._query_results = google.cloud.bigquery.query._QueryResults.from_api_repr(
+        job._thread_local._query_results = google.cloud.bigquery.query._QueryResults.from_api_repr(
             {"jobComplete": True, "jobReference": resource["jobReference"]}
         )
         self.assertTrue(job.done())
@@ -5001,7 +5001,16 @@ class TestQueryJob(unittest.TestCase, _Base):
             "datasetId": self.DS_ID,
             "tableId": self.TABLE_ID,
         }
-        conn = _make_connection(query_results_resource, query_results_resource_page_2)
+        conn = _make_connection(
+            # Test 1
+            query_results_resource, query_results_resource_page_2,
+            # Test 2
+           query_results_resource,
+            # Test 3
+           query_results_resource,
+            # Test 4
+           query_results_resource,
+        )
         client = _make_client(self.PROJECT, connection=conn)
         job = self._get_target_class().from_api_repr(job_resource, client)
 
@@ -5113,7 +5122,7 @@ class TestQueryJob(unittest.TestCase, _Base):
             "errors": [error_result],
             "state": "DONE",
         }
-        job._query_results = google.cloud.bigquery.query._QueryResults.from_api_repr(
+        job._thread_local._query_results = google.cloud.bigquery.query._QueryResults.from_api_repr(
             {"jobComplete": True, "jobReference": job._properties["jobReference"]}
         )
         job._set_future_result()

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -5003,13 +5003,14 @@ class TestQueryJob(unittest.TestCase, _Base):
         }
         conn = _make_connection(
             # Test 1
-            query_results_resource, query_results_resource_page_2,
+            query_results_resource,
+            query_results_resource_page_2,
             # Test 2
-           query_results_resource,
+            query_results_resource,
             # Test 3
-           query_results_resource,
+            query_results_resource,
             # Test 4
-           query_results_resource,
+            query_results_resource,
         )
         client = _make_client(self.PROJECT, connection=conn)
         job = self._get_target_class().from_api_repr(job_resource, client)

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -4261,15 +4261,14 @@ class TestQueryJob(unittest.TestCase, _Base):
         conn = _make_connection(job_resource_done)
         client = _make_client(self.PROJECT, connection=conn)
         job = self._get_target_class().from_api_repr(job_resource, client)
-        job._thread_local._query_results = google.cloud.bigquery.query._QueryResults({
-            "jobReference": job._properties["jobReference"],
-            "jobComplete": True,
-        })
+        job._thread_local._query_results = google.cloud.bigquery.query._QueryResults(
+            {"jobReference": job._properties["jobReference"], "jobComplete": True}
+        )
 
         self.assertTrue(job.done())
         job_path = f"/projects/{job.project}/jobs/{job.job_id}"
         conn.api_request.assert_called_once_with(
-            method='GET', path=job_path, query_params={}, timeout=None
+            method="GET", path=job_path, query_params={}, timeout=None
         )
 
     def test_query_plan(self):
@@ -4966,10 +4965,7 @@ class TestQueryJob(unittest.TestCase, _Base):
             "jobReference": {"projectId": self.PROJECT, "jobId": self.JOB_ID},
             "schema": {"fields": [{"name": "col1", "type": "STRING"}]},
             "totalRows": "2",
-            "rows": [
-                {"f": [{"v": "row1"}]},
-                {"f": [{"v": "row2"}]},
-            ],
+            "rows": [{"f": [{"v": "row1"}]}, {"f": [{"v": "row2"}]}],
         }
         job_resource = self._make_resource(started=True, ended=True)
         conn = _make_connection(query_results_resource, query_results_resource)


### PR DESCRIPTION
Since `getQueryResults` was already used to wait for the job to finish,
this avoids an additional call to `tabledata.list`. The first page of
results are cached in-memory.

Additional changes will come in the future to avoid calling the BQ
Storage API when the cached results contain the full result set.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Towards https://github.com/googleapis/python-bigquery/issues/362