### PR TITLE
deps: declare support for Python 3.9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ dependencies.
 
 Supported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-Python >= 3.6, < 3.9
+Python >= 3.6, < 3.10
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,6 +23,10 @@ import nox
 
 BLACK_VERSION = "black==19.10b0"
 BLACK_PATHS = ("docs", "google", "samples", "tests", "noxfile.py", "setup.py")
+
+DEFAULT_PYTHON_VERSION = "3.8"
+SYSTEM_TEST_PYTHON_VERSIONS = ["3.8"]
+UNIT_TEST_PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9"]
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 # 'docfx' is excluded since it only needs to run in 'docs-presubmit'
@@ -80,13 +84,13 @@ def default(session):
     )
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
+@nox.session(python=UNIT_TEST_PYTHON_VERSIONS)
 def unit(session):
     """Run the unit test suite."""
     default(session)
 
 
-@nox.session(python=["3.9"])
+@nox.session(python=SYSTEM_TEST_PYTHON_VERSIONS)
 def system(session):
     """Run the system test suite."""
 
@@ -118,7 +122,7 @@ def system(session):
     session.run("py.test", "--quiet", os.path.join("tests", "system"), *session.posargs)
 
 
-@nox.session(python=["3.8"])
+@nox.session(python=SYSTEM_TEST_PYTHON_VERSIONS)
 def snippets(session):
     """Run the snippets test suite."""
 
@@ -154,7 +158,7 @@ def snippets(session):
     )
 
 
-@nox.session(python="3.9")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def cover(session):
     """Run the final coverage report.
 
@@ -166,7 +170,7 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python="3.9")
+@nox.session(python=SYSTEM_TEST_PYTHON_VERSIONS)
 def prerelease_deps(session):
     """Run all tests with prerelease versions of dependencies installed.
 
@@ -201,7 +205,7 @@ def prerelease_deps(session):
     session.run("py.test", "samples/tests")
 
 
-@nox.session(python="3.9")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def lint(session):
     """Run linters.
 
@@ -218,7 +222,7 @@ def lint(session):
     session.run("black", "--check", *BLACK_PATHS)
 
 
-@nox.session(python="3.9")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
 
@@ -239,7 +243,7 @@ def blacken(session):
     session.run("black", *BLACK_PATHS)
 
 
-@nox.session(python="3.9")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def docs(session):
     """Build the docs."""
 
@@ -262,7 +266,7 @@ def docs(session):
     )
 
 
-@nox.session(python="3.9")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def docfx(session):
     """Build the docfx yaml files for this library."""
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -80,13 +80,13 @@ def default(session):
     )
 
 
-@nox.session(python=["3.6", "3.7", "3.8"])
+@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
 def unit(session):
     """Run the unit test suite."""
     default(session)
 
 
-@nox.session(python=["3.8"])
+@nox.session(python=["3.9"])
 def system(session):
     """Run the system test suite."""
 
@@ -154,7 +154,7 @@ def snippets(session):
     )
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.9")
 def cover(session):
     """Run the final coverage report.
 
@@ -166,7 +166,7 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.9")
 def prerelease_deps(session):
     """Run all tests with prerelease versions of dependencies installed.
 
@@ -201,7 +201,7 @@ def prerelease_deps(session):
     session.run("py.test", "samples/tests")
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.9")
 def lint(session):
     """Run linters.
 
@@ -218,7 +218,7 @@ def lint(session):
     session.run("black", "--check", *BLACK_PATHS)
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.9")
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
 
@@ -239,7 +239,7 @@ def blacken(session):
     session.run("black", *BLACK_PATHS)
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.9")
 def docs(session):
     """Build the docs."""
 
@@ -262,7 +262,7 @@ def docs(session):
     )
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.9")
 def docfx(session):
     """Build the docfx yaml files for this library."""
 

--- a/setup.py
+++ b/setup.py
@@ -45,12 +45,11 @@ extras = {
         # grpc.Channel.close() method isn't added until 1.32.0.
         # https://github.com/grpc/grpc/pull/15254
         "grpcio >= 1.32.0, < 2.0dev",
-        "pyarrow >= 1.0.0, < 3.0dev",
+        "pyarrow >= 3.0.0, < 4.0dev",
     ],
     "pandas": [
         "pandas>=0.23.0",
-        # pyarrow 1.0.0 is required for the use of timestamp_as_object keyword.
-        "pyarrow >= 1.0.0, < 3.0dev",
+        "pyarrow >= 3.0.0, < 4.0dev",
     ],
     "tqdm": ["tqdm >= 4.7.4, <5.0.0dev"],
     "opentelemetry": [
@@ -112,6 +111,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Operating System :: OS Independent",
         "Topic :: Internet",
     ],
@@ -120,7 +120,7 @@ setuptools.setup(
     namespace_packages=namespaces,
     install_requires=dependencies,
     extras_require=extras,
-    python_requires=">=3.6, <3.9",
+    python_requires=">=3.6, <3.10",
     include_package_data=True,
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -45,11 +45,11 @@ extras = {
         # grpc.Channel.close() method isn't added until 1.32.0.
         # https://github.com/grpc/grpc/pull/15254
         "grpcio >= 1.32.0, < 2.0dev",
-        "pyarrow >= 3.0.0, < 4.0dev",
+        "pyarrow >= 1.0.0, < 4.0dev",
     ],
     "pandas": [
         "pandas>=0.23.0",
-        "pyarrow >= 3.0.0, < 4.0dev",
+        "pyarrow >= 1.0.0, < 4.0dev",
     ],
     "tqdm": ["tqdm >= 4.7.4, <5.0.0dev"],
     "opentelemetry": [

--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,7 @@ extras = {
         "grpcio >= 1.32.0, < 2.0dev",
         "pyarrow >= 1.0.0, < 4.0dev",
     ],
-    "pandas": [
-        "pandas>=0.23.0",
-        "pyarrow >= 1.0.0, < 4.0dev",
-    ],
+    "pandas": ["pandas>=0.23.0", "pyarrow >= 1.0.0, < 4.0dev",],
     "tqdm": ["tqdm >= 4.7.4, <5.0.0dev"],
     "opentelemetry": [
         "opentelemetry-api==0.11b0",

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -6,26 +6,16 @@
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
 google-api-core==1.23.0
-proto-plus==1.10.0
+google-cloud-bigquery-storage==2.0.0
 google-cloud-core==1.4.1
 google-resumable-media==0.6.0
-six==1.13.0
+grpcio==1.32.0
+opentelemetry-api==0.11b0
+opentelemetry-instrumentation==0.11b0
+opentelemetry-sdk==0.11b0
+pandas==0.23.0
+proto-plus==1.10.0
 protobuf==3.12.0
-google-cloud-bigquery-storage==2.0.0
-grpcio==1.32.0
 pyarrow==1.0.0
-pandas==0.23.0
-pyarrow==1.0.0
-tqdm==4.7.4
-opentelemetry-api==0.11b0
-opentelemetry-sdk==0.11b0
-opentelemetry-instrumentation==0.11b0
-google-cloud-bigquery-storage==2.0.0
-grpcio==1.32.0
-pyarrow==1.0.0
-opentelemetry-api==0.11b0
-opentelemetry-sdk==0.11b0
-opentelemetry-instrumentation==0.11b0
-pandas==0.23.0
-pyarrow==3.0.0
+six==1.13.0
 tqdm==4.7.4

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -27,5 +27,5 @@ opentelemetry-api==0.11b0
 opentelemetry-sdk==0.11b0
 opentelemetry-instrumentation==0.11b0
 pandas==0.23.0
-pyarrow==1.0.0
+pyarrow==3.0.0
 tqdm==4.7.4


### PR DESCRIPTION
Towards #462.

With wheels for `pyarrow==3.0.0` released we can now officially support Python 3.9 - well, at least after when we add Python 3.9 checks to Kokoro.

PR checklist:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
