### PR TITLE
fix: reading the labels attribute on Job instances

### DIFF
--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -233,7 +233,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
     @property
     def labels(self):
         """Dict[str, str]: Labels for the job."""
-        return self._properties.setdefault("labels", {})
+        return self._properties.setdefault("configuration", {}).setdefault("labels", {})
 
     @property
     def etag(self):
@@ -671,9 +671,8 @@ class _JobConfig(object):
     def labels(self):
         """Dict[str, str]: Labels for the job.
 
-        This method always returns a dict. To change a job's labels,
-        modify the dict, then call ``Client.update_job``. To delete a
-        label, set its value to :data:`None` before updating.
+        This method always returns a dict. Once a job has been created on the
+        server, its labels cannot be modified anymore.
 
         Raises:
             ValueError: If ``value`` type is invalid.

--- a/tests/system.py
+++ b/tests/system.py
@@ -1667,6 +1667,23 @@ class TestBigQuery(unittest.TestCase):
         # raise an error, and that the job completed (in the `retry()`
         # above).
 
+    def test_job_labels(self):
+        DATASET_ID = _make_dataset_id("job_cancel")
+        JOB_ID_PREFIX = "fetch_" + DATASET_ID
+        QUERY = "SELECT 1 as one"
+
+        self.temp_dataset(DATASET_ID)
+
+        job_config = bigquery.QueryJobConfig(
+            labels={"custom_label": "label_value", "another_label": "foo123"}
+        )
+        job = Config.CLIENT.query(
+            QUERY, job_id_prefix=JOB_ID_PREFIX, job_config=job_config
+        )
+
+        expected_labels = {"custom_label": "label_value", "another_label": "foo123"}
+        self.assertEqual(job.labels, expected_labels)
+
     def test_get_failed_job(self):
         # issue 4246
         from google.api_core.exceptions import BadRequest

--- a/tests/unit/job/test_base.py
+++ b/tests/unit/job/test_base.py
@@ -251,7 +251,7 @@ class Test_AsyncJob(unittest.TestCase):
         labels = {"foo": "bar"}
         client = _make_client(project=self.PROJECT)
         job = self._make_one(self.JOB_ID, client)
-        job._properties["labels"] = labels
+        job._properties.setdefault("configuration", {})["labels"] = labels
         self.assertEqual(job.labels, labels)
 
     def test_etag(self):


### PR DESCRIPTION
Fixes #469.

This PR fixes reading the labels on Job instances and adds a system test that would have caught this bug.

PR checklist:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
