### PR TITLE
fix: add minimum timeout to getQueryResults API requests

### DIFF
--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -1579,7 +1579,9 @@ class Client(ClientWithProject):
             location (Optional[str]): Location of the query job.
             timeout (Optional[float]):
                 The number of seconds to wait for the underlying HTTP transport
-                before using ``retry``.
+                before using ``retry``. If set, this connection timeout may be
+                increased to a minimum value. This prevents retries on what
+                would otherwise be a successful response.
 
         Returns:
             google.cloud.bigquery.query._QueryResults:
@@ -3305,7 +3307,9 @@ class Client(ClientWithProject):
                 How to retry the RPC.
             timeout (Optional[float]):
                 The number of seconds to wait for the underlying HTTP transport
-                before using ``retry``.
+                before using ``retry``. If set, this connection timeout may be
+                increased to a minimum value. This prevents retries on what
+                would otherwise be a successful response.
                 If multiple requests are made under the hood, ``timeout``
                 applies to each individual request.
         Returns:

--- a/tests/system.py
+++ b/tests/system.py
@@ -1809,10 +1809,11 @@ class TestBigQuery(unittest.TestCase):
         )
 
         with self.assertRaises(concurrent.futures.TimeoutError):
-            query_job.done(timeout=1)
-
-        with self.assertRaises(concurrent.futures.TimeoutError):
             query_job.result(timeout=1)
+
+        # Even though the query takes >1 second, the call to getQueryResults
+        # should succeed.
+        self.assertFalse(query_job.done(timeout=1))
 
         Config.CLIENT.cancel_job(query_job.job_id, location=query_job.location)
 

--- a/tests/system.py
+++ b/tests/system.py
@@ -1798,14 +1798,23 @@ class TestBigQuery(unittest.TestCase):
             Config.CLIENT.query(good_query, job_config=bad_config).result()
 
     def test_query_w_timeout(self):
+        job_config = bigquery.QueryJobConfig()
+        job_config.use_query_cache = False
+
         query_job = Config.CLIENT.query(
             "SELECT * FROM `bigquery-public-data.github_repos.commits`;",
             job_id_prefix="test_query_w_timeout_",
+            location="US",
+            job_config=job_config,
         )
 
         with self.assertRaises(concurrent.futures.TimeoutError):
-            # 1 second is much too short for this query.
+            query_job.done(timeout=1)
+
+        with self.assertRaises(concurrent.futures.TimeoutError):
             query_job.result(timeout=1)
+
+        Config.CLIENT.cancel_job(query_job.job_id, location=query_job.location)
 
     def test_query_w_page_size(self):
         page_size = 45
@@ -2407,26 +2416,6 @@ class TestBigQuery(unittest.TestCase):
         self.assertIsInstance(iter(query_job), types.GeneratorType)
         row_tuples = [r.values() for r in query_job]
         self.assertEqual(row_tuples, [(1,)])
-
-    def test_querying_data_w_timeout(self):
-        job_config = bigquery.QueryJobConfig()
-        job_config.use_query_cache = False
-
-        query_job = Config.CLIENT.query(
-            """
-            SELECT COUNT(*)
-            FROM UNNEST(GENERATE_ARRAY(1,1000000)), UNNEST(GENERATE_ARRAY(1, 10000))
-            """,
-            location="US",
-            job_config=job_config,
-        )
-
-        # Specify a very tight deadline to demonstrate that the timeout
-        # actually has effect.
-        with self.assertRaises(requests.exceptions.Timeout):
-            query_job.done(timeout=0.1)
-
-        Config.CLIENT.cancel_job(query_job.job_id, location=query_job.location)
 
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_query_results_to_dataframe(self):

--- a/tests/system.py
+++ b/tests/system.py
@@ -26,7 +26,6 @@ import unittest
 import uuid
 import re
 
-import requests
 import six
 import psutil
 import pytest

--- a/tests/unit/job/test_query.py
+++ b/tests/unit/job/test_query.py
@@ -1046,6 +1046,8 @@ class TestQueryJob(_Base):
         self.assertEqual(reload_request[1]["method"], "GET")
 
     def test_result_w_timeout(self):
+        import google.cloud.bigquery.client
+
         begun_resource = self._make_resource()
         query_resource = {
             "jobComplete": True,
@@ -1072,6 +1074,10 @@ class TestQueryJob(_Base):
             "/projects/{}/queries/{}".format(self.PROJECT, self.JOB_ID),
         )
         self.assertEqual(query_request[1]["query_params"]["timeoutMs"], 900)
+        self.assertEqual(
+            query_request[1]["timeout"],
+            google.cloud.bigquery.client._MIN_GET_QUERY_RESULTS_TIMEOUT,
+        )
         self.assertEqual(reload_request[1]["method"], "GET")
 
     def test_result_w_page_size(self):


### PR DESCRIPTION
Since successful responses can still take a long time to download, have
a minimum timeout which should accomodate 99.9%+ of responses.

I figure it's more important that *any* timeout is set if desired than
it is that the specific timeout is used.  This is especially true in
cases where a short timeout is requested for the purposes of a progress
bar. Making forward progress is more important than the progress bar
update frequency.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #438 🦕
