### PR TITLE
fix: DB API depends on pyarrow when decimal query parameters are used

### DIFF
--- a/google/cloud/bigquery/dbapi/_helpers.py
+++ b/google/cloud/bigquery/dbapi/_helpers.py
@@ -189,6 +189,10 @@ def bigquery_scalar_type(value):
     elif isinstance(value, numbers.Real):
         return "FLOAT64"
     elif isinstance(value, decimal.Decimal):
+        if pyarrow is None:
+            # We don't try to manually guess if it's maybe a BIGNUMERIC.
+            return "NUMERIC"
+
         # We check for NUMERIC before BIGNUMERIC in order to support pyarrow < 3.0.
         scalar_object = pyarrow.scalar(value)
         if isinstance(scalar_object, pyarrow.Decimal128Scalar):

--- a/google/cloud/bigquery/dbapi/_helpers.py
+++ b/google/cloud/bigquery/dbapi/_helpers.py
@@ -19,14 +19,13 @@ import decimal
 import functools
 import numbers
 
-try:
-    import pyarrow
-except ImportError:  # pragma: NO COVER
-    pyarrow = None
-
 from google.cloud import bigquery
 from google.cloud.bigquery import table
 from google.cloud.bigquery.dbapi import exceptions
+
+
+_NUMERIC_SERVER_MIN = decimal.Decimal("-9.9999999999999999999999999999999999999E+28")
+_NUMERIC_SERVER_MAX = decimal.Decimal("9.9999999999999999999999999999999999999E+28")
 
 
 def scalar_to_query_parameter(value, name=None):
@@ -189,16 +188,20 @@ def bigquery_scalar_type(value):
     elif isinstance(value, numbers.Real):
         return "FLOAT64"
     elif isinstance(value, decimal.Decimal):
-        if pyarrow is None:
-            # We don't try to manually guess if it's maybe a BIGNUMERIC.
-            return "NUMERIC"
-
-        # We check for NUMERIC before BIGNUMERIC in order to support pyarrow < 3.0.
-        scalar_object = pyarrow.scalar(value)
-        if isinstance(scalar_object, pyarrow.Decimal128Scalar):
+        vtuple = value.as_tuple()
+        # NUMERIC values have precision of 38 (number of digits) and scale of 9 (number
+        # of fractional digits), and their max absolute value must be strictly smaller
+        # than 1.0E+29.
+        # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#decimal_types
+        if (
+            len(vtuple.digits) <= 38  # max precision: 38
+            and vtuple.exponent >= -9  # max scale: 9
+            and _NUMERIC_SERVER_MIN <= value <= _NUMERIC_SERVER_MAX
+        ):
             return "NUMERIC"
         else:
             return "BIGNUMERIC"
+
     elif isinstance(value, str):
         return "STRING"
     elif isinstance(value, bytes):

--- a/tests/unit/test_dbapi__helpers.py
+++ b/tests/unit/test_dbapi__helpers.py
@@ -42,7 +42,7 @@ class TestQueryParameters(unittest.TestCase):
             (1.25, "FLOAT64"),
             (decimal.Decimal("1.25"), "NUMERIC"),
             (b"I am some bytes", "BYTES"),
-            (u"I am a string", "STRING"),
+            ("I am a string", "STRING"),
             (datetime.date(2017, 4, 1), "DATE"),
             (datetime.time(12, 34, 56), "TIME"),
             (datetime.datetime(2012, 3, 4, 5, 6, 7), "DATETIME"),
@@ -113,7 +113,7 @@ class TestQueryParameters(unittest.TestCase):
             ([1.25, 2.50], "FLOAT64"),
             ([decimal.Decimal("1.25")], "NUMERIC"),
             ([b"foo", b"bar"], "BYTES"),
-            ([u"foo", u"bar"], "STRING"),
+            (["foo", "bar"], "STRING"),
             ([datetime.date(2017, 4, 1), datetime.date(2018, 4, 1)], "DATE"),
             ([datetime.time(12, 34, 56), datetime.time(10, 20, 30)], "TIME"),
             (
@@ -157,7 +157,7 @@ class TestQueryParameters(unittest.TestCase):
             _helpers.array_to_query_parameter([])
 
     def test_array_to_query_parameter_unsupported_sequence(self):
-        unsupported_iterables = [{10, 20, 30}, u"foo", b"bar", bytearray([65, 75, 85])]
+        unsupported_iterables = [{10, 20, 30}, "foo", b"bar", bytearray([65, 75, 85])]
         for iterable in unsupported_iterables:
             with self.assertRaises(exceptions.ProgrammingError):
                 _helpers.array_to_query_parameter(iterable)
@@ -167,7 +167,7 @@ class TestQueryParameters(unittest.TestCase):
             _helpers.array_to_query_parameter([object(), 2, 7])
 
     def test_to_query_parameters_w_dict(self):
-        parameters = {"somebool": True, "somestring": u"a-string-value"}
+        parameters = {"somebool": True, "somestring": "a-string-value"}
         query_parameters = _helpers.to_query_parameters(parameters)
         query_parameter_tuples = []
         for param in query_parameters:
@@ -177,7 +177,7 @@ class TestQueryParameters(unittest.TestCase):
             sorted(
                 [
                     ("somebool", "BOOL", True),
-                    ("somestring", "STRING", u"a-string-value"),
+                    ("somestring", "STRING", "a-string-value"),
                 ]
             ),
         )
@@ -200,14 +200,14 @@ class TestQueryParameters(unittest.TestCase):
             _helpers.to_query_parameters(parameters)
 
     def test_to_query_parameters_w_list(self):
-        parameters = [True, u"a-string-value"]
+        parameters = [True, "a-string-value"]
         query_parameters = _helpers.to_query_parameters(parameters)
         query_parameter_tuples = []
         for param in query_parameters:
             query_parameter_tuples.append((param.name, param.type_, param.value))
         self.assertSequenceEqual(
             sorted(query_parameter_tuples),
-            sorted([(None, "BOOL", True), (None, "STRING", u"a-string-value")]),
+            sorted([(None, "BOOL", True), (None, "STRING", "a-string-value")]),
         )
 
     def test_to_query_parameters_w_list_array_param(self):


### PR DESCRIPTION
Fixes #549.

This PR removes the hard dependency of DB API on the optional `pyarrow` dependency.

**PR checklist**:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
