### PR TITLE
chore: Bound maximum supported Python version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ dependencies.
 
 Supported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-Python >= 3.6
+Python >= 3.6, < 3.9
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ dependencies = [
     "proto-plus >= 1.10.0",
     "google-cloud-core >= 1.4.1, < 2.0dev",
     "google-resumable-media >= 0.6.0, < 2.0dev",
-    "six >=1.13.0,< 2.0.0dev",
     "protobuf >= 3.12.0",
 ]
 extras = {
@@ -121,7 +120,7 @@ setuptools.setup(
     namespace_packages=namespaces,
     install_requires=dependencies,
     extras_require=extras,
-    python_requires=">=3.6",
+    python_requires=">=3.6, <3.9",
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
Closes #464.

Bounding the Python versions gives a much more clear error message on installation attempts, as opposed to compile errors when trying to install `pyarrow` from source (pulls in the `numpy==1.16.0` dependency which fails to compile).
