### PR TITLE
perf: cache first page of `jobs.getQueryResults` rows

### DIFF
--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -1534,7 +1534,7 @@ class Client(ClientWithProject):
                 A new ``_QueryResults`` instance.
         """
 
-        extra_params = {"maxResults": 0}
+        extra_params = {}
 
         if project is None:
             project = self.project
@@ -3187,6 +3187,7 @@ class Client(ClientWithProject):
         page_size=None,
         retry=DEFAULT_RETRY,
         timeout=None,
+        first_page_response=None,
     ):
         """List the rows of a completed query.
         See
@@ -3247,6 +3248,7 @@ class Client(ClientWithProject):
             table=destination,
             extra_params=params,
             total_rows=total_rows,
+            first_page_response=first_page_response,
         )
         return row_iterator
 

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -1308,7 +1308,9 @@ class RowIterator(HTTPIterator):
             A subset of columns to select from this table.
         total_rows (Optional[int]):
             Total number of rows in the table.
-
+        first_page_response (Optional[dict]):
+            API response for the first page of results. These are returned when
+            the first page is requested.
     """
 
     def __init__(
@@ -1324,6 +1326,7 @@ class RowIterator(HTTPIterator):
         table=None,
         selected_fields=None,
         total_rows=None,
+        first_page_response=None,
     ):
         super(RowIterator, self).__init__(
             client,
@@ -1346,6 +1349,7 @@ class RowIterator(HTTPIterator):
         self._selected_fields = selected_fields
         self._table = table
         self._total_rows = total_rows
+        self._first_page_response = first_page_response
 
     def _get_next_page_response(self):
         """Requests the next page from the path provided.
@@ -1354,6 +1358,11 @@ class RowIterator(HTTPIterator):
             Dict[str, object]:
                 The parsed JSON response of the next page's contents.
         """
+        if self._first_page_response:
+            response = self._first_page_response
+            self._first_page_response = None
+            return response
+
         params = self._get_query_params()
         if self._page_size is not None:
             if self.page_number and "startIndex" in params:

--- a/tests/unit/job/test_query.py
+++ b/tests/unit/job/test_query.py
@@ -787,7 +787,9 @@ class TestQueryJob(_Base):
                 "location": "EU",
             },
             "schema": {"fields": [{"name": "col1", "type": "STRING"}]},
-            "totalRows": "2",
+            "totalRows": "3",
+            "rows": [{"f": [{"v": "abc"}]}],
+            "pageToken": "next-page",
         }
         job_resource = self._make_resource(started=True, location="EU")
         job_resource_done = self._make_resource(started=True, ended=True, location="EU")
@@ -799,9 +801,9 @@ class TestQueryJob(_Base):
         query_page_resource = {
             # Explicitly set totalRows to be different from the initial
             # response to test update during iteration.
-            "totalRows": "1",
+            "totalRows": "2",
             "pageToken": None,
-            "rows": [{"f": [{"v": "abc"}]}],
+            "rows": [{"f": [{"v": "def"}]}],
         }
         conn = _make_connection(
             query_resource, query_resource_done, job_resource_done, query_page_resource
@@ -812,19 +814,20 @@ class TestQueryJob(_Base):
         result = job.result()
 
         self.assertIsInstance(result, RowIterator)
-        self.assertEqual(result.total_rows, 2)
+        self.assertEqual(result.total_rows, 3)
         rows = list(result)
-        self.assertEqual(len(rows), 1)
+        self.assertEqual(len(rows), 2)
         self.assertEqual(rows[0].col1, "abc")
+        self.assertEqual(rows[1].col1, "def")
         # Test that the total_rows property has changed during iteration, based
         # on the response from tabledata.list.
-        self.assertEqual(result.total_rows, 1)
+        self.assertEqual(result.total_rows, 2)
 
         query_results_path = f"/projects/{self.PROJECT}/queries/{self.JOB_ID}"
         query_results_call = mock.call(
             method="GET",
             path=query_results_path,
-            query_params={"maxResults": 0, "location": "EU"},
+            query_params={"location": "EU"},
             timeout=None,
         )
         reload_call = mock.call(
@@ -839,6 +842,7 @@ class TestQueryJob(_Base):
             query_params={
                 "fields": _LIST_ROWS_FROM_QUERY_RESULTS_FIELDS,
                 "location": "EU",
+                "pageToken": "next-page",
             },
             timeout=None,
         )
@@ -851,7 +855,9 @@ class TestQueryJob(_Base):
             "jobComplete": True,
             "jobReference": {"projectId": self.PROJECT, "jobId": self.JOB_ID},
             "schema": {"fields": [{"name": "col1", "type": "STRING"}]},
-            "totalRows": "1",
+            "totalRows": "2",
+            "rows": [{"f": [{"v": "abc"}]}],
+            "pageToken": "next-page",
         }
         job_resource = self._make_resource(started=True, ended=True, location="EU")
         job_resource["configuration"]["query"]["destinationTable"] = {
@@ -860,9 +866,9 @@ class TestQueryJob(_Base):
             "tableId": "dest_table",
         }
         results_page_resource = {
-            "totalRows": "1",
+            "totalRows": "2",
             "pageToken": None,
-            "rows": [{"f": [{"v": "abc"}]}],
+            "rows": [{"f": [{"v": "def"}]}],
         }
         conn = _make_connection(query_resource_done, results_page_resource)
         client = _make_client(self.PROJECT, connection=conn)
@@ -871,14 +877,15 @@ class TestQueryJob(_Base):
         result = job.result()
 
         rows = list(result)
-        self.assertEqual(len(rows), 1)
+        self.assertEqual(len(rows), 2)
         self.assertEqual(rows[0].col1, "abc")
+        self.assertEqual(rows[1].col1, "def")
 
         query_results_path = f"/projects/{self.PROJECT}/queries/{self.JOB_ID}"
         query_results_call = mock.call(
             method="GET",
             path=query_results_path,
-            query_params={"maxResults": 0, "location": "EU"},
+            query_params={"location": "EU"},
             timeout=None,
         )
         query_results_page_call = mock.call(
@@ -887,6 +894,7 @@ class TestQueryJob(_Base):
             query_params={
                 "fields": _LIST_ROWS_FROM_QUERY_RESULTS_FIELDS,
                 "location": "EU",
+                "pageToken": "next-page",
             },
             timeout=None,
         )
@@ -900,6 +908,12 @@ class TestQueryJob(_Base):
             "jobReference": {"projectId": self.PROJECT, "jobId": self.JOB_ID},
             "schema": {"fields": [{"name": "col1", "type": "STRING"}]},
             "totalRows": "5",
+            # These rows are discarded because max_results is set.
+            "rows": [
+                {"f": [{"v": "xyz"}]},
+                {"f": [{"v": "uvw"}]},
+                {"f": [{"v": "rst"}]},
+            ],
         }
         query_page_resource = {
             "totalRows": "5",
@@ -925,6 +939,7 @@ class TestQueryJob(_Base):
         rows = list(result)
 
         self.assertEqual(len(rows), 3)
+        self.assertEqual(rows[0].col1, "abc")
         self.assertEqual(len(connection.api_request.call_args_list), 2)
         query_page_request = connection.api_request.call_args_list[1]
         self.assertEqual(
@@ -979,7 +994,7 @@ class TestQueryJob(_Base):
         query_results_call = mock.call(
             method="GET",
             path=f"/projects/{self.PROJECT}/queries/{self.JOB_ID}",
-            query_params={"maxResults": 0, "location": "asia-northeast1"},
+            query_params={"location": "asia-northeast1"},
             timeout=None,
         )
         reload_call = mock.call(
@@ -1079,6 +1094,12 @@ class TestQueryJob(_Base):
             "jobReference": {"projectId": self.PROJECT, "jobId": self.JOB_ID},
             "schema": {"fields": [{"name": "col1", "type": "STRING"}]},
             "totalRows": "4",
+            # These rows are discarded because page_size is set.
+            "rows": [
+                {"f": [{"v": "xyz"}]},
+                {"f": [{"v": "uvw"}]},
+                {"f": [{"v": "rst"}]},
+            ],
         }
         job_resource = self._make_resource(started=True, ended=True, location="US")
         q_config = job_resource["configuration"]["query"]
@@ -1109,6 +1130,7 @@ class TestQueryJob(_Base):
         # Assert
         actual_rows = list(result)
         self.assertEqual(len(actual_rows), 4)
+        self.assertEqual(actual_rows[0].col1, "row1")
 
         query_results_path = f"/projects/{self.PROJECT}/queries/{self.JOB_ID}"
         query_page_1_call = mock.call(
@@ -1142,6 +1164,12 @@ class TestQueryJob(_Base):
             "jobReference": {"projectId": self.PROJECT, "jobId": self.JOB_ID},
             "schema": {"fields": [{"name": "col1", "type": "STRING"}]},
             "totalRows": "5",
+            # These rows are discarded because start_index is set.
+            "rows": [
+                {"f": [{"v": "xyz"}]},
+                {"f": [{"v": "uvw"}]},
+                {"f": [{"v": "rst"}]},
+            ],
         }
         tabledata_resource = {
             "totalRows": "5",
@@ -1168,6 +1196,7 @@ class TestQueryJob(_Base):
         rows = list(result)
 
         self.assertEqual(len(rows), 4)
+        self.assertEqual(rows[0].col1, "abc")
         self.assertEqual(len(connection.api_request.call_args_list), 2)
         tabledata_list_request = connection.api_request.call_args_list[1]
         self.assertEqual(

--- a/tests/unit/job/test_query_pandas.py
+++ b/tests/unit/job/test_query_pandas.py
@@ -161,8 +161,6 @@ def test_to_arrow():
                 },
             ]
         },
-    }
-    tabledata_resource = {
         "rows": [
             {
                 "f": [
@@ -176,13 +174,11 @@ def test_to_arrow():
                     {"v": {"f": [{"v": "Bharney Rhubble"}, {"v": "33"}]}},
                 ]
             },
-        ]
+        ],
     }
     done_resource = copy.deepcopy(begun_resource)
     done_resource["status"] = {"state": "DONE"}
-    connection = _make_connection(
-        begun_resource, query_resource, done_resource, tabledata_resource
-    )
+    connection = _make_connection(begun_resource, query_resource, done_resource)
     client = _make_client(connection=connection)
     job = target_class.from_api_repr(begun_resource, client)
 
@@ -234,20 +230,16 @@ def test_to_dataframe():
                 {"name": "age", "type": "INTEGER", "mode": "NULLABLE"},
             ]
         },
-    }
-    tabledata_resource = {
         "rows": [
             {"f": [{"v": "Phred Phlyntstone"}, {"v": "32"}]},
             {"f": [{"v": "Bharney Rhubble"}, {"v": "33"}]},
             {"f": [{"v": "Wylma Phlyntstone"}, {"v": "29"}]},
             {"f": [{"v": "Bhettye Rhubble"}, {"v": "27"}]},
-        ]
+        ],
     }
     done_resource = copy.deepcopy(begun_resource)
     done_resource["status"] = {"state": "DONE"}
-    connection = _make_connection(
-        begun_resource, query_resource, done_resource, tabledata_resource
-    )
+    connection = _make_connection(begun_resource, query_resource, done_resource)
     client = _make_client(connection=connection)
     job = target_class.from_api_repr(begun_resource, client)
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -319,7 +319,7 @@ class TestClient(unittest.TestCase):
         conn.api_request.assert_called_once_with(
             method="GET",
             path=path,
-            query_params={"maxResults": 0, "timeoutMs": 500, "location": self.LOCATION},
+            query_params={"timeoutMs": 500, "location": self.LOCATION},
             timeout=42,
         )
 
@@ -336,7 +336,7 @@ class TestClient(unittest.TestCase):
         conn.api_request.assert_called_once_with(
             method="GET",
             path="/projects/PROJECT/queries/nothere",
-            query_params={"maxResults": 0, "location": self.LOCATION},
+            query_params={"location": self.LOCATION},
             timeout=None,
         )
 


### PR DESCRIPTION
Replaces and simplifies #347 . The cache is only used if `max_results`, `page_size`, and `start_index` are not set.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Towards #362 🦕
