### PR TITLE
feat: add mtls feature

### DIFF
--- a/google/cloud/bigquery/_http.py
+++ b/google/cloud/bigquery/_http.py
@@ -22,6 +22,9 @@ from google.cloud import _http
 from google.cloud.bigquery import __version__
 
 
+# TODO: Increase the minimum version of google-cloud-core to 1.6.0
+# and remove this logic. See:
+# https://github.com/googleapis/python-bigquery/issues/509
 if os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE") == "true":  # pragma: NO COVER
     release = pkg_resources.get_distribution("google-cloud-core").parsed_version
     if release < pkg_resources.parse_version("1.6.0"):

--- a/google/cloud/bigquery/_http.py
+++ b/google/cloud/bigquery/_http.py
@@ -14,9 +14,18 @@
 
 """Create / interact with Google BigQuery connections."""
 
+import os
+import pkg_resources
+
 from google.cloud import _http
 
 from google.cloud.bigquery import __version__
+
+
+if os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE") == "true":  # pragma: NO COVER
+    release = pkg_resources.get_distribution("google-cloud-core").parsed_version
+    if release < pkg_resources.parse_version("1.6.0"):
+        raise ImportError("google-cloud-core >= 1.6.0 is required to use mTLS feature")
 
 
 class Connection(_http.JSONConnection):

--- a/google/cloud/bigquery/_http.py
+++ b/google/cloud/bigquery/_http.py
@@ -26,13 +26,18 @@ class Connection(_http.JSONConnection):
         client (google.cloud.bigquery.client.Client): The client that owns the current connection.
 
         client_info (Optional[google.api_core.client_info.ClientInfo]): Instance used to generate user agent.
+
+        api_endpoint (str): The api_endpoint to use. If None, the library will decide what endpoint to use.
     """
 
     DEFAULT_API_ENDPOINT = "https://bigquery.googleapis.com"
+    DEFAULT_API_MTLS_ENDPOINT = "https://bigquery.mtls.googleapis.com"
 
-    def __init__(self, client, client_info=None, api_endpoint=DEFAULT_API_ENDPOINT):
+    def __init__(self, client, client_info=None, api_endpoint=None):
         super(Connection, self).__init__(client, client_info)
-        self.API_BASE_URL = api_endpoint
+        self.API_BASE_URL = api_endpoint or self.DEFAULT_API_ENDPOINT
+        self.API_BASE_MTLS_URL = self.DEFAULT_API_MTLS_ENDPOINT
+        self.ALLOW_AUTO_SWITCH_TO_MTLS_URL = api_endpoint is None
         self._client_info.gapic_version = __version__
         self._client_info.client_library_version = __version__
 

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -2544,6 +2544,9 @@ class Client(ClientWithProject):
 
         if project is None:
             project = self.project
+        # TODO: Increase the minimum version of google-cloud-core to 1.6.0
+        # and remove this logic. See:
+        # https://github.com/googleapis/python-bigquery/issues/509
         hostname = (
             self._connection.API_BASE_URL
             if not hasattr(self._connection, "get_api_base_url_for_mtls")

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -2621,6 +2621,9 @@ class Client(ClientWithProject):
         if project is None:
             project = self.project
 
+        # TODO: Increase the minimum version of google-cloud-core to 1.6.0
+        # and remove this logic. See:
+        # https://github.com/googleapis/python-bigquery/issues/509
         hostname = (
             self._connection.API_BASE_URL
             if not hasattr(self._connection, "get_api_base_url_for_mtls")

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -78,10 +78,7 @@ from google.cloud.bigquery.table import RowIterator
 _DEFAULT_CHUNKSIZE = 1048576  # 1024 * 1024 B = 1 MB
 _MAX_MULTIPART_SIZE = 5 * 1024 * 1024
 _DEFAULT_NUM_RETRIES = 6
-_BASE_UPLOAD_TEMPLATE = (
-    "https://bigquery.googleapis.com/upload/bigquery/v2/projects/"
-    "{project}/jobs?uploadType="
-)
+_BASE_UPLOAD_TEMPLATE = "{host}/upload/bigquery/v2/projects/{project}/jobs?uploadType="
 _MULTIPART_URL_TEMPLATE = _BASE_UPLOAD_TEMPLATE + "multipart"
 _RESUMABLE_URL_TEMPLATE = _BASE_UPLOAD_TEMPLATE + "resumable"
 _GENERIC_CONTENT_TYPE = "*/*"
@@ -2547,7 +2544,12 @@ class Client(ClientWithProject):
 
         if project is None:
             project = self.project
-        upload_url = _RESUMABLE_URL_TEMPLATE.format(project=project)
+        hostname = (
+            self._connection.API_BASE_URL
+            if not hasattr(self._connection, "get_api_base_url_for_mtls")
+            else self._connection.get_api_base_url_for_mtls()
+        )
+        upload_url = _RESUMABLE_URL_TEMPLATE.format(host=hostname, project=project)
 
         # TODO: modify ResumableUpload to take a retry.Retry object
         # that it can use for the initial RPC.
@@ -2616,7 +2618,12 @@ class Client(ClientWithProject):
         if project is None:
             project = self.project
 
-        upload_url = _MULTIPART_URL_TEMPLATE.format(project=project)
+        hostname = (
+            self._connection.API_BASE_URL
+            if not hasattr(self._connection, "get_api_base_url_for_mtls")
+            else self._connection.get_api_base_url_for_mtls()
+        )
+        upload_url = _MULTIPART_URL_TEMPLATE.format(host=hostname, project=project)
         upload = MultipartUpload(upload_url, headers=headers)
 
         if num_retries is not None:

--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -28,6 +28,7 @@ import unittest
 import uuid
 
 import psutil
+import pytest
 import pytz
 import pkg_resources
 
@@ -131,6 +132,8 @@ if pyarrow:
     PYARROW_INSTALLED_VERSION = pkg_resources.get_distribution("pyarrow").parsed_version
 else:
     PYARROW_INSTALLED_VERSION = None
+
+MTLS_TESTING = os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE") == "true"
 
 
 def _has_rows(result):
@@ -2651,6 +2654,9 @@ class TestBigQuery(unittest.TestCase):
         expected_rows = [("Some value", record)]
         self.assertEqual(row_tuples, expected_rows)
 
+    @pytest.mark.skipif(
+        MTLS_TESTING, reason="mTLS testing has no permission to the max-value.js file"
+    )
     def test_create_routine(self):
         routine_name = "test_routine"
         dataset = self.temp_dataset(_make_dataset_id("create_routine"))

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -21,6 +21,7 @@ def make_connection(*responses):
     mock_conn = mock.create_autospec(google.cloud.bigquery._http.Connection)
     mock_conn.user_agent = "testing 1.2.3"
     mock_conn.api_request.side_effect = list(responses) + [NotFound("miss")]
+    mock_conn.API_BASE_URL = "https://bigquery.googleapis.com"
     return mock_conn
 
 

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -22,6 +22,7 @@ def make_connection(*responses):
     mock_conn.user_agent = "testing 1.2.3"
     mock_conn.api_request.side_effect = list(responses) + [NotFound("miss")]
     mock_conn.API_BASE_URL = "https://bigquery.googleapis.com"
+    mock_conn.get_api_base_url_for_mtls = mock.Mock(return_value=mock_conn.API_BASE_URL)
     return mock_conn
 
 

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -33,7 +33,7 @@ class TestConnection(unittest.TestCase):
 
     def _make_one(self, *args, **kw):
         if "api_endpoint" not in kw:
-            kw["api_endpoint"] = "https://storage.googleapis.com"
+            kw["api_endpoint"] = "https://bigquery.googleapis.com"
 
         return self._get_target_class()(*args, **kw)
 

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -32,6 +32,9 @@ class TestConnection(unittest.TestCase):
         return Connection
 
     def _make_one(self, *args, **kw):
+        if "api_endpoint" not in kw:
+            kw["api_endpoint"] = "https://storage.googleapis.com"
+
         return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
@@ -138,3 +141,14 @@ class TestConnection(unittest.TestCase):
             url=expected_uri,
             timeout=self._get_default_timeout(),
         )
+
+    def test_ctor_mtls(self):
+        conn = self._make_one(object(), api_endpoint=None)
+        self.assertEqual(conn.ALLOW_AUTO_SWITCH_TO_MTLS_URL, True)
+        self.assertEqual(conn.API_BASE_URL, "https://bigquery.googleapis.com")
+        self.assertEqual(conn.API_BASE_MTLS_URL, "https://bigquery.mtls.googleapis.com")
+
+        conn = self._make_one(object(), api_endpoint="http://foo")
+        self.assertEqual(conn.ALLOW_AUTO_SWITCH_TO_MTLS_URL, False)
+        self.assertEqual(conn.API_BASE_URL, "http://foo")
+        self.assertEqual(conn.API_BASE_MTLS_URL, "https://bigquery.mtls.googleapis.com")


### PR DESCRIPTION
https://google.aip.dev/auth/4114
googlers see [this doc](go/mtls-python-cloud-core-clients) for more details.

Part of the mtls feature is implemented in https://github.com/googleapis/python-cloud-core/pull/75, and will be released as version 1.16.0.

This PR adds the mtls feature to bigquery client lib. Note that:
(1) if the python-cloud-core version is < 1.16.0, this PR does nothing, it is backward compatible and won't break any current users.
(2) if the user sets `GOOGLE_API_USE_CLIENT_CERTIFICATE` env var to "true" to trigger mtls, then the PR checks python-cloud-core version. It throws an exception asking the user to bump the version, if the version < 1.16.0. So probably it is a good idea to release python-cloud-core 1.16.0 before merging this PR.
(3) the unit tests work for both python-cloud-core versions, so unit test shouldn't break after the upgrading in the future.