### PR TITLE
docs: clarify `%%bigquery`` magics and fix broken link

### DIFF
--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -29,7 +29,7 @@ Integrations with Other Libraries
 
   pandas
 
-See also, the :mod:`google.cloud.bigquery.magics` module for integrations
-with Jupyter.
+See also, the :mod:`google.cloud.bigquery.magics.magics` module for
+integrations with Jupyter.
 
 

--- a/google/cloud/bigquery/magics/magics.py
+++ b/google/cloud/bigquery/magics/magics.py
@@ -14,6 +14,15 @@
 
 """IPython Magics
 
+To use these magics, you must first register them. Run the ``%load_ext`` magic
+in a Jupyter notebook cell.
+
+.. code::
+
+    %load_ext google.cloud.bigquery
+
+This makes the ``%%bigquery`` magic available.
+
 .. function:: %%bigquery
 
     IPython cell magic to run a query and display the result as a DataFrame


### PR DESCRIPTION
The link at https://googleapis.dev/python/bigquery/latest/usage/index.html
was broken. Also, I was having trouble remembering what I needed to do to
enable the `%%bigquery` extension, so I put that prerequisite right at the
top of the docs.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
