### PR TITLE
fix(DBAPI): keep cursor hot when statement is a script

### DIFF
--- a/google/cloud/bigquery/dbapi/cursor.py
+++ b/google/cloud/bigquery/dbapi/cursor.py
@@ -222,7 +222,7 @@ class Cursor(object):
 
         is_dml = (
             self._query_job.statement_type
-            and self._query_job.statement_type.upper() != "SELECT"
+            and self._query_job.statement_type.upper() not in ("SELECT", "SCRIPT")
         )
         if is_dml:
             self._query_data = iter([])


### PR DESCRIPTION
all the details here: https://github.com/googleapis/python-bigquery/issues/377

I guess technically a script isn't DML :trollface: 