### PR TITLE
refactor: split system tests across modules

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -115,9 +115,7 @@ def system(session):
     session.install("ipython", "-c", constraints_path)
 
     # Run py.test against the system tests.
-    session.run(
-        "py.test", "--quiet", os.path.join("tests", "system.py"), *session.posargs
-    )
+    session.run("py.test", "--quiet", os.path.join("tests", "system"), *session.posargs)
 
 
 @nox.session(python=["3.8"])

--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -1,0 +1,39 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from . import helpers
+
+
+@pytest.fixture(scope="session")
+def bigquery_client():
+    from google.cloud import bigquery
+
+    return bigquery.Client()
+
+
+@pytest.fixture(scope="session")
+def bqstorage_client(bigquery_client):
+    from google.cloud import bigquery_storage
+
+    return bigquery_storage.BigQueryReadClient(credentials=bigquery_client._credentials)
+
+
+@pytest.fixture(scope="session")
+def dataset_id(bigquery_client):
+    dataset_id = f"bqsystem_{helpers.temp_suffix()}"
+    bigquery_client.create_dataset(dataset_id)
+    yield dataset_id
+    bigquery_client.delete_dataset(dataset_id, delete_contents=True)

--- a/tests/system/helpers.py
+++ b/tests/system/helpers.py
@@ -1,0 +1,94 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import decimal
+import uuid
+
+import google.api_core.exceptions
+import test_utils.retry
+
+from google.cloud._helpers import UTC
+
+
+_naive = datetime.datetime(2016, 12, 5, 12, 41, 9)
+_naive_microseconds = datetime.datetime(2016, 12, 5, 12, 41, 9, 250000)
+_stamp = "%s %s" % (_naive.date().isoformat(), _naive.time().isoformat())
+_stamp_microseconds = _stamp + ".250000"
+_zoned = _naive.replace(tzinfo=UTC)
+_zoned_microseconds = _naive_microseconds.replace(tzinfo=UTC)
+_numeric = decimal.Decimal("123456789.123456789")
+
+
+# Examples of most data types to test with query() and DB-API.
+STANDARD_SQL_EXAMPLES = [
+    ("SELECT 1", 1),
+    ("SELECT 1.3", 1.3),
+    ("SELECT TRUE", True),
+    ('SELECT "ABC"', "ABC"),
+    ('SELECT CAST("foo" AS BYTES)', b"foo"),
+    ('SELECT TIMESTAMP "%s"' % (_stamp,), _zoned),
+    ('SELECT TIMESTAMP "%s"' % (_stamp_microseconds,), _zoned_microseconds,),
+    ('SELECT DATETIME(TIMESTAMP "%s")' % (_stamp,), _naive),
+    ('SELECT DATETIME(TIMESTAMP "%s")' % (_stamp_microseconds,), _naive_microseconds,),
+    ('SELECT DATE(TIMESTAMP "%s")' % (_stamp,), _naive.date()),
+    ('SELECT TIME(TIMESTAMP "%s")' % (_stamp,), _naive.time()),
+    ('SELECT NUMERIC "%s"' % (_numeric,), _numeric),
+    ("SELECT (1, 2)", {"_field_1": 1, "_field_2": 2}),
+    (
+        "SELECT ((1, 2), (3, 4), 5)",
+        {
+            "_field_1": {"_field_1": 1, "_field_2": 2},
+            "_field_2": {"_field_1": 3, "_field_2": 4},
+            "_field_3": 5,
+        },
+    ),
+    ("SELECT [1, 2, 3]", [1, 2, 3]),
+    (
+        "SELECT ([1, 2], 3, [4, 5])",
+        {"_field_1": [1, 2], "_field_2": 3, "_field_3": [4, 5]},
+    ),
+    (
+        "SELECT [(1, 2, 3), (4, 5, 6)]",
+        [
+            {"_field_1": 1, "_field_2": 2, "_field_3": 3},
+            {"_field_1": 4, "_field_2": 5, "_field_3": 6},
+        ],
+    ),
+    (
+        "SELECT [([1, 2, 3], 4), ([5, 6], 7)]",
+        [{"_field_1": [1, 2, 3], "_field_2": 4}, {"_field_1": [5, 6], "_field_2": 7}],
+    ),
+    ("SELECT ARRAY(SELECT STRUCT([1, 2]))", [{"_field_1": [1, 2]}],),
+    ("SELECT ST_GeogPoint(1, 2)", "POINT(1 2)"),
+]
+
+
+def temp_suffix():
+    now = datetime.datetime.now()
+    return f"{now.strftime('%Y%m%d%H%M%S')}_{uuid.uuid4().hex[:8]}"
+
+
+def _rate_limit_exceeded(forbidden):
+    """Predicate: pass only exceptions with 'rateLimitExceeded' as reason."""
+    return any(error["reason"] == "rateLimitExceeded" for error in forbidden._errors)
+
+
+# We need to wait to stay within the rate limits.
+# The alternative outcome is a 403 Forbidden response from upstream, which
+# they return instead of the more appropriate 429.
+# See https://cloud.google.com/bigquery/quota-policy
+retry_403 = test_utils.retry.RetryErrors(
+    google.api_core.exceptions.Forbidden, error_predicate=_rate_limit_exceeded,
+)

--- a/tests/system/test_dbapi.py
+++ b/tests/system/test_dbapi.py
@@ -1,0 +1,258 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import operator
+import itertools
+import uuid
+
+from google.cloud._helpers import UTC
+import psutil
+import pytest
+
+from google.cloud.bigquery import dbapi
+from . import helpers
+
+try:
+    from google.cloud import bigquery_storage
+except ImportError:  # pragma: NO COVER
+    bigquery_storage = None
+
+try:
+    import pyarrow
+    import pyarrow.types
+except ImportError:  # pragma: NO COVER
+    pyarrow = None
+
+
+@pytest.fixture(scope="session")
+def connection(bigquery_client):
+    return dbapi.connect(bigquery_client)
+
+
+@pytest.fixture
+def cursor(connection):
+    return connection.cursor()
+
+
+@pytest.mark.parametrize(("sql", "expected"), helpers.STANDARD_SQL_EXAMPLES)
+def test_w_standard_sql_types(sql, expected, cursor):
+    cursor.execute(sql)
+    assert cursor.rowcount == 1
+    row = cursor.fetchone()
+    assert len(row) == 1
+    assert row[0] == expected
+    row = cursor.fetchone()
+    assert row is None
+
+
+def test_fetchall(cursor):
+    query = "SELECT * FROM UNNEST([(1, 2), (3, 4), (5, 6)])"
+    for arraysize in itertools.chain((None,), range(1, 5)):
+        cursor.execute(query)
+        assert cursor.rowcount == 3
+        cursor.arraysize = arraysize
+        rows = cursor.fetchall()
+        row_tuples = [r.values() for r in rows]
+        assert row_tuples == [(1, 2), (3, 4), (5, 6)]
+
+
+def test_fetchall_from_script(cursor):
+    query = """
+    CREATE TEMP TABLE Example
+    (
+      x INT64,
+      y STRING
+    );
+
+    INSERT INTO Example
+    VALUES (5, 'foo'),
+    (6, 'bar'),
+    (7, 'baz');
+
+    SELECT *
+    FROM Example
+    ORDER BY x ASC;
+    """
+
+    cursor.execute(query)
+    assert cursor.rowcount == 3
+    rows = cursor.fetchall()
+    row_tuples = [r.values() for r in rows]
+    assert row_tuples == [(5, "foo"), (6, "bar"), (7, "baz")]
+
+
+def test_create_view(cursor, dataset_id):
+    query = f"""
+    CREATE VIEW {dataset_id}.dbapi_create_view
+    AS SELECT name, SUM(number) AS total
+    FROM `bigquery-public-data.usa_names.usa_1910_2013`
+    GROUP BY name;
+    """
+
+    cursor.execute(query)
+    assert cursor.rowcount == 0
+
+
+@pytest.mark.skipif(
+    bigquery_storage is None, reason="Requires `google-cloud-bigquery-storage`"
+)
+@pytest.mark.skipif(pyarrow is None, reason="Requires `pyarrow`")
+def test_fetch_w_bqstorage_client_large_result_set(bigquery_client, bqstorage_client):
+    cursor = dbapi.connect(bigquery_client, bqstorage_client).cursor()
+
+    cursor.execute(
+        """
+        SELECT id, `by`, time_ts
+        FROM `bigquery-public-data.hacker_news.comments`
+        ORDER BY `id` ASC
+        LIMIT 100000
+        """
+    )
+
+    result_rows = [cursor.fetchone(), cursor.fetchone(), cursor.fetchone()]
+
+    field_name = operator.itemgetter(0)
+    fetched_data = [sorted(row.items(), key=field_name) for row in result_rows]
+
+    # Since DB API is not thread safe, only a single result stream should be
+    # requested by the BQ storage client, meaning that results should arrive
+    # in the sorted order.
+    expected_data = [
+        [
+            ("by", "sama"),
+            ("id", 15),
+            ("time_ts", datetime.datetime(2006, 10, 9, 19, 51, 1, tzinfo=UTC)),
+        ],
+        [
+            ("by", "pg"),
+            ("id", 17),
+            ("time_ts", datetime.datetime(2006, 10, 9, 19, 52, 45, tzinfo=UTC)),
+        ],
+        [
+            ("by", "pg"),
+            ("id", 22),
+            ("time_ts", datetime.datetime(2006, 10, 10, 2, 18, 22, tzinfo=UTC)),
+        ],
+    ]
+    assert fetched_data == expected_data
+
+
+def test_dry_run_query(cursor):
+    from google.cloud.bigquery.job import QueryJobConfig
+
+    query = """
+        SELECT country_name
+        FROM `bigquery-public-data.utility_us.country_code_iso`
+        WHERE country_name LIKE 'U%'
+    """
+
+    cursor.execute(query, job_config=QueryJobConfig(dry_run=True))
+    assert cursor.rowcount == 0
+
+    rows = cursor.fetchall()
+    assert list(rows) == []
+
+
+@pytest.mark.skipif(
+    bigquery_storage is None, reason="Requires `google-cloud-bigquery-storage`"
+)
+def test_connection_does_not_leak_sockets():
+    current_process = psutil.Process()
+    conn_count_start = len(current_process.connections())
+
+    # Provide no explicit clients, so that the connection will create and own them.
+    connection = dbapi.connect()
+    cursor = connection.cursor()
+
+    cursor.execute(
+        """
+        SELECT id, `by`, time_ts
+        FROM `bigquery-public-data.hacker_news.comments`
+        ORDER BY `id` ASC
+        LIMIT 100000
+    """
+    )
+    rows = cursor.fetchall()
+    assert len(rows) == 100000
+
+    connection.close()
+    conn_count_end = len(current_process.connections())
+    assert conn_count_end <= conn_count_start
+
+
+def test_w_dml(bigquery_client, cursor, dataset_id):
+    table_id = "dbapi_test_w_dml"
+    bigquery_client.load_table_from_json(
+        [{"greeting": "こんにちは"}, {"greeting": "Hello World"}, {"greeting": "Howdy!"}],
+        f"{dataset_id}.{table_id}",
+    ).result()
+
+    query = f"""UPDATE {dataset_id}.{table_id}
+        SET greeting = 'Guten Tag'
+        WHERE greeting = 'Hello World'
+        """
+    cursor.execute(
+        query, job_id="test_w_dml_{}".format(str(uuid.uuid4())),
+    )
+    assert cursor.rowcount == 1
+
+
+@pytest.mark.parametrize(
+    ("sql", "expected", "query_parameters"),
+    [
+        ("SELECT %(boolval)s", True, {"boolval": True},),
+        ('SELECT %(a "very" weird `name`)s', True, {'a "very" weird `name`': True},),
+        ("SELECT %(select)s", True, {"select": True},),  # this name is a keyword
+        ("SELECT %s", False, [False]),
+        ("SELECT %(intval)s", 123, {"intval": 123},),
+        ("SELECT %s", -123456789, [-123456789],),
+        ("SELECT %(floatval)s", 1.25, {"floatval": 1.25},),
+        ("SELECT LOWER(%(strval)s)", "i am a string", {"strval": "I Am A String"},),
+        (
+            "SELECT DATE_SUB(%(dateval)s, INTERVAL 1 DAY)",
+            datetime.date(2017, 4, 1),
+            {"dateval": datetime.date(2017, 4, 2)},
+        ),
+        (
+            "SELECT TIME_ADD(%(timeval)s, INTERVAL 4 SECOND)",
+            datetime.time(12, 35, 0),
+            {"timeval": datetime.time(12, 34, 56)},
+        ),
+        (
+            ("SELECT DATETIME_ADD(%(datetimeval)s, INTERVAL 53 SECOND)"),
+            datetime.datetime(2012, 3, 4, 5, 7, 0),
+            {"datetimeval": datetime.datetime(2012, 3, 4, 5, 6, 7)},
+        ),
+        (
+            "SELECT TIMESTAMP_TRUNC(%(zoned)s, MINUTE)",
+            datetime.datetime(2012, 3, 4, 5, 6, 0, tzinfo=UTC),
+            {"zoned": datetime.datetime(2012, 3, 4, 5, 6, 7, tzinfo=UTC)},
+        ),
+        (
+            "SELECT TIMESTAMP_TRUNC(%(zoned)s, MINUTE)",
+            datetime.datetime(2012, 3, 4, 5, 6, 0, tzinfo=UTC),
+            {"zoned": datetime.datetime(2012, 3, 4, 5, 6, 7, 250000, tzinfo=UTC)},
+        ),
+    ],
+)
+def test_w_query_parameters(cursor, sql, query_parameters, expected):
+    cursor.execute(sql, query_parameters)
+
+    assert cursor.rowcount == 1
+    row = cursor.fetchone()
+    assert len(row) == 1
+    assert row[0] == expected
+    row = cursor.fetchone()
+    assert row is None

--- a/tests/system/test_magics.py
+++ b/tests/system/test_magics.py
@@ -1,0 +1,83 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""System tests for Jupyter/IPython connector."""
+
+import re
+
+import pytest
+import psutil
+
+
+IPython = pytest.importorskip("IPython")
+io = pytest.importorskip("IPython.utils.io")
+pandas = pytest.importorskip("pandas")
+tools = pytest.importorskip("IPython.testing.tools")
+interactiveshell = pytest.importorskip("IPython.terminal.interactiveshell")
+
+
+@pytest.fixture(scope="session")
+def ipython():
+    config = tools.default_config()
+    config.TerminalInteractiveShell.simple_prompt = True
+    shell = interactiveshell.TerminalInteractiveShell.instance(config=config)
+    return shell
+
+
+@pytest.fixture()
+def ipython_interactive(ipython):
+    """Activate IPython's builtin hooks
+
+    for the duration of the test scope.
+    """
+    with ipython.builtin_trap:
+        yield ipython
+
+
+def test_bigquery_magic(ipython_interactive):
+    ip = IPython.get_ipython()
+    current_process = psutil.Process()
+    conn_count_start = len(current_process.connections())
+
+    ip.extension_manager.load_extension("google.cloud.bigquery")
+    sql = """
+        SELECT
+            CONCAT(
+            'https://stackoverflow.com/questions/',
+            CAST(id as STRING)) as url,
+            view_count
+        FROM `bigquery-public-data.stackoverflow.posts_questions`
+        WHERE tags like '%google-bigquery%'
+        ORDER BY view_count DESC
+        LIMIT 10
+    """
+    with io.capture_output() as captured:
+        result = ip.run_cell_magic("bigquery", "--use_rest_api", sql)
+
+    conn_count_end = len(current_process.connections())
+
+    lines = re.split("\n|\r", captured.stdout)
+    # Removes blanks & terminal code (result of display clearing)
+    updates = list(filter(lambda x: bool(x) and x != "\x1b[2K", lines))
+    assert re.match("Executing query with job ID: .*", updates[0])
+    assert all(re.match("Query executing: .*s", line) for line in updates[1:-1])
+    assert re.match("Query complete after .*s", updates[-1])
+    assert isinstance(result, pandas.DataFrame)
+    assert len(result) == 10  # verify row count
+    assert list(result) == ["url", "view_count"]  # verify column names
+
+    # NOTE: For some reason, the number of open sockets is sometimes one *less*
+    # than expected when running system tests on Kokoro, thus using the <= assertion.
+    # That's still fine, however, since the sockets are apparently not leaked.
+    assert conn_count_end <= conn_count_start  # system resources are released

--- a/tests/system/test_pandas.py
+++ b/tests/system/test_pandas.py
@@ -1,0 +1,740 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""System tests for pandas connector."""
+
+import collections
+import datetime
+import decimal
+import operator
+
+import pkg_resources
+import pytest
+import pytz
+import six
+
+from google.cloud import bigquery
+from . import helpers
+
+
+bigquery_storage = pytest.importorskip(
+    "google.cloud.bigquery_storage", minversion="2.0.0"
+)
+pandas = pytest.importorskip("pandas", minversion="0.23.0")
+pyarrow = pytest.importorskip("pyarrow", minversion="1.0.0")
+
+
+PANDAS_INSTALLED_VERSION = pkg_resources.get_distribution("pandas").parsed_version
+PANDAS_INT64_VERSION = pkg_resources.parse_version("1.0.0")
+
+
+def test_list_rows_max_results_w_bqstorage(bigquery_client, bqstorage_client):
+    table_ref = bigquery.TableReference.from_string(
+        "bigquery-public-data.utility_us.country_code_iso"
+    )
+
+    row_iterator = bigquery_client.list_rows(
+        table_ref,
+        selected_fields=[bigquery.SchemaField("country_name", "STRING")],
+        max_results=100,
+    )
+    with pytest.warns(
+        UserWarning, match="Cannot use bqstorage_client if max_results is set"
+    ):
+        dataframe = row_iterator.to_dataframe(bqstorage_client=bqstorage_client)
+
+    assert len(dataframe.index) == 100
+
+
+def test_nested_table_to_dataframe(bigquery_client, dataset_id):
+    from google.cloud.bigquery.job import SourceFormat
+    from google.cloud.bigquery.job import WriteDisposition
+
+    SF = bigquery.SchemaField
+    schema = [
+        SF("string_col", "STRING", mode="NULLABLE"),
+        SF(
+            "record_col",
+            "RECORD",
+            mode="NULLABLE",
+            fields=[
+                SF("nested_string", "STRING", mode="NULLABLE"),
+                SF("nested_repeated", "INTEGER", mode="REPEATED"),
+                SF(
+                    "nested_record",
+                    "RECORD",
+                    mode="NULLABLE",
+                    fields=[SF("nested_nested_string", "STRING", mode="NULLABLE")],
+                ),
+            ],
+        ),
+        SF("bigfloat_col", "FLOAT", mode="NULLABLE"),
+        SF("smallfloat_col", "FLOAT", mode="NULLABLE"),
+    ]
+    record = {
+        "nested_string": "another string value",
+        "nested_repeated": [0, 1, 2],
+        "nested_record": {"nested_nested_string": "some deep insight"},
+    }
+    # Load data into a temporary table, which we can then read from.
+    to_insert = [
+        {
+            "string_col": "Some value",
+            "record_col": record,
+            "bigfloat_col": 3.14,
+            "smallfloat_col": 2.72,
+        }
+    ]
+    table_id = "pandas_test_nested_table_to_dataframe" + helpers.temp_suffix()
+    job_config = bigquery.LoadJobConfig()
+    job_config.write_disposition = WriteDisposition.WRITE_TRUNCATE
+    job_config.source_format = SourceFormat.NEWLINE_DELIMITED_JSON
+    job_config.schema = schema
+    bigquery_client.load_table_from_json(
+        to_insert, f"{dataset_id}.{table_id}", job_config=job_config
+    ).result()
+
+    df = bigquery_client.list_rows(
+        f"{dataset_id}.{table_id}", selected_fields=schema,
+    ).to_dataframe(dtypes={"smallfloat_col": "float16"})
+
+    assert isinstance(df, pandas.DataFrame)
+    assert len(df.index) == 1  # verify the number of rows
+    exp_columns = ["string_col", "record_col", "bigfloat_col", "smallfloat_col"]
+    assert list(df) == exp_columns  # verify the column names
+    row = df.iloc[0]
+    # verify the row content
+    assert row["string_col"] == "Some value"
+    expected_keys = tuple(sorted(record.keys()))
+    row_keys = tuple(sorted(row["record_col"].keys()))
+    assert row_keys == expected_keys
+    # Can't compare numpy arrays, which pyarrow encodes the embedded
+    # repeated column to, so convert to list.
+    assert list(row["record_col"]["nested_repeated"]) == [0, 1, 2]
+    # verify that nested data can be accessed with indices/keys
+    assert row["record_col"]["nested_repeated"][0] == 0
+    assert (
+        row["record_col"]["nested_record"]["nested_nested_string"]
+        == "some deep insight"
+    )
+    # verify dtypes
+    assert df.dtypes["bigfloat_col"].name == "float64"
+    assert df.dtypes["smallfloat_col"].name == "float16"
+
+
+@pytest.mark.parametrize(("create_bqstorage_client",), [(True,), (False,)])
+def test_query_results_to_dataframe(bigquery_client, create_bqstorage_client):
+    query = """
+    SELECT id, author, time_ts, dead
+    FROM `bigquery-public-data.hacker_news.comments`
+    LIMIT 10
+    """
+    df = (
+        bigquery_client.query(query)
+        .result()
+        .to_dataframe(create_bqstorage_client=create_bqstorage_client)
+    )
+
+    assert isinstance(df, pandas.DataFrame)
+    assert len(df.index) == 10  # verify the number of rows
+    column_names = ["id", "author", "time_ts", "dead"]
+    assert list(df) == column_names  # verify the column names
+    exp_datatypes = {
+        "id": int,
+        "author": six.text_type,
+        "time_ts": pandas.Timestamp,
+        "dead": bool,
+    }
+    for _, row in df.iterrows():
+        for col in column_names:
+            # all the schema fields are nullable, so None is acceptable
+            assert row[col] is None or isinstance(row[col], exp_datatypes[col])
+
+
+def test_insert_rows_from_dataframe(bigquery_client, dataset_id):
+    SF = bigquery.SchemaField
+    schema = [
+        SF("float_col", "FLOAT", mode="REQUIRED"),
+        SF("int_col", "INTEGER", mode="REQUIRED"),
+        SF("bool_col", "BOOLEAN", mode="REQUIRED"),
+        SF("string_col", "STRING", mode="NULLABLE"),
+    ]
+
+    dataframe = pandas.DataFrame(
+        [
+            {
+                "float_col": 1.11,
+                "bool_col": True,
+                "string_col": "my string",
+                "int_col": 10,
+            },
+            {
+                "float_col": 2.22,
+                "bool_col": False,
+                "string_col": "another string",
+                "int_col": 20,
+            },
+            {
+                "float_col": 3.33,
+                "bool_col": False,
+                "string_col": "another string",
+                "int_col": 30,
+            },
+            {
+                "float_col": 4.44,
+                "bool_col": True,
+                "string_col": "another string",
+                "int_col": 40,
+            },
+            {
+                "float_col": 5.55,
+                "bool_col": False,
+                "string_col": "another string",
+                "int_col": 50,
+            },
+            {
+                "float_col": 6.66,
+                "bool_col": True,
+                # Include a NaN value, because pandas often uses NaN as a
+                # NULL value indicator.
+                "string_col": float("NaN"),
+                "int_col": 60,
+            },
+        ]
+    )
+
+    table_id = "pandas_test_insert_rows_from_dataframe" + helpers.temp_suffix()
+    table_arg = bigquery.Table(
+        f"{bigquery_client.project}.{dataset_id}.{table_id}", schema=schema
+    )
+    table = helpers.retry_403(bigquery_client.create_table)(table_arg)
+
+    chunk_errors = bigquery_client.insert_rows_from_dataframe(
+        table, dataframe, chunk_size=3
+    )
+    for errors in chunk_errors:
+        assert not errors
+
+    # Use query to fetch rows instead of listing directly from the table so
+    # that we get values from the streaming buffer.
+    rows = list(
+        bigquery_client.query(
+            "SELECT * FROM `{}.{}.{}`".format(
+                table.project, table.dataset_id, table.table_id
+            )
+        )
+    )
+
+    sorted_rows = sorted(rows, key=operator.attrgetter("int_col"))
+    row_tuples = [r.values() for r in sorted_rows]
+    expected = [
+        tuple(None if col != col else col for col in data_row)
+        for data_row in dataframe.itertuples(index=False)
+    ]
+
+    assert len(row_tuples) == len(expected)
+
+    for row, expected_row in zip(row_tuples, expected):
+        # column order does not matter
+        assert len(row) == len(expected_row)
+
+
+def test_load_table_from_dataframe_w_automatic_schema(bigquery_client, dataset_id):
+    """Test that a DataFrame with dtypes that map well to BigQuery types
+    can be uploaded without specifying a schema.
+
+    https://github.com/googleapis/google-cloud-python/issues/9044
+    """
+    df_data = collections.OrderedDict(
+        [
+            ("bool_col", pandas.Series([True, False, True], dtype="bool")),
+            (
+                "ts_col",
+                pandas.Series(
+                    [
+                        datetime.datetime(2010, 1, 2, 3, 44, 50),
+                        datetime.datetime(2011, 2, 3, 14, 50, 59),
+                        datetime.datetime(2012, 3, 14, 15, 16),
+                    ],
+                    dtype="datetime64[ns]",
+                ).dt.tz_localize(pytz.utc),
+            ),
+            (
+                "dt_col",
+                pandas.Series(
+                    [
+                        datetime.datetime(2010, 1, 2, 3, 44, 50),
+                        datetime.datetime(2011, 2, 3, 14, 50, 59),
+                        datetime.datetime(2012, 3, 14, 15, 16),
+                    ],
+                    dtype="datetime64[ns]",
+                ),
+            ),
+            ("float32_col", pandas.Series([1.0, 2.0, 3.0], dtype="float32")),
+            ("float64_col", pandas.Series([4.0, 5.0, 6.0], dtype="float64")),
+            ("int8_col", pandas.Series([-12, -11, -10], dtype="int8")),
+            ("int16_col", pandas.Series([-9, -8, -7], dtype="int16")),
+            ("int32_col", pandas.Series([-6, -5, -4], dtype="int32")),
+            ("int64_col", pandas.Series([-3, -2, -1], dtype="int64")),
+            ("uint8_col", pandas.Series([0, 1, 2], dtype="uint8")),
+            ("uint16_col", pandas.Series([3, 4, 5], dtype="uint16")),
+            ("uint32_col", pandas.Series([6, 7, 8], dtype="uint32")),
+        ]
+    )
+    dataframe = pandas.DataFrame(df_data, columns=df_data.keys())
+    table_id = (
+        f"{bigquery_client.project}.{dataset_id}"
+        ".pandas_test_load_table_from_dataframe_w_automatic_schema"
+        f"{helpers.temp_suffix()}"
+    )
+
+    load_job = bigquery_client.load_table_from_dataframe(dataframe, table_id)
+    load_job.result()
+
+    table = bigquery_client.get_table(table_id)
+    assert tuple(table.schema) == (
+        bigquery.SchemaField("bool_col", "BOOLEAN"),
+        bigquery.SchemaField("ts_col", "TIMESTAMP"),
+        # BigQuery does not support uploading DATETIME values from
+        # Parquet files. See:
+        # https://github.com/googleapis/google-cloud-python/issues/9996
+        bigquery.SchemaField("dt_col", "TIMESTAMP"),
+        bigquery.SchemaField("float32_col", "FLOAT"),
+        bigquery.SchemaField("float64_col", "FLOAT"),
+        bigquery.SchemaField("int8_col", "INTEGER"),
+        bigquery.SchemaField("int16_col", "INTEGER"),
+        bigquery.SchemaField("int32_col", "INTEGER"),
+        bigquery.SchemaField("int64_col", "INTEGER"),
+        bigquery.SchemaField("uint8_col", "INTEGER"),
+        bigquery.SchemaField("uint16_col", "INTEGER"),
+        bigquery.SchemaField("uint32_col", "INTEGER"),
+    )
+    assert table.num_rows == 3
+
+
+@pytest.mark.skipif(
+    pandas is None or PANDAS_INSTALLED_VERSION < PANDAS_INT64_VERSION,
+    reason="only `pandas version >=1.0.0` supports Int64 extension dtype",
+)
+def test_load_table_from_dataframe_w_nullable_int64_datatype(
+    bigquery_client, dataset_id
+):
+    """Test that a DataFrame containing column with None-type values and int64 datatype
+    can be uploaded if a BigQuery schema is specified.
+
+    https://github.com/googleapis/python-bigquery/issues/22
+    """
+
+    table_id = (
+        f"{bigquery_client.project}.{dataset_id}"
+        ".pandas_test_load_table_from_dataframe_w_nullable_int64_datatype"
+        f"{helpers.temp_suffix()}"
+    )
+    table_schema = (bigquery.SchemaField("x", "INTEGER", mode="NULLABLE"),)
+    table = helpers.retry_403(bigquery_client.create_table)(
+        bigquery.Table(table_id, schema=table_schema)
+    )
+    df_data = collections.OrderedDict(
+        [("x", pandas.Series([1, 2, None, 4], dtype="Int64"))]
+    )
+    dataframe = pandas.DataFrame(df_data, columns=df_data.keys())
+    load_job = bigquery_client.load_table_from_dataframe(dataframe, table_id)
+    load_job.result()
+    table = bigquery_client.get_table(table_id)
+    assert tuple(table.schema) == (bigquery.SchemaField("x", "INTEGER"),)
+    assert table.num_rows == 4
+
+
+@pytest.mark.skipif(
+    pandas is None or PANDAS_INSTALLED_VERSION < PANDAS_INT64_VERSION,
+    reason="only `pandas version >=1.0.0` supports Int64 extension dtype",
+)
+def test_load_table_from_dataframe_w_nullable_int64_datatype_automatic_schema(
+    bigquery_client, dataset_id
+):
+    """Test that a DataFrame containing column with None-type values and int64 datatype
+    can be uploaded without specifying a schema.
+
+    https://github.com/googleapis/python-bigquery/issues/22
+    """
+
+    table_id = (
+        f"{bigquery_client.project}.{dataset_id}"
+        ".pandas_test_load_table_from_dataframe_w_nullable_int64_datatype_automatic_schema"
+        f"{helpers.temp_suffix()}"
+    )
+    df_data = collections.OrderedDict(
+        [("x", pandas.Series([1, 2, None, 4], dtype="Int64"))]
+    )
+    dataframe = pandas.DataFrame(df_data, columns=df_data.keys())
+    load_job = bigquery_client.load_table_from_dataframe(dataframe, table_id)
+    load_job.result()
+    table = bigquery_client.get_table(table_id)
+    assert tuple(table.schema) == (bigquery.SchemaField("x", "INTEGER"),)
+    assert table.num_rows == 4
+
+
+def test_load_table_from_dataframe_w_nulls(bigquery_client, dataset_id):
+    """Test that a DataFrame with null columns can be uploaded if a
+    BigQuery schema is specified.
+
+    See: https://github.com/googleapis/google-cloud-python/issues/7370
+    """
+    # Schema with all scalar types.
+    scalars_schema = (
+        bigquery.SchemaField("bool_col", "BOOLEAN"),
+        bigquery.SchemaField("bytes_col", "BYTES"),
+        bigquery.SchemaField("date_col", "DATE"),
+        bigquery.SchemaField("dt_col", "DATETIME"),
+        bigquery.SchemaField("float_col", "FLOAT"),
+        bigquery.SchemaField("geo_col", "GEOGRAPHY"),
+        bigquery.SchemaField("int_col", "INTEGER"),
+        bigquery.SchemaField("num_col", "NUMERIC"),
+        bigquery.SchemaField("str_col", "STRING"),
+        bigquery.SchemaField("time_col", "TIME"),
+        bigquery.SchemaField("ts_col", "TIMESTAMP"),
+    )
+    table_schema = scalars_schema + (
+        bigquery.SchemaField(
+            "record_col",
+            "RECORD",
+            fields=[
+                bigquery.SchemaField("id", "INTEGER"),
+                bigquery.SchemaField("age", "INTEGER"),
+            ],
+        ),
+        # TODO: Array columns aren't supported.
+        #       https://github.com/googleapis/python-bigquery/issues/19
+        # bigquery.SchemaField("array_col", "INTEGER", mode="REPEATED"),
+        # bigquery.SchemaField("struct_col", "RECORD", fields=scalars_schema),
+    )
+    num_rows = 100
+    nulls = [None] * num_rows
+    df_data = collections.OrderedDict(
+        [
+            ("bool_col", nulls),
+            ("bytes_col", nulls),
+            ("date_col", nulls),
+            ("dt_col", nulls),
+            ("float_col", nulls),
+            ("geo_col", nulls),
+            ("int_col", nulls),
+            ("num_col", nulls),
+            ("str_col", nulls),
+            ("time_col", nulls),
+            ("ts_col", nulls),
+            ("record_col", nulls),
+        ]
+    )
+    dataframe = pandas.DataFrame(df_data, columns=df_data.keys())
+    table_id = (
+        f"{bigquery_client.project}.{dataset_id}"
+        ".pandas_test_load_table_from_dataframe_w_nulls"
+        f"{helpers.temp_suffix()}"
+    )
+
+    # Create the table before loading so that schema mismatch errors are
+    # identified.
+    table = helpers.retry_403(bigquery_client.create_table)(
+        bigquery.Table(table_id, schema=table_schema)
+    )
+
+    job_config = bigquery.LoadJobConfig(schema=table_schema)
+    load_job = bigquery_client.load_table_from_dataframe(
+        dataframe, table_id, job_config=job_config
+    )
+    load_job.result()
+
+    table = bigquery_client.get_table(table)
+    assert tuple(table.schema) == table_schema
+    assert table.num_rows == num_rows
+
+
+def test_load_table_from_dataframe_w_required(bigquery_client, dataset_id):
+    """Test that a DataFrame with required columns can be uploaded if a
+    BigQuery schema is specified.
+
+    See: https://github.com/googleapis/google-cloud-python/issues/8093
+    """
+    table_schema = (
+        bigquery.SchemaField("name", "STRING", mode="REQUIRED"),
+        bigquery.SchemaField("age", "INTEGER", mode="REQUIRED"),
+    )
+
+    records = [{"name": "Chip", "age": 2}, {"name": "Dale", "age": 3}]
+    dataframe = pandas.DataFrame(records, columns=["name", "age"])
+    job_config = bigquery.LoadJobConfig(schema=table_schema)
+    table_id = (
+        f"{bigquery_client.project}.{dataset_id}"
+        ".pandas_test_load_table_from_dataframe_w_required"
+        f"{helpers.temp_suffix()}"
+    )
+
+    # Create the table before loading so that schema mismatch errors are
+    # identified.
+    table = helpers.retry_403(bigquery_client.create_table)(
+        bigquery.Table(table_id, schema=table_schema)
+    )
+
+    job_config = bigquery.LoadJobConfig(schema=table_schema)
+    load_job = bigquery_client.load_table_from_dataframe(
+        dataframe, table_id, job_config=job_config
+    )
+    load_job.result()
+
+    table = bigquery_client.get_table(table)
+    assert tuple(table.schema) == table_schema
+    assert table.num_rows == 2
+
+
+def test_load_table_from_dataframe_w_explicit_schema(bigquery_client, dataset_id):
+    # Schema with all scalar types.
+    # TODO: Uploading DATETIME columns currently fails, thus that field type
+    #       is temporarily  removed from the test.
+    # See:
+    #       https://github.com/googleapis/python-bigquery/issues/61
+    #       https://issuetracker.google.com/issues/151765076
+    scalars_schema = (
+        bigquery.SchemaField("bool_col", "BOOLEAN"),
+        bigquery.SchemaField("bytes_col", "BYTES"),
+        bigquery.SchemaField("date_col", "DATE"),
+        # bigquery.SchemaField("dt_col", "DATETIME"),
+        bigquery.SchemaField("float_col", "FLOAT"),
+        bigquery.SchemaField("geo_col", "GEOGRAPHY"),
+        bigquery.SchemaField("int_col", "INTEGER"),
+        bigquery.SchemaField("num_col", "NUMERIC"),
+        bigquery.SchemaField("str_col", "STRING"),
+        bigquery.SchemaField("time_col", "TIME"),
+        bigquery.SchemaField("ts_col", "TIMESTAMP"),
+    )
+    table_schema = scalars_schema + (
+        # Struct / Record columns are supported when serializing to Parquet.
+        # https://github.com/googleapis/python-bigquery/issues/21
+        bigquery.SchemaField(
+            "record_col",
+            "RECORD",
+            fields=[
+                bigquery.SchemaField("id", "INTEGER", mode="REQUIRED"),
+                bigquery.SchemaField("age", "INTEGER", mode="REQUIRED"),
+            ],
+            mode="REQUIRED",
+        ),
+        # TODO: Array columns can't be read due to NULLABLE versus REPEATED
+        #       mode mismatch. See:
+        #       https://issuetracker.google.com/133415569#comment3
+        # bigquery.SchemaField("array_col", "INTEGER", mode="REPEATED"),
+        # TODO: Support writing StructArrays to Parquet. See:
+        #       https://jira.apache.org/jira/browse/ARROW-2587
+        # bigquery.SchemaField("struct_col", "RECORD", fields=scalars_schema),
+    )
+    df_data = collections.OrderedDict(
+        [
+            ("bool_col", [True, None, False]),
+            ("bytes_col", [b"abc", None, b"def"]),
+            ("date_col", [datetime.date(1, 1, 1), None, datetime.date(9999, 12, 31)],),
+            # (
+            #     "dt_col",
+            #     [
+            #         datetime.datetime(1, 1, 1, 0, 0, 0),
+            #         None,
+            #         datetime.datetime(9999, 12, 31, 23, 59, 59, 999999),
+            #     ],
+            # ),
+            ("float_col", [float("-inf"), float("nan"), float("inf")]),
+            (
+                "geo_col",
+                [
+                    "POINT(30 10)",
+                    None,
+                    "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))",
+                ],
+            ),
+            ("int_col", [-9223372036854775808, None, 9223372036854775807]),
+            (
+                "num_col",
+                [
+                    decimal.Decimal("-99999999999999999999999999999.999999999"),
+                    None,
+                    decimal.Decimal("99999999999999999999999999999.999999999"),
+                ],
+            ),
+            ("str_col", ["abc", None, "def"]),
+            (
+                "time_col",
+                [datetime.time(0, 0, 0), None, datetime.time(23, 59, 59, 999999)],
+            ),
+            (
+                "ts_col",
+                [
+                    datetime.datetime(1, 1, 1, 0, 0, 0, tzinfo=pytz.utc),
+                    None,
+                    datetime.datetime(
+                        9999, 12, 31, 23, 59, 59, 999999, tzinfo=pytz.utc
+                    ),
+                ],
+            ),
+            ("record_col", [None, {"id": 2, "age": 22}, {"id": 3, "age": 23}],),
+        ]
+    )
+    dataframe = pandas.DataFrame(df_data, dtype="object", columns=df_data.keys())
+
+    table_id = (
+        f"{bigquery_client.project}.{dataset_id}"
+        ".pandas_test_load_table_from_dataframe_w_explicit_schema"
+        f"{helpers.temp_suffix()}"
+    )
+
+    job_config = bigquery.LoadJobConfig(schema=table_schema)
+    load_job = bigquery_client.load_table_from_dataframe(
+        dataframe, table_id, job_config=job_config
+    )
+    load_job.result()
+
+    table = bigquery_client.get_table(table_id)
+    assert tuple(table.schema) == table_schema
+    assert table.num_rows == 3
+
+
+def test_load_table_from_dataframe_w_explicit_schema_source_format_csv(
+    bigquery_client, dataset_id
+):
+    from google.cloud.bigquery.job import SourceFormat
+
+    table_schema = (
+        bigquery.SchemaField("bool_col", "BOOLEAN"),
+        bigquery.SchemaField("bytes_col", "BYTES"),
+        bigquery.SchemaField("date_col", "DATE"),
+        bigquery.SchemaField("dt_col", "DATETIME"),
+        bigquery.SchemaField("float_col", "FLOAT"),
+        bigquery.SchemaField("geo_col", "GEOGRAPHY"),
+        bigquery.SchemaField("int_col", "INTEGER"),
+        bigquery.SchemaField("num_col", "NUMERIC"),
+        bigquery.SchemaField("str_col", "STRING"),
+        bigquery.SchemaField("time_col", "TIME"),
+        bigquery.SchemaField("ts_col", "TIMESTAMP"),
+    )
+    df_data = collections.OrderedDict(
+        [
+            ("bool_col", [True, None, False]),
+            ("bytes_col", ["abc", None, "def"]),
+            ("date_col", [datetime.date(1, 1, 1), None, datetime.date(9999, 12, 31)],),
+            (
+                "dt_col",
+                [
+                    datetime.datetime(1, 1, 1, 0, 0, 0),
+                    None,
+                    datetime.datetime(9999, 12, 31, 23, 59, 59, 999999),
+                ],
+            ),
+            ("float_col", [float("-inf"), float("nan"), float("inf")]),
+            (
+                "geo_col",
+                [
+                    "POINT(30 10)",
+                    None,
+                    "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))",
+                ],
+            ),
+            ("int_col", [-9223372036854775808, None, 9223372036854775807]),
+            (
+                "num_col",
+                [
+                    decimal.Decimal("-99999999999999999999999999999.999999999"),
+                    None,
+                    decimal.Decimal("99999999999999999999999999999.999999999"),
+                ],
+            ),
+            ("str_col", ["abc", None, "def"]),
+            (
+                "time_col",
+                [datetime.time(0, 0, 0), None, datetime.time(23, 59, 59, 999999)],
+            ),
+            (
+                "ts_col",
+                [
+                    datetime.datetime(1, 1, 1, 0, 0, 0, tzinfo=pytz.utc),
+                    None,
+                    datetime.datetime(
+                        9999, 12, 31, 23, 59, 59, 999999, tzinfo=pytz.utc
+                    ),
+                ],
+            ),
+        ]
+    )
+    dataframe = pandas.DataFrame(df_data, dtype="object", columns=df_data.keys())
+
+    table_id = (
+        f"{bigquery_client.project}.{dataset_id}"
+        ".pandas_test_load_table_from_dataframe_w_explicit_schema_source_format_csv"
+        f"{helpers.temp_suffix()}"
+    )
+
+    job_config = bigquery.LoadJobConfig(
+        schema=table_schema, source_format=SourceFormat.CSV
+    )
+    load_job = bigquery_client.load_table_from_dataframe(
+        dataframe, table_id, job_config=job_config
+    )
+    load_job.result()
+
+    table = bigquery_client.get_table(table_id)
+    assert tuple(table.schema) == table_schema
+    assert table.num_rows == 3
+
+
+def test_load_table_from_dataframe_w_explicit_schema_source_format_csv_floats(
+    bigquery_client, dataset_id
+):
+    from google.cloud.bigquery.job import SourceFormat
+
+    table_schema = (bigquery.SchemaField("float_col", "FLOAT"),)
+    df_data = collections.OrderedDict(
+        [
+            (
+                "float_col",
+                [
+                    0.14285714285714285,
+                    0.51428571485748,
+                    0.87128748,
+                    1.807960649,
+                    2.0679610649,
+                    2.4406779661016949,
+                    3.7148514257,
+                    3.8571428571428572,
+                    1.51251252e40,
+                ],
+            ),
+        ]
+    )
+    dataframe = pandas.DataFrame(df_data, dtype="object", columns=df_data.keys())
+    table_id = (
+        f"{bigquery_client.project}.{dataset_id}"
+        ".pandas_test_load_table_from_dataframe_w_explicit_schema_source_format_csv_floats"
+        f"{helpers.temp_suffix()}"
+    )
+
+    job_config = bigquery.LoadJobConfig(
+        schema=table_schema, source_format=SourceFormat.CSV
+    )
+    load_job = bigquery_client.load_table_from_dataframe(
+        dataframe, table_id, job_config=job_config
+    )
+    load_job.result()
+
+    table = bigquery_client.get_table(table_id)
+    rows = list(bigquery_client.list_rows(table))
+    floats = [r.values()[0] for r in rows]
+    assert tuple(table.schema) == table_schema
+    assert table.num_rows == 9
+    assert floats == df_data["float_col"]


### PR DESCRIPTION
This should make it easier to see which pandas tests
we have and which we are missing.

Despite the branch name, not exactly related to https://github.com/googleapis/python-bigquery/issues/56, but I realized I was having trouble determining if this pandas DATETIME use case was tested when all system tests were in the same file.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Towards #366