### PR TITLE
test: remove duplicate test for Decimal scalars

### DIFF
--- a/tests/unit/test_dbapi__helpers.py
+++ b/tests/unit/test_dbapi__helpers.py
@@ -72,33 +72,6 @@ class TestQueryParameters(unittest.TestCase):
             self.assertEqual(named_parameter.type_, expected_type, msg=msg)
             self.assertEqual(named_parameter.value, value, msg=msg)
 
-    def test_decimal_to_query_parameter(self):  # TODO: merge with previous test
-
-        expected_types = [
-            (decimal.Decimal("9.9999999999999999999999999999999999999E+28"), "NUMERIC"),
-            (decimal.Decimal("1.0E+29"), "BIGNUMERIC"),  # more than max value
-            (decimal.Decimal("1.123456789"), "NUMERIC"),
-            (decimal.Decimal("1.1234567891"), "BIGNUMERIC"),  # scale > 9
-            (decimal.Decimal("12345678901234567890123456789.012345678"), "NUMERIC"),
-            (
-                decimal.Decimal("12345678901234567890123456789012345678"),
-                "BIGNUMERIC",  # larger than max size, even if precision <=38
-            ),
-        ]
-
-        for value, expected_type in expected_types:
-            msg = f"value: {value} expected_type: {expected_type}"
-
-            parameter = _helpers.scalar_to_query_parameter(value)
-            self.assertIsNone(parameter.name, msg=msg)
-            self.assertEqual(parameter.type_, expected_type, msg=msg)
-            self.assertEqual(parameter.value, value, msg=msg)
-
-            named_parameter = _helpers.scalar_to_query_parameter(value, name="myvar")
-            self.assertEqual(named_parameter.name, "myvar", msg=msg)
-            self.assertEqual(named_parameter.type_, expected_type, msg=msg)
-            self.assertEqual(named_parameter.value, value, msg=msg)
-
     def test_scalar_to_query_parameter_w_unexpected_type(self):
         with self.assertRaises(exceptions.ProgrammingError):
             _helpers.scalar_to_query_parameter(value={"a": "dictionary"})


### PR DESCRIPTION
This is a follow-up to #551, just removing a duplicate unit test.

**Checklist**
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
