### PR TITLE
feat: add support for unrecognized model types

### DIFF
--- a/google/cloud/bigquery/model.py
+++ b/google/cloud/bigquery/model.py
@@ -310,8 +310,7 @@ class Model(object):
                 resource, types.Model()._pb, ignore_unknown_fields=True
             )
         except json_format.ParseError:
-            if this.model_type == 0:
-                resource["modelType"] = "MODEL_TYPE_UNSPECIFIED"
+            resource["modelType"] = "MODEL_TYPE_UNSPECIFIED"
             this._proto = json_format.ParseDict(
                 resource, types.Model()._pb, ignore_unknown_fields=True
             )

--- a/google/cloud/bigquery/model.py
+++ b/google/cloud/bigquery/model.py
@@ -305,9 +305,16 @@ class Model(object):
             start_time = datetime_helpers.from_microseconds(1e3 * float(start_time))
             training_run["startTime"] = datetime_helpers.to_rfc3339(start_time)
 
-        this._proto = json_format.ParseDict(
-            resource, types.Model()._pb, ignore_unknown_fields=True
-        )
+        try:
+            this._proto = json_format.ParseDict(
+                resource, types.Model()._pb, ignore_unknown_fields=True
+            )
+        except json_format.ParseError:
+            if this.model_type == 0:
+                resource["modelType"] = "MODEL_TYPE_UNSPECIFIED"
+            this._proto = json_format.ParseDict(
+                resource, types.Model()._pb, ignore_unknown_fields=True
+            )
         return this
 
     def _build_resource(self, filter_fields):

--- a/tests/unit/model/test_model.py
+++ b/tests/unit/model/test_model.py
@@ -186,6 +186,23 @@ def test_from_api_repr_w_unknown_fields(target_class):
     assert got._properties is resource
 
 
+def test_from_api_repr_w_unknown_type(target_class):
+    from google.cloud.bigquery import ModelReference
+
+    resource = {
+        "modelReference": {
+            "projectId": "my-project",
+            "datasetId": "my_dataset",
+            "modelId": "my_model",
+        },
+        "modelType": "BE_A_GOOD_ROLE_MODEL",
+    }
+    got = target_class.from_api_repr(resource)
+    assert got.reference == ModelReference.from_string("my-project.my_dataset.my_model")
+    assert got.model_type == 0
+    assert got._properties is resource
+
+
 @pytest.mark.parametrize(
     "resource,filter_fields,expected",
     [


### PR DESCRIPTION
If fails to parse model type enum, sets to MODEL_TYPE_UNSPECIFIED.

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #334  🦕
