### PR TITLE
chore: Remove six dependency

### DIFF
--- a/google/cloud/bigquery/_helpers.py
+++ b/google/cloud/bigquery/_helpers.py
@@ -18,7 +18,6 @@ import base64
 import datetime
 import decimal
 import re
-import six
 
 from google.cloud._helpers import UTC
 from google.cloud._helpers import _date_from_iso8601_date
@@ -451,7 +450,7 @@ def _record_field_to_json(fields, row_value):
         for field_name in not_processed:
             value = row_value[field_name]
             if value is not None:
-                record[field_name] = six.text_type(value)
+                record[field_name] = str(value)
 
     return record
 

--- a/google/cloud/bigquery/_pandas_helpers.py
+++ b/google/cloud/bigquery/_pandas_helpers.py
@@ -17,10 +17,9 @@
 import concurrent.futures
 import functools
 import logging
+import queue
 import warnings
 
-import six
-from six.moves import queue
 
 try:
     import pandas
@@ -738,7 +737,7 @@ def download_dataframe_bqstorage(
 def dataframe_to_json_generator(dataframe):
     for row in dataframe.itertuples(index=False, name=None):
         output = {}
-        for column, value in six.moves.zip(dataframe.columns, row):
+        for column, value in zip(dataframe.columns, row):
             # Omit NaN values.
             if value != value:
                 continue

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -34,7 +34,6 @@ try:
     import pyarrow
 except ImportError:  # pragma: NO COVER
     pyarrow = None
-import six
 
 from google import resumable_media
 from google.resumable_media.requests import MultipartUpload
@@ -2017,7 +2016,7 @@ class Client(ClientWithProject):
 
         job_ref = job._JobReference(job_id, project=project, location=location)
 
-        if isinstance(source_uris, six.string_types):
+        if isinstance(source_uris, str):
             source_uris = [source_uris]
 
         destination = _table_arg_to_table_ref(destination, default_project=self.project)
@@ -2779,7 +2778,7 @@ class Client(ClientWithProject):
                 )
             )
 
-        if isinstance(destination_uris, six.string_types):
+        if isinstance(destination_uris, str):
             destination_uris = [destination_uris]
 
         if job_config:

--- a/google/cloud/bigquery/dataset.py
+++ b/google/cloud/bigquery/dataset.py
@@ -16,7 +16,6 @@
 
 from __future__ import absolute_import
 
-import six
 import copy
 
 import google.cloud._helpers
@@ -260,9 +259,9 @@ class DatasetReference(object):
     """
 
     def __init__(self, project, dataset_id):
-        if not isinstance(project, six.string_types):
+        if not isinstance(project, str):
             raise ValueError("Pass a string for project")
-        if not isinstance(dataset_id, six.string_types):
+        if not isinstance(dataset_id, str):
             raise ValueError("Pass a string for dataset_id")
         self._project = project
         self._dataset_id = dataset_id
@@ -407,7 +406,7 @@ class Dataset(object):
     }
 
     def __init__(self, dataset_ref):
-        if isinstance(dataset_ref, six.string_types):
+        if isinstance(dataset_ref, str):
             dataset_ref = DatasetReference.from_string(dataset_ref)
         self._properties = {"datasetReference": dataset_ref.to_api_repr(), "labels": {}}
 
@@ -544,7 +543,7 @@ class Dataset(object):
 
     @default_table_expiration_ms.setter
     def default_table_expiration_ms(self, value):
-        if not isinstance(value, six.integer_types) and value is not None:
+        if not isinstance(value, int) and value is not None:
             raise ValueError("Pass an integer, or None")
         self._properties["defaultTableExpirationMs"] = _helpers._str_or_none(value)
 
@@ -560,7 +559,7 @@ class Dataset(object):
 
     @description.setter
     def description(self, value):
-        if not isinstance(value, six.string_types) and value is not None:
+        if not isinstance(value, str) and value is not None:
             raise ValueError("Pass a string, or None")
         self._properties["description"] = value
 
@@ -576,7 +575,7 @@ class Dataset(object):
 
     @friendly_name.setter
     def friendly_name(self, value):
-        if not isinstance(value, six.string_types) and value is not None:
+        if not isinstance(value, str) and value is not None:
             raise ValueError("Pass a string, or None")
         self._properties["friendlyName"] = value
 
@@ -592,7 +591,7 @@ class Dataset(object):
 
     @location.setter
     def location(self, value):
-        if not isinstance(value, six.string_types) and value is not None:
+        if not isinstance(value, str) and value is not None:
             raise ValueError("Pass a string, or None")
         self._properties["location"] = value
 

--- a/google/cloud/bigquery/dbapi/_helpers.py
+++ b/google/cloud/bigquery/dbapi/_helpers.py
@@ -19,8 +19,6 @@ import decimal
 import functools
 import numbers
 
-import six
-
 from google.cloud import bigquery
 from google.cloud.bigquery import table
 from google.cloud.bigquery.dbapi import exceptions
@@ -132,7 +130,7 @@ def to_query_parameters_dict(parameters):
     """
     result = []
 
-    for name, value in six.iteritems(parameters):
+    for name, value in parameters.items():
         if isinstance(value, collections_abc.Mapping):
             raise NotImplementedError(
                 "STRUCT-like parameter values are not supported "
@@ -187,9 +185,9 @@ def bigquery_scalar_type(value):
         return "FLOAT64"
     elif isinstance(value, decimal.Decimal):
         return "NUMERIC"
-    elif isinstance(value, six.text_type):
+    elif isinstance(value, str):
         return "STRING"
-    elif isinstance(value, six.binary_type):
+    elif isinstance(value, bytes):
         return "BYTES"
     elif isinstance(value, datetime.datetime):
         return "DATETIME" if value.tzinfo is None else "TIMESTAMP"
@@ -215,7 +213,7 @@ def array_like(value):
         bool: ``True`` if the value is considered array-like, ``False`` otherwise.
     """
     return isinstance(value, collections_abc.Sequence) and not isinstance(
-        value, (six.text_type, six.binary_type, bytearray)
+        value, (str, bytes, bytearray)
     )
 
 

--- a/google/cloud/bigquery/dbapi/cursor.py
+++ b/google/cloud/bigquery/dbapi/cursor.py
@@ -19,8 +19,6 @@ from collections import abc as collections_abc
 import copy
 import logging
 
-import six
-
 from google.cloud.bigquery import job
 from google.cloud.bigquery.dbapi import _helpers
 from google.cloud.bigquery.dbapi import exceptions
@@ -289,7 +287,7 @@ class Cursor(object):
         """
         self._try_fetch()
         try:
-            return six.next(self._query_data)
+            return next(self._query_data)
         except StopIteration:
             return None
 

--- a/google/cloud/bigquery/enums.py
+++ b/google/cloud/bigquery/enums.py
@@ -15,7 +15,7 @@
 import re
 
 import enum
-import six
+import itertools
 
 from google.cloud.bigquery_v2 import types as gapic_types
 
@@ -178,7 +178,7 @@ def _make_sql_scalars_enum():
     )
 
     new_doc = "\n".join(
-        six.moves.filterfalse(skip_pattern.search, orig_doc.splitlines())
+        itertools.filterfalse(skip_pattern.search, orig_doc.splitlines())
     )
     new_enum.__doc__ = "An Enum of scalar SQL types.\n" + new_doc
 

--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -15,11 +15,11 @@
 """Base classes and helpers for job classes."""
 
 import copy
+import http
 import threading
 
 from google.api_core import exceptions
 import google.api_core.future.polling
-from six.moves import http_client
 
 from google.cloud.bigquery import _helpers
 from google.cloud.bigquery.retry import DEFAULT_RETRY
@@ -28,24 +28,24 @@ from google.cloud.bigquery.retry import DEFAULT_RETRY
 _DONE_STATE = "DONE"
 _STOPPED_REASON = "stopped"
 _ERROR_REASON_TO_EXCEPTION = {
-    "accessDenied": http_client.FORBIDDEN,
-    "backendError": http_client.INTERNAL_SERVER_ERROR,
-    "billingNotEnabled": http_client.FORBIDDEN,
-    "billingTierLimitExceeded": http_client.BAD_REQUEST,
-    "blocked": http_client.FORBIDDEN,
-    "duplicate": http_client.CONFLICT,
-    "internalError": http_client.INTERNAL_SERVER_ERROR,
-    "invalid": http_client.BAD_REQUEST,
-    "invalidQuery": http_client.BAD_REQUEST,
-    "notFound": http_client.NOT_FOUND,
-    "notImplemented": http_client.NOT_IMPLEMENTED,
-    "quotaExceeded": http_client.FORBIDDEN,
-    "rateLimitExceeded": http_client.FORBIDDEN,
-    "resourceInUse": http_client.BAD_REQUEST,
-    "resourcesExceeded": http_client.BAD_REQUEST,
-    "responseTooLarge": http_client.FORBIDDEN,
-    "stopped": http_client.OK,
-    "tableUnavailable": http_client.BAD_REQUEST,
+    "accessDenied": http.client.FORBIDDEN,
+    "backendError": http.client.INTERNAL_SERVER_ERROR,
+    "billingNotEnabled": http.client.FORBIDDEN,
+    "billingTierLimitExceeded": http.client.BAD_REQUEST,
+    "blocked": http.client.FORBIDDEN,
+    "duplicate": http.client.CONFLICT,
+    "internalError": http.client.INTERNAL_SERVER_ERROR,
+    "invalid": http.client.BAD_REQUEST,
+    "invalidQuery": http.client.BAD_REQUEST,
+    "notFound": http.client.NOT_FOUND,
+    "notImplemented": http.client.NOT_IMPLEMENTED,
+    "quotaExceeded": http.client.FORBIDDEN,
+    "rateLimitExceeded": http.client.FORBIDDEN,
+    "resourceInUse": http.client.BAD_REQUEST,
+    "resourcesExceeded": http.client.BAD_REQUEST,
+    "responseTooLarge": http.client.FORBIDDEN,
+    "stopped": http.client.OK,
+    "tableUnavailable": http.client.BAD_REQUEST,
 }
 
 
@@ -66,7 +66,7 @@ def _error_result_to_exception(error_result):
     """
     reason = error_result.get("reason")
     status_code = _ERROR_REASON_TO_EXCEPTION.get(
-        reason, http_client.INTERNAL_SERVER_ERROR
+        reason, http.client.INTERNAL_SERVER_ERROR
     )
     return exceptions.from_http_status(
         status_code, error_result.get("message", ""), errors=[error_result]

--- a/google/cloud/bigquery/job/query.py
+++ b/google/cloud/bigquery/job/query.py
@@ -20,7 +20,6 @@ import re
 
 from google.api_core import exceptions
 import requests
-import six
 
 from google.cloud.bigquery.dataset import Dataset
 from google.cloud.bigquery.dataset import DatasetListItem
@@ -192,7 +191,7 @@ class QueryJobConfig(_JobConfig):
             self._set_sub_prop("defaultDataset", None)
             return
 
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             value = DatasetReference.from_string(value)
 
         if isinstance(value, (Dataset, DatasetListItem)):
@@ -1168,7 +1167,7 @@ class QueryJob(_AsyncJob):
             exc.query_job = self
             raise
         except requests.exceptions.Timeout as exc:
-            six.raise_from(concurrent.futures.TimeoutError, exc)
+            raise concurrent.futures.TimeoutError from exc
 
         # If the query job is complete but there are no query results, this was
         # special job, such as a DDL query. Return an empty result set to

--- a/google/cloud/bigquery/magics/magics.py
+++ b/google/cloud/bigquery/magics/magics.py
@@ -153,8 +153,6 @@ try:
 except ImportError:  # pragma: NO COVER
     raise ImportError("This module can only be loaded in IPython.")
 
-import six
-
 from google.api_core import client_info
 from google.api_core import client_options
 from google.api_core.exceptions import NotFound
@@ -577,16 +575,16 @@ def _cell_magic(line, query):
             "--params is not a correctly formatted JSON string or a JSON "
             "serializable dictionary"
         )
-        six.raise_from(rebranded_error, exc)
+        raise rebranded_error from exc
     except lap.exceptions.DuplicateQueryParamsError as exc:
         rebranded_error = ValueError("Duplicate --params option.")
-        six.raise_from(rebranded_error, exc)
+        raise rebranded_error from exc
     except lap.exceptions.ParseError as exc:
         rebranded_error = ValueError(
             "Unrecognized input, are option values correct? "
             "Error details: {}".format(exc.args[0])
         )
-        six.raise_from(rebranded_error, exc)
+        raise rebranded_error from exc
 
     args = magic_arguments.parse_argstring(_cell_magic, rest_of_args)
 
@@ -768,7 +766,7 @@ def _make_bqstorage_client(use_bqstorage_api, credentials, client_options):
             "to use it. Alternatively, use the classic REST API by specifying "
             "the --use_rest_api magic option."
         )
-        six.raise_from(customized_error, err)
+        raise customized_error from err
 
     try:
         from google.api_core.gapic_v1 import client_info as gapic_client_info
@@ -776,7 +774,7 @@ def _make_bqstorage_client(use_bqstorage_api, credentials, client_options):
         customized_error = ImportError(
             "Install the grpcio package to use the BigQuery Storage API."
         )
-        six.raise_from(customized_error, err)
+        raise customized_error from err
 
     return bigquery_storage.BigQueryReadClient(
         credentials=credentials,

--- a/google/cloud/bigquery/model.py
+++ b/google/cloud/bigquery/model.py
@@ -19,7 +19,6 @@
 import copy
 
 from google.protobuf import json_format
-import six
 
 import google.cloud._helpers
 from google.api_core import datetime_helpers
@@ -63,7 +62,7 @@ class Model(object):
         # buffer classes do not.
         self._properties = {}
 
-        if isinstance(model_ref, six.string_types):
+        if isinstance(model_ref, str):
             model_ref = ModelReference.from_string(model_ref)
 
         if model_ref:
@@ -455,7 +454,7 @@ def _model_arg_to_model_ref(value, default_project=None):
 
     This function keeps ModelReference and other kinds of objects unchanged.
     """
-    if isinstance(value, six.string_types):
+    if isinstance(value, str):
         return ModelReference.from_string(value, default_project=default_project)
     if isinstance(value, Model):
         return value.reference

--- a/google/cloud/bigquery/routine.py
+++ b/google/cloud/bigquery/routine.py
@@ -17,7 +17,6 @@
 """Define resources for the BigQuery Routines API."""
 
 from google.protobuf import json_format
-import six
 
 import google.cloud._helpers
 from google.cloud.bigquery import _helpers
@@ -54,7 +53,7 @@ class Routine(object):
     }
 
     def __init__(self, routine_ref, **kwargs):
-        if isinstance(routine_ref, six.string_types):
+        if isinstance(routine_ref, str):
             routine_ref = RoutineReference.from_string(routine_ref)
 
         self._properties = {"routineReference": routine_ref.to_api_repr()}

--- a/google/cloud/bigquery/schema.py
+++ b/google/cloud/bigquery/schema.py
@@ -14,7 +14,7 @@
 
 """Schemas for BigQuery tables / queries."""
 
-from six.moves import collections_abc
+import collections
 
 from google.cloud.bigquery_v2 import types
 
@@ -318,7 +318,7 @@ def _to_schema_fields(schema):
         instance or a compatible mapping representation of the field.
     """
     for field in schema:
-        if not isinstance(field, (SchemaField, collections_abc.Mapping)):
+        if not isinstance(field, (SchemaField, collections.abc.Mapping)):
             raise ValueError(
                 "Schema items must either be fields or compatible "
                 "mapping representations."

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -24,8 +24,6 @@ import operator
 import pytz
 import warnings
 
-import six
-
 try:
     import pandas
 except ImportError:  # pragma: NO COVER
@@ -657,7 +655,7 @@ class Table(object):
 
     @description.setter
     def description(self, value):
-        if not isinstance(value, six.string_types) and value is not None:
+        if not isinstance(value, str) and value is not None:
             raise ValueError("Pass a string, or None")
         self._properties["description"] = value
 
@@ -694,7 +692,7 @@ class Table(object):
 
     @friendly_name.setter
     def friendly_name(self, value):
-        if not isinstance(value, six.string_types) and value is not None:
+        if not isinstance(value, str) and value is not None:
             raise ValueError("Pass a string, or None")
         self._properties["friendlyName"] = value
 
@@ -721,7 +719,7 @@ class Table(object):
 
     @view_query.setter
     def view_query(self, value):
-        if not isinstance(value, six.string_types):
+        if not isinstance(value, str):
             raise ValueError("Pass a string")
         _helpers._set_sub_prop(self._properties, ["view", "query"], value)
         view = self._properties["view"]
@@ -1244,7 +1242,7 @@ class Row(object):
             >>> list(Row(('a', 'b'), {'x': 0, 'y': 1}).keys())
             ['x', 'y']
         """
-        return six.iterkeys(self._xxx_field_to_index)
+        return self._xxx_field_to_index.keys()
 
     def items(self):
         """Return items as ``(key, value)`` pairs.
@@ -1258,7 +1256,7 @@ class Row(object):
             >>> list(Row(('a', 'b'), {'x': 0, 'y': 1}).items())
             [('x', 'a'), ('y', 'b')]
         """
-        for key, index in six.iteritems(self._xxx_field_to_index):
+        for key, index in self._xxx_field_to_index.items():
             yield (key, copy.deepcopy(self._xxx_values[index]))
 
     def get(self, key, default=None):
@@ -1308,7 +1306,7 @@ class Row(object):
         return len(self._xxx_values)
 
     def __getitem__(self, key):
-        if isinstance(key, six.string_types):
+        if isinstance(key, str):
             value = self._xxx_field_to_index.get(key)
             if value is None:
                 raise KeyError("no row field {!r}".format(key))
@@ -2293,7 +2291,7 @@ def _table_arg_to_table_ref(value, default_project=None):
 
     This function keeps TableReference and other kinds of objects unchanged.
     """
-    if isinstance(value, six.string_types):
+    if isinstance(value, str):
         value = TableReference.from_string(value, default_project=default_project)
     if isinstance(value, (Table, TableListItem)):
         value = value.reference
@@ -2305,7 +2303,7 @@ def _table_arg_to_table(value, default_project=None):
 
     This function keeps Table and other kinds of objects unchanged.
     """
-    if isinstance(value, six.string_types):
+    if isinstance(value, str):
         value = TableReference.from_string(value, default_project=default_project)
     if isinstance(value, TableReference):
         value = Table(value)

--- a/samples/load_table_uri_truncate_avro.py
+++ b/samples/load_table_uri_truncate_avro.py
@@ -16,7 +16,7 @@
 def load_table_uri_truncate_avro(table_id):
 
     # [START bigquery_load_table_gcs_avro_truncate]
-    import six
+    import io
 
     from google.cloud import bigquery
 
@@ -33,7 +33,7 @@ def load_table_uri_truncate_avro(table_id):
         ],
     )
 
-    body = six.BytesIO(b"Washington,WA")
+    body = io.BytesIO(b"Washington,WA")
     client.load_table_from_file(body, table_id, job_config=job_config).result()
     previous_rows = client.get_table(table_id).num_rows
     assert previous_rows > 0

--- a/samples/load_table_uri_truncate_csv.py
+++ b/samples/load_table_uri_truncate_csv.py
@@ -16,7 +16,7 @@
 def load_table_uri_truncate_csv(table_id):
 
     # [START bigquery_load_table_gcs_csv_truncate]
-    import six
+    import io
 
     from google.cloud import bigquery
 
@@ -33,7 +33,7 @@ def load_table_uri_truncate_csv(table_id):
         ],
     )
 
-    body = six.BytesIO(b"Washington,WA")
+    body = io.BytesIO(b"Washington,WA")
     client.load_table_from_file(body, table_id, job_config=job_config).result()
     previous_rows = client.get_table(table_id).num_rows
     assert previous_rows > 0

--- a/samples/load_table_uri_truncate_json.py
+++ b/samples/load_table_uri_truncate_json.py
@@ -16,7 +16,7 @@
 def load_table_uri_truncate_json(table_id):
 
     # [START bigquery_load_table_gcs_json_truncate]
-    import six
+    import io
 
     from google.cloud import bigquery
 
@@ -33,7 +33,7 @@ def load_table_uri_truncate_json(table_id):
         ],
     )
 
-    body = six.BytesIO(b"Washington,WA")
+    body = io.BytesIO(b"Washington,WA")
     client.load_table_from_file(body, table_id, job_config=job_config).result()
     previous_rows = client.get_table(table_id).num_rows
     assert previous_rows > 0

--- a/samples/load_table_uri_truncate_orc.py
+++ b/samples/load_table_uri_truncate_orc.py
@@ -16,7 +16,7 @@
 def load_table_uri_truncate_orc(table_id):
 
     # [START bigquery_load_table_gcs_orc_truncate]
-    import six
+    import io
 
     from google.cloud import bigquery
 
@@ -33,7 +33,7 @@ def load_table_uri_truncate_orc(table_id):
         ],
     )
 
-    body = six.BytesIO(b"Washington,WA")
+    body = io.BytesIO(b"Washington,WA")
     client.load_table_from_file(body, table_id, job_config=job_config).result()
     previous_rows = client.get_table(table_id).num_rows
     assert previous_rows > 0

--- a/samples/load_table_uri_truncate_parquet.py
+++ b/samples/load_table_uri_truncate_parquet.py
@@ -16,7 +16,7 @@
 def load_table_uri_truncate_parquet(table_id):
 
     # [START bigquery_load_table_gcs_parquet_truncate]
-    import six
+    import io
 
     from google.cloud import bigquery
 
@@ -33,7 +33,7 @@ def load_table_uri_truncate_parquet(table_id):
         ],
     )
 
-    body = six.BytesIO(b"Washington,WA")
+    body = io.BytesIO(b"Washington,WA")
     client.load_table_from_file(body, table_id, job_config=job_config).result()
     previous_rows = client.get_table(table_id).num_rows
     assert previous_rows > 0

--- a/samples/tests/test_copy_table_multiple_source.py
+++ b/samples/tests/test_copy_table_multiple_source.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import six
+import io
 from google.cloud import bigquery
 
 from .. import copy_table_multiple_source
@@ -32,7 +32,7 @@ def test_copy_table_multiple_source(capsys, random_table_id, random_dataset_id, 
                 bigquery.SchemaField("post_abbr", "STRING"),
             ]
         )
-        body = six.BytesIO(data)
+        body = io.BytesIO(data)
         client.load_table_from_file(
             body, table_ref, location="US", job_config=job_config
         ).result()

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ dependencies = [
     "proto-plus >= 1.10.0",
     "google-cloud-core >= 1.4.1, < 2.0dev",
     "google-resumable-media >= 0.6.0, < 2.0dev",
-    "six >=1.13.0,< 2.0.0dev",
     "protobuf >= 3.12.0",
 ]
 extras = {

--- a/tests/system.py
+++ b/tests/system.py
@@ -2572,9 +2572,7 @@ class TestBigQuery(unittest.TestCase):
         assert len(row_tuples) == len(expected)
 
         for row, expected_row in zip(row_tuples, expected):
-            self.assertCountEqual(
-                self, row, expected_row
-            )  # column order does not matter
+            self.assertCountEqual(row, expected_row)  # column order does not matter
 
     def test_insert_rows_nested_nested(self):
         # See #2951

--- a/tests/system.py
+++ b/tests/system.py
@@ -18,6 +18,7 @@ import concurrent.futures
 import csv
 import datetime
 import decimal
+import io
 import json
 import operator
 import os
@@ -27,7 +28,6 @@ import uuid
 import re
 
 import requests
-import six
 import psutil
 import pytest
 import pytz
@@ -54,7 +54,7 @@ except ImportError:  # pragma: NO COVER
     pyarrow = None
 try:
     import IPython
-    from IPython.utils import io
+    from IPython.utils import io as ipython_io
     from IPython.testing import tools
     from IPython.terminal import interactiveshell
 except ImportError:  # pragma: NO COVER
@@ -219,7 +219,7 @@ class TestBigQuery(unittest.TestCase):
 
         got = client.get_service_account_email()
 
-        self.assertIsInstance(got, six.text_type)
+        self.assertIsInstance(got, str)
         self.assertIn("@", got)
 
     def _create_bucket(self, bucket_name, location=None):
@@ -598,7 +598,7 @@ class TestBigQuery(unittest.TestCase):
     @staticmethod
     def _fetch_single_page(table, selected_fields=None):
         iterator = Config.CLIENT.list_rows(table, selected_fields=selected_fields)
-        page = six.next(iterator.pages)
+        page = next(iterator.pages)
         return list(page)
 
     def _create_table_many_columns(self, rowcount):
@@ -1415,7 +1415,7 @@ class TestBigQuery(unittest.TestCase):
         self._create_bucket(bucket_name, location="eu")
 
         # Create a temporary dataset & table in the EU.
-        table_bytes = six.BytesIO(b"a,3\nb,2\nc,1\n")
+        table_bytes = io.BytesIO(b"a,3\nb,2\nc,1\n")
         client = Config.CLIENT
         dataset = self.temp_dataset(_make_dataset_id("eu_load_file"), location="EU")
         table_ref = dataset.table("letters")
@@ -2444,7 +2444,7 @@ class TestBigQuery(unittest.TestCase):
         self.assertEqual(list(df), column_names)  # verify the column names
         exp_datatypes = {
             "id": int,
-            "author": six.text_type,
+            "author": str,
             "time_ts": pandas.Timestamp,
             "dead": bool,
         }
@@ -2477,7 +2477,7 @@ class TestBigQuery(unittest.TestCase):
         self.assertEqual(list(df), column_names)
         exp_datatypes = {
             "id": int,
-            "author": six.text_type,
+            "author": str,
             "time_ts": pandas.Timestamp,
             "dead": bool,
         }
@@ -2572,7 +2572,7 @@ class TestBigQuery(unittest.TestCase):
         assert len(row_tuples) == len(expected)
 
         for row, expected_row in zip(row_tuples, expected):
-            six.assertCountEqual(
+            self.assertCountEqual(
                 self, row, expected_row
             )  # column order does not matter
 
@@ -2780,7 +2780,7 @@ class TestBigQuery(unittest.TestCase):
             {"string_col": "Some value", "record_col": record, "float_col": 3.14}
         ]
         rows = [json.dumps(row) for row in to_insert]
-        body = six.BytesIO("{}\n".format("\n".join(rows)).encode("ascii"))
+        body = io.BytesIO("{}\n".format("\n".join(rows)).encode("ascii"))
         table_id = "test_table"
         dataset = self.temp_dataset(_make_dataset_id("nested_df"))
         table = dataset.table(table_id)
@@ -2858,7 +2858,7 @@ class TestBigQuery(unittest.TestCase):
             }
         ]
         rows = [json.dumps(row) for row in to_insert]
-        body = six.BytesIO("{}\n".format("\n".join(rows)).encode("ascii"))
+        body = io.BytesIO("{}\n".format("\n".join(rows)).encode("ascii"))
         table_id = "test_table"
         dataset = self.temp_dataset(_make_dataset_id("nested_df"))
         table = dataset.table(table_id)
@@ -2923,7 +2923,7 @@ class TestBigQuery(unittest.TestCase):
         schema = [SF("string_col", "STRING", mode="NULLABLE")]
         to_insert = [{"string_col": "item%d" % i} for i in range(num_items)]
         rows = [json.dumps(row) for row in to_insert]
-        body = six.BytesIO("{}\n".format("\n".join(rows)).encode("ascii"))
+        body = io.BytesIO("{}\n".format("\n".join(rows)).encode("ascii"))
 
         table_id = "test_table"
         dataset = self.temp_dataset(_make_dataset_id("nested_df"))
@@ -2997,7 +2997,7 @@ def test_bigquery_magic():
         ORDER BY view_count DESC
         LIMIT 10
     """
-    with io.capture_output() as captured:
+    with ipython_io.capture_output() as captured:
         result = ip.run_cell_magic("bigquery", "--use_rest_api", sql)
 
     conn_count_end = len(current_process.connections())

--- a/tests/unit/job/test_base.py
+++ b/tests/unit/job/test_base.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 import copy
+import http
 import unittest
 
 from google.api_core import exceptions
 import google.api_core.retry
 import mock
-from six.moves import http_client
 
 from .helpers import _make_client
 from .helpers import _make_connection
@@ -35,14 +35,14 @@ class Test__error_result_to_exception(unittest.TestCase):
     def test_simple(self):
         error_result = {"reason": "invalid", "message": "bad request"}
         exception = self._call_fut(error_result)
-        self.assertEqual(exception.code, http_client.BAD_REQUEST)
+        self.assertEqual(exception.code, http.client.BAD_REQUEST)
         self.assertTrue(exception.message.startswith("bad request"))
         self.assertIn(error_result, exception.errors)
 
     def test_missing_reason(self):
         error_result = {}
         exception = self._call_fut(error_result)
-        self.assertEqual(exception.code, http_client.INTERNAL_SERVER_ERROR)
+        self.assertEqual(exception.code, http.client.INTERNAL_SERVER_ERROR)
 
 
 class Test_JobReference(unittest.TestCase):

--- a/tests/unit/job/test_query.py
+++ b/tests/unit/job/test_query.py
@@ -14,6 +14,7 @@
 
 import concurrent
 import copy
+import http
 import textwrap
 
 import freezegun
@@ -21,7 +22,6 @@ from google.api_core import exceptions
 import google.api_core.retry
 import mock
 import requests
-from six.moves import http_client
 
 from google.cloud.bigquery.client import _LIST_ROWS_FROM_QUERY_RESULTS_FIELDS
 import google.cloud.bigquery.query
@@ -1210,7 +1210,7 @@ class TestQueryJob(_Base):
             job.result()
 
         self.assertIsInstance(exc_info.exception, exceptions.GoogleCloudError)
-        self.assertEqual(exc_info.exception.code, http_client.BAD_REQUEST)
+        self.assertEqual(exc_info.exception.code, http.client.BAD_REQUEST)
 
         exc_job_instance = getattr(exc_info.exception, "query_job", None)
         self.assertIs(exc_job_instance, job)
@@ -1265,7 +1265,7 @@ class TestQueryJob(_Base):
             job.result()
 
         self.assertIsInstance(exc_info.exception, exceptions.GoogleCloudError)
-        self.assertEqual(exc_info.exception.code, http_client.BAD_REQUEST)
+        self.assertEqual(exc_info.exception.code, http.client.BAD_REQUEST)
 
         exc_job_instance = getattr(exc_info.exception, "query_job", None)
         self.assertIs(exc_job_instance, job)

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -18,7 +18,6 @@ import decimal
 import unittest
 
 import mock
-import six
 
 
 class Test_not_null(unittest.TestCase):
@@ -894,7 +893,7 @@ class Test_record_field_to_json(unittest.TestCase):
         ]
         original = [42]
 
-        with six.assertRaisesRegex(self, ValueError, r".*not match schema length.*"):
+        with self.assertRaisesRegex(ValueError, r".*not match schema length.*"):
             self._call_fut(fields, original)
 
     def test_w_list_too_many_fields(self):
@@ -904,7 +903,7 @@ class Test_record_field_to_json(unittest.TestCase):
         ]
         original = [42, "two", "three"]
 
-        with six.assertRaisesRegex(self, ValueError, r".*not match schema length.*"):
+        with self.assertRaisesRegex(ValueError, r".*not match schema length.*"):
             self._call_fut(fields, original)
 
     def test_w_non_empty_dict(self):

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -35,8 +35,8 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
-        from six.moves.urllib.parse import parse_qsl
-        from six.moves.urllib.parse import urlsplit
+        from urllib.parse import parse_qsl
+        from urllib.parse import urlsplit
 
         conn = self._make_one(object())
         uri = conn.build_api_url("/foo")
@@ -49,8 +49,8 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(parms, {})
 
     def test_build_api_url_w_custom_endpoint(self):
-        from six.moves.urllib.parse import parse_qsl
-        from six.moves.urllib.parse import urlsplit
+        from urllib.parse import parse_qsl
+        from urllib.parse import urlsplit
 
         custom_endpoint = "https://foo-bigquery.googleapis.com"
         conn = self._make_one(object(), api_endpoint=custom_endpoint)
@@ -64,8 +64,8 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(parms, {})
 
     def test_build_api_url_w_extra_query_params(self):
-        from six.moves.urllib.parse import parse_qsl
-        from six.moves.urllib.parse import urlsplit
+        from urllib.parse import parse_qsl
+        from urllib.parse import urlsplit
 
         conn = self._make_one(object())
         uri = conn.build_api_url("/foo", {"bar": "baz"})

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -18,7 +18,9 @@ import datetime
 import decimal
 import email
 import gzip
+import http.client
 import io
+import itertools
 import json
 import operator
 import unittest
@@ -26,8 +28,6 @@ import warnings
 
 import mock
 import requests
-import six
-from six.moves import http_client
 import pytest
 import pytz
 import pkg_resources
@@ -474,7 +474,7 @@ class TestClient(unittest.TestCase):
         with mock.patch(
             "google.cloud.bigquery.opentelemetry_tracing._get_final_span_attributes"
         ) as final_attributes:
-            page = six.next(iterator.pages)
+            page = next(iterator.pages)
 
         final_attributes.assert_called_once_with({"path": "/projects"}, client, None)
         projects = list(page)
@@ -508,7 +508,7 @@ class TestClient(unittest.TestCase):
         with mock.patch(
             "google.cloud.bigquery.opentelemetry_tracing._get_final_span_attributes"
         ) as final_attributes:
-            six.next(iterator.pages)
+            next(iterator.pages)
 
         final_attributes.assert_called_once_with({"path": "/projects"}, client, None)
 
@@ -528,7 +528,7 @@ class TestClient(unittest.TestCase):
         with mock.patch(
             "google.cloud.bigquery.opentelemetry_tracing._get_final_span_attributes"
         ) as final_attributes:
-            page = six.next(iterator.pages)
+            page = next(iterator.pages)
 
         final_attributes.assert_called_once_with({"path": "/projects"}, client, None)
         projects = list(page)
@@ -582,7 +582,7 @@ class TestClient(unittest.TestCase):
         with mock.patch(
             "google.cloud.bigquery.opentelemetry_tracing._get_final_span_attributes"
         ) as final_attributes:
-            page = six.next(iterator.pages)
+            page = next(iterator.pages)
 
         final_attributes.assert_called_once_with({"path": "/%s" % PATH}, client, None)
         datasets = list(page)
@@ -635,7 +635,7 @@ class TestClient(unittest.TestCase):
         with mock.patch(
             "google.cloud.bigquery.opentelemetry_tracing._get_final_span_attributes"
         ) as final_attributes:
-            page = six.next(iterator.pages)
+            page = next(iterator.pages)
 
         final_attributes.assert_called_once_with({"path": "/%s" % PATH}, client, None)
         datasets = list(page)
@@ -2919,7 +2919,7 @@ class TestClient(unittest.TestCase):
         with mock.patch(
             "google.cloud.bigquery.opentelemetry_tracing._get_final_span_attributes"
         ) as final_attributes:
-            page = six.next(iterator.pages)
+            page = next(iterator.pages)
 
         final_attributes.assert_called_once_with({"path": path}, client, None)
         tables = list(page)
@@ -2942,7 +2942,7 @@ class TestClient(unittest.TestCase):
         with mock.patch(
             "google.cloud.bigquery.opentelemetry_tracing._get_final_span_attributes"
         ) as final_attributes:
-            page = six.next(iterator.pages)
+            page = next(iterator.pages)
 
         final_attributes.assert_called_once_with({"path": path}, client, None)
         models = list(page)
@@ -2991,7 +2991,7 @@ class TestClient(unittest.TestCase):
         with mock.patch(
             "google.cloud.bigquery.opentelemetry_tracing._get_final_span_attributes"
         ) as final_attributes:
-            page = six.next(iterator.pages)
+            page = next(iterator.pages)
 
         final_attributes.assert_called_once_with({"path": "/%s" % PATH}, client, None)
         models = list(page)
@@ -3022,7 +3022,7 @@ class TestClient(unittest.TestCase):
         with mock.patch(
             "google.cloud.bigquery.opentelemetry_tracing._get_final_span_attributes"
         ) as final_attributes:
-            page = six.next(iterator.pages)
+            page = next(iterator.pages)
 
         final_attributes.assert_called_once_with(
             {"path": "/projects/test-routines/datasets/test_routines/routines"},
@@ -3080,7 +3080,7 @@ class TestClient(unittest.TestCase):
         with mock.patch(
             "google.cloud.bigquery.opentelemetry_tracing._get_final_span_attributes"
         ) as final_attributes:
-            page = six.next(iterator.pages)
+            page = next(iterator.pages)
 
         final_attributes.assert_called_once_with({"path": path}, client, None)
         routines = list(page)
@@ -3149,7 +3149,7 @@ class TestClient(unittest.TestCase):
         with mock.patch(
             "google.cloud.bigquery.opentelemetry_tracing._get_final_span_attributes"
         ) as final_attributes:
-            page = six.next(iterator.pages)
+            page = next(iterator.pages)
 
         final_attributes.assert_called_once_with({"path": "/%s" % PATH}, client, None)
         tables = list(page)
@@ -3213,7 +3213,7 @@ class TestClient(unittest.TestCase):
         with mock.patch(
             "google.cloud.bigquery.opentelemetry_tracing._get_final_span_attributes"
         ) as final_attributes:
-            page = six.next(iterator.pages)
+            page = next(iterator.pages)
 
         final_attributes.assert_called_once_with({"path": "/%s" % PATH}, client, None)
         tables = list(page)
@@ -4040,7 +4040,7 @@ class TestClient(unittest.TestCase):
         with mock.patch(
             "google.cloud.bigquery.opentelemetry_tracing._get_final_span_attributes"
         ) as final_attributes:
-            page = six.next(iterator.pages)
+            page = next(iterator.pages)
 
         final_attributes.assert_called_once_with({"path": "/%s" % PATH}, client, None)
         jobs = list(page)
@@ -4090,7 +4090,7 @@ class TestClient(unittest.TestCase):
         with mock.patch(
             "google.cloud.bigquery.opentelemetry_tracing._get_final_span_attributes"
         ) as final_attributes:
-            page = six.next(iterator.pages)
+            page = next(iterator.pages)
 
         final_attributes.assert_called_once_with({"path": "/%s" % PATH}, client, None)
         jobs = list(page)
@@ -4124,7 +4124,7 @@ class TestClient(unittest.TestCase):
         with mock.patch(
             "google.cloud.bigquery.opentelemetry_tracing._get_final_span_attributes"
         ) as final_attributes:
-            page = six.next(iterator.pages)
+            page = next(iterator.pages)
 
         final_attributes.assert_called_once_with({"path": "/%s" % PATH}, client, None)
         jobs = list(page)
@@ -4412,7 +4412,7 @@ class TestClient(unittest.TestCase):
         # Create mocks to be checked for doing transport.
         resumable_url = "http://test.invalid?upload_id=hey-you"
         response_headers = {"location": resumable_url}
-        fake_transport = self._mock_transport(http_client.OK, response_headers)
+        fake_transport = self._mock_transport(http.client.OK, response_headers)
         client = self._make_one(project=self.PROJECT, _http=fake_transport)
         conn = client._connection = make_connection()
 
@@ -4479,7 +4479,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.bigquery.job import LoadJobConfig
         from google.cloud.bigquery.job import SourceFormat
 
-        fake_transport = self._mock_transport(http_client.OK, {})
+        fake_transport = self._mock_transport(http.client.OK, {})
         client = self._make_one(project=self.PROJECT, _http=fake_transport)
         conn = client._connection = make_connection()
 
@@ -5022,7 +5022,7 @@ class TestClient(unittest.TestCase):
         _, req = conn.api_request.call_args
         self.assertEqual(req["method"], "POST")
         self.assertEqual(req["path"], "/projects/PROJECT/jobs")
-        self.assertIsInstance(req["data"]["jobReference"]["jobId"], six.string_types)
+        self.assertIsInstance(req["data"]["jobReference"]["jobId"], str)
         self.assertIsNone(req["timeout"])
 
         # Check the job resource.
@@ -5227,7 +5227,7 @@ class TestClient(unittest.TestCase):
         job = client.query(QUERY)
 
         self.assertIsInstance(job, QueryJob)
-        self.assertIsInstance(job.job_id, six.string_types)
+        self.assertIsInstance(job.job_id, str)
         self.assertIs(job._client, client)
         self.assertEqual(job.query, QUERY)
         self.assertEqual(job.udf_resources, [])
@@ -5240,7 +5240,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req["path"], "/projects/PROJECT/jobs")
         self.assertIsNone(req["timeout"])
         sent = req["data"]
-        self.assertIsInstance(sent["jobReference"]["jobId"], six.string_types)
+        self.assertIsInstance(sent["jobReference"]["jobId"], str)
         sent_config = sent["configuration"]["query"]
         self.assertEqual(sent_config["query"], QUERY)
         self.assertFalse(sent_config["useLegacySql"])
@@ -5687,7 +5687,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req["path"], "/projects/PROJECT/jobs")
         self.assertIsNone(req["timeout"])
         sent = req["data"]
-        self.assertIsInstance(sent["jobReference"]["jobId"], six.string_types)
+        self.assertIsInstance(sent["jobReference"]["jobId"], str)
         sent_config = sent["configuration"]["query"]
         self.assertEqual(sent_config["query"], QUERY)
         self.assertTrue(sent_config["useLegacySql"])
@@ -6398,7 +6398,7 @@ class TestClient(unittest.TestCase):
 
         actual_calls = conn.api_request.call_args_list
 
-        for call, expected_data in six.moves.zip_longest(
+        for call, expected_data in itertools.zip_longest(
             actual_calls, EXPECTED_SENT_DATA
         ):
             expected_call = mock.call(
@@ -6466,7 +6466,7 @@ class TestClient(unittest.TestCase):
 
         actual_calls = conn.api_request.call_args_list
 
-        for call, expected_data in six.moves.zip_longest(
+        for call, expected_data in itertools.zip_longest(
             actual_calls, EXPECTED_SENT_DATA
         ):
             expected_call = mock.call(
@@ -6776,7 +6776,7 @@ class TestClient(unittest.TestCase):
 
         # Check that initial total_rows is populated from the table.
         self.assertEqual(iterator.total_rows, 7)
-        page = six.next(iterator.pages)
+        page = next(iterator.pages)
         rows = list(page)
 
         # Check that total_rows is updated based on API response.
@@ -6831,14 +6831,14 @@ class TestClient(unittest.TestCase):
         table = Table(self.TABLE_REF, schema=[full_name])
         iterator = client.list_rows(table, max_results=4, page_size=2, start_index=1)
         pages = iterator.pages
-        rows = list(six.next(pages))
+        rows = list(next(pages))
         extra_params = iterator.extra_params
         f2i = {"full_name": 0}
         self.assertEqual(len(rows), 2)
         self.assertEqual(rows[0], Row(("Phred Phlyntstone",), f2i))
         self.assertEqual(rows[1], Row(("Bharney Rhubble",), f2i))
 
-        rows = list(six.next(pages))
+        rows = list(next(pages))
 
         self.assertEqual(len(rows), 2)
         self.assertEqual(rows[0], Row(("Wylma Phlyntstone",), f2i))
@@ -6915,7 +6915,7 @@ class TestClient(unittest.TestCase):
         conn = client._connection = make_connection(*len(tests) * [{}])
         for i, test in enumerate(tests):
             iterator = client.list_rows(table, **test[0])
-            six.next(iterator.pages)
+            next(iterator.pages)
             req = conn.api_request.call_args_list[i]
             test[1]["formatOptions.useInt64Timestamp"] = True
             self.assertEqual(req[1]["query_params"], test[1], "for kwargs %s" % test[0])
@@ -7000,7 +7000,7 @@ class TestClient(unittest.TestCase):
         struct = SchemaField("struct", "RECORD", mode="REPEATED", fields=[index, score])
 
         iterator = client.list_rows(self.TABLE_REF, selected_fields=[color, struct])
-        page = six.next(iterator.pages)
+        page = next(iterator.pages)
         rows = list(page)
         total_rows = iterator.total_rows
         page_token = iterator.next_page_token
@@ -7065,7 +7065,7 @@ class TestClient(unittest.TestCase):
         table = Table(self.TABLE_REF, schema=[full_name, phone])
 
         iterator = client.list_rows(table)
-        page = six.next(iterator.pages)
+        page = next(iterator.pages)
         rows = list(page)
         total_rows = iterator.total_rows
         page_token = iterator.next_page_token
@@ -7241,7 +7241,7 @@ class TestClientUpload(object):
         if side_effect is None:
             side_effect = [
                 cls._make_response(
-                    http_client.OK,
+                    http.client.OK,
                     json.dumps(resource),
                     {"Content-Type": "application/json"},
                 )
@@ -7522,7 +7522,7 @@ class TestClientUpload(object):
         file_obj = self._make_file_obj()
 
         response = self._make_response(
-            content="Someone is already in this spot.", status_code=http_client.CONFLICT
+            content="Someone is already in this spot.", status_code=http.client.CONFLICT
         )
 
         do_upload_patch = self._make_do_upload_patch(
@@ -8584,7 +8584,7 @@ class TestClientUpload(object):
 
         resumable_url = "http://test.invalid?upload_id=and-then-there-was-1"
         initial_response = cls._make_response(
-            http_client.OK, "", {"location": resumable_url}
+            http.client.OK, "", {"location": resumable_url}
         )
         data_response = cls._make_response(
             resumable_media.PERMANENT_REDIRECT,
@@ -8592,7 +8592,7 @@ class TestClientUpload(object):
             {"range": "bytes=0-{:d}".format(size - 1)},
         )
         final_response = cls._make_response(
-            http_client.OK,
+            http.client.OK,
             json.dumps({"size": size}),
             {"Content-Type": "application/json"},
         )
@@ -8634,7 +8634,7 @@ class TestClientUpload(object):
         )
 
     def test__do_multipart_upload(self):
-        transport = self._make_transport([self._make_response(http_client.OK)])
+        transport = self._make_transport([self._make_response(http.client.OK)])
         client = self._make_client(transport)
         file_obj = self._make_file_obj()
         file_obj_len = len(file_obj.getvalue())

--- a/tests/unit/test_dbapi__helpers.py
+++ b/tests/unit/test_dbapi__helpers.py
@@ -23,8 +23,6 @@ try:
 except ImportError:  # pragma: NO COVER
     pyarrow = None
 
-import six
-
 import google.cloud._helpers
 from google.cloud.bigquery import table
 from google.cloud.bigquery.dbapi import _helpers
@@ -293,7 +291,7 @@ class TestRaiseOnClosedDecorator(unittest.TestCase):
         instance = decorated_class()
         instance._closed = True
 
-        with six.assertRaisesRegex(self, exceptions.ProgrammingError, "I'm closed!"):
+        with self.assertRaisesRegex(exceptions.ProgrammingError, "I'm closed!"):
             instance.instance_method()
 
     def test_methods_wo_public_instance_methods_on_closed_instance(self):
@@ -316,7 +314,7 @@ class TestRaiseOnClosedDecorator(unittest.TestCase):
         instance._closed = False
         instance._really_closed = True
 
-        with six.assertRaisesRegex(self, exceptions.ProgrammingError, "I'm closed!"):
+        with self.assertRaisesRegex(exceptions.ProgrammingError, "I'm closed!"):
             instance.instance_method()
 
     def test_custom_on_closed_error_type(self):
@@ -327,5 +325,5 @@ class TestRaiseOnClosedDecorator(unittest.TestCase):
         instance = decorated_class()
         instance._closed = True
 
-        with six.assertRaisesRegex(self, RuntimeError, "I'm closed!"):
+        with self.assertRaisesRegex(RuntimeError, "I'm closed!"):
             instance.instance_method()

--- a/tests/unit/test_dbapi_connection.py
+++ b/tests/unit/test_dbapi_connection.py
@@ -16,7 +16,6 @@ import gc
 import unittest
 
 import mock
-import six
 
 try:
     from google.cloud import bigquery_storage
@@ -124,8 +123,8 @@ class TestConnection(unittest.TestCase):
         connection.close()
 
         for method in ("close", "commit", "cursor"):
-            with six.assertRaisesRegex(
-                self, ProgrammingError, r"Operating on a closed connection\."
+            with self.assertRaisesRegex(
+                ProgrammingError, r"Operating on a closed connection\."
             ):
                 getattr(connection, method)()
 

--- a/tests/unit/test_dbapi_cursor.py
+++ b/tests/unit/test_dbapi_cursor.py
@@ -16,7 +16,6 @@ import operator as op
 import unittest
 
 import mock
-import six
 
 try:
     import pyarrow
@@ -181,8 +180,8 @@ class TestCursor(unittest.TestCase):
         )
 
         for method in method_names:
-            with six.assertRaisesRegex(
-                self, ProgrammingError, r"Operating on a closed cursor\."
+            with self.assertRaisesRegex(
+                ProgrammingError, r"Operating on a closed cursor\."
             ):
                 getattr(cursor, method)()
 
@@ -375,7 +374,7 @@ class TestCursor(unittest.TestCase):
         cursor = connection.cursor()
         cursor.execute("SELECT foo, bar FROM some_table")
 
-        with six.assertRaisesRegex(self, exceptions.Forbidden, "invalid credentials"):
+        with self.assertRaisesRegex(exceptions.Forbidden, "invalid credentials"):
             cursor.fetchall()
 
         # the default client was not used

--- a/tests/unit/test_opentelemetry_tracing.py
+++ b/tests/unit/test_opentelemetry_tracing.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+import importlib
 import sys
 
 import mock
@@ -28,7 +29,6 @@ try:
 except ImportError:  # pragma: NO COVER
     opentelemetry = None
 import pytest
-from six.moves import reload_module
 
 from google.cloud.bigquery import opentelemetry_tracing
 
@@ -39,7 +39,7 @@ TEST_SPAN_ATTRIBUTES = {"foo": "baz"}
 @pytest.mark.skipif(opentelemetry is None, reason="Require `opentelemetry`")
 @pytest.fixture
 def setup():
-    reload_module(opentelemetry_tracing)
+    importlib.reload(opentelemetry_tracing)
     tracer_provider = TracerProvider()
     memory_exporter = InMemorySpanExporter()
     span_processor = SimpleExportSpanProcessor(memory_exporter)
@@ -51,7 +51,7 @@ def setup():
 @pytest.mark.skipif(opentelemetry is None, reason="Require `opentelemetry`")
 def test_opentelemetry_not_installed(setup, monkeypatch):
     monkeypatch.setitem(sys.modules, "opentelemetry", None)
-    reload_module(opentelemetry_tracing)
+    importlib.reload(opentelemetry_tracing)
     with opentelemetry_tracing.create_span("No-op for opentelemetry") as span:
         assert span is None
 

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -22,7 +22,6 @@ import mock
 import pkg_resources
 import pytest
 import pytz
-import six
 
 import google.api_core.exceptions
 
@@ -1674,16 +1673,16 @@ class TestRowIterator(unittest.TestCase):
 
         rows_iter = iter(row_iterator)
 
-        val1 = six.next(rows_iter)
+        val1 = next(rows_iter)
         self.assertEqual(val1.name, "Phred Phlyntstone")
         self.assertEqual(row_iterator.num_results, 1)
 
-        val2 = six.next(rows_iter)
+        val2 = next(rows_iter)
         self.assertEqual(val2.name, "Bharney Rhubble")
         self.assertEqual(row_iterator.num_results, 2)
 
         with self.assertRaises(StopIteration):
-            six.next(rows_iter)
+            next(rows_iter)
 
         api_request.assert_called_once_with(method="GET", path=path, query_params={})
 
@@ -2437,13 +2436,6 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(df.name.dtype.name, "object")
         self.assertEqual(df.age.dtype.name, "int64")
 
-    @pytest.mark.xfail(
-        six.PY2,
-        reason=(
-            "Requires pyarrow>-1.0 to work, but the latter is not compatible "
-            "with Python 2 anymore."
-        ),
-    )
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_dataframe_timestamp_out_of_pyarrow_bounds(self):
@@ -2475,13 +2467,6 @@ class TestRowIterator(unittest.TestCase):
             ],
         )
 
-    @pytest.mark.xfail(
-        six.PY2,
-        reason=(
-            "Requires pyarrow>-1.0 to work, but the latter is not compatible "
-            "with Python 2 anymore."
-        ),
-    )
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_dataframe_datetime_out_of_pyarrow_bounds(self):
@@ -2697,7 +2682,7 @@ class TestRowIterator(unittest.TestCase):
             else:
                 self.assertIsInstance(row.start_timestamp, pandas.Timestamp)
                 self.assertIsInstance(row.seconds, float)
-                self.assertIsInstance(row.payment_type, six.string_types)
+                self.assertIsInstance(row.payment_type, str)
                 self.assertIsInstance(row.complete, bool)
                 self.assertIsInstance(row.date, datetime.date)
 
@@ -3542,7 +3527,7 @@ class TestPartitionRange(unittest.TestCase):
     def test_unhashable_object(self):
         object_under_test1 = self._make_one(start=1, end=10, interval=2)
 
-        with six.assertRaisesRegex(self, TypeError, r".*unhashable type.*"):
+        with self.assertRaisesRegex(TypeError, r".*unhashable type.*"):
             hash(object_under_test1)
 
     def test_repr(self):
@@ -3642,7 +3627,7 @@ class TestRangePartitioning(unittest.TestCase):
         object_under_test1 = self._make_one(
             range_=PartitionRange(start=1, end=10, interval=2), field="integer_col"
         )
-        with six.assertRaisesRegex(self, TypeError, r".*unhashable type.*"):
+        with self.assertRaisesRegex(TypeError, r".*unhashable type.*"):
             hash(object_under_test1)
 
     def test_repr(self):


### PR DESCRIPTION
Closes #460.

This PR gets rid of `six` that we don't need anymore after dropping Python 2 support.

PR checklist:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


