### PR TITLE
feat: add `TableReference.__str__` to get table ID in standard SQL

### DIFF
--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -262,6 +262,9 @@ class TableReference(object):
     def __hash__(self):
         return hash(self._key())
 
+    def __str__(self):
+        return f"{self.project}.{self.dataset_id}.{self.table_id}"
+
     def __repr__(self):
         from google.cloud.bigquery.dataset import DatasetReference
 
@@ -475,7 +478,7 @@ class Table(object):
         """Union[str, None]: ID for the table (:data:`None` until set from the
         server).
 
-        In the format ``project_id:dataset_id.table_id``.
+        In the format ``project-id:dataset_id.table_id``.
         """
         return self._properties.get("id")
 
@@ -484,7 +487,8 @@ class Table(object):
         """Union[str, None]: The type of the table (:data:`None` until set from
         the server).
 
-        Possible values are ``'TABLE'``, ``'VIEW'``, or ``'EXTERNAL'``.
+        Possible values are ``'TABLE'``, ``'VIEW'``, ``'MATERIALIZED_VIEW'`` or
+        ``'EXTERNAL'``.
         """
         return self._properties.get("type")
 

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -818,7 +818,9 @@ class TestTable(unittest.TestCase, _SchemaBase):
         self.assertEqual(got.project, "string-project")
         self.assertEqual(got.dataset_id, "string_dataset")
         self.assertEqual(got.table_id, "string_table")
-        self.assertEqual(str(got.reference), "string-project.string_dataset.string_table")
+        self.assertEqual(
+            str(got.reference), "string-project.string_dataset.string_table"
+        )
 
     def test_from_string_legacy_string(self):
         cls = self._get_target_class()

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -272,6 +272,11 @@ class TestTableReference(unittest.TestCase):
         )
         self.assertEqual(repr(table1), expected)
 
+    def test___str__(self):
+        dataset = DatasetReference("project1", "dataset1")
+        table1 = self._make_one(dataset, "table1")
+        self.assertEqual(str(table1), "project1.dataset1.table1")
+
 
 class TestTable(unittest.TestCase, _SchemaBase):
 
@@ -813,6 +818,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         self.assertEqual(got.project, "string-project")
         self.assertEqual(got.dataset_id, "string_dataset")
         self.assertEqual(got.table_id, "string_table")
+        self.assertEqual(str(got.reference), "string-project.string_dataset.string_table")
 
     def test_from_string_legacy_string(self):
         cls = self._get_target_class()


### PR DESCRIPTION
This is the natural inverse of the `TableReference.from_string` method.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #354 🦕
