### PR TITLE
fix: avoid policy tags 403 error in `load_table_from_dataframe`

### DIFF
--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -2291,9 +2291,13 @@ class Client(ClientWithProject):
                     name
                     for name, _ in _pandas_helpers.list_columns_and_indexes(dataframe)
                 )
-                # schema fields not present in the dataframe are not needed
                 job_config.schema = [
-                    field for field in table.schema if field.name in columns_and_indexes
+                    # Field description and policy tags are not needed to
+                    # serialize a data frame.
+                    SchemaField(field.name, field.field_type, mode=field.mode)
+                    # schema fields not present in the dataframe are not needed
+                    for field in table.schema
+                    if field.name in columns_and_indexes
                 ]
 
         job_config.schema = _pandas_helpers.dataframe_to_bq_schema(

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -2294,7 +2294,12 @@ class Client(ClientWithProject):
                 job_config.schema = [
                     # Field description and policy tags are not needed to
                     # serialize a data frame.
-                    SchemaField(field.name, field.field_type, mode=field.mode)
+                    SchemaField(
+                        field.name,
+                        field.field_type,
+                        mode=field.mode,
+                        fields=field.fields,
+                    )
                     # schema fields not present in the dataframe are not needed
                     for field in table.schema
                     if field.name in columns_and_indexes

--- a/tests/unit/job/test_load_config.py
+++ b/tests/unit/job/test_load_config.py
@@ -434,13 +434,11 @@ class TestLoadJobConfig(_Base):
             "name": "full_name",
             "type": "STRING",
             "mode": "REQUIRED",
-            "description": None,
         }
         age_repr = {
             "name": "age",
             "type": "INTEGER",
             "mode": "REQUIRED",
-            "description": None,
         }
         self.assertEqual(
             config._properties["load"]["schema"], {"fields": [full_name_repr, age_repr]}
@@ -449,24 +447,18 @@ class TestLoadJobConfig(_Base):
     def test_schema_setter_valid_mappings_list(self):
         config = self._get_target_class()()
 
-        schema = [
-            {"name": "full_name", "type": "STRING", "mode": "REQUIRED"},
-            {"name": "age", "type": "INTEGER", "mode": "REQUIRED"},
-        ]
-        config.schema = schema
-
         full_name_repr = {
             "name": "full_name",
             "type": "STRING",
             "mode": "REQUIRED",
-            "description": None,
         }
         age_repr = {
             "name": "age",
             "type": "INTEGER",
             "mode": "REQUIRED",
-            "description": None,
         }
+        schema = [full_name_repr, age_repr]
+        config.schema = schema
         self.assertEqual(
             config._properties["load"]["schema"], {"fields": [full_name_repr, age_repr]}
         )

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -2755,13 +2755,24 @@ class TestClient(unittest.TestCase):
                     "name": "age",
                     "type": "INTEGER",
                     "mode": "REQUIRED",
-                    "description": None,
+                    "description": "this is a column",
                 },
+                {"name": "country", "type": "STRING", "mode": "NULLABLE"},
             ]
         }
         schema = [
-            SchemaField("full_name", "STRING", mode="REQUIRED"),
-            SchemaField("age", "INTEGER", mode="REQUIRED"),
+            SchemaField(
+                "full_name",
+                "STRING",
+                mode="REQUIRED",
+                # Explicitly unset the description.
+                description=None,
+            ),
+            SchemaField(
+                "age", "INTEGER", mode="REQUIRED", description="this is a column"
+            ),
+            # Omit the description to not make updates to it.
+            SchemaField("country", "STRING"),
         ]
         resource = self._make_table_resource()
         resource.update(

--- a/tests/unit/test_external_config.py
+++ b/tests/unit/test_external_config.py
@@ -77,14 +77,7 @@ class TestExternalConfig(unittest.TestCase):
         ec.schema = [schema.SchemaField("full_name", "STRING", mode="REQUIRED")]
 
         exp_schema = {
-            "fields": [
-                {
-                    "name": "full_name",
-                    "type": "STRING",
-                    "mode": "REQUIRED",
-                    "description": None,
-                }
-            ]
+            "fields": [{"name": "full_name", "type": "STRING", "mode": "REQUIRED"}]
         }
         got_resource = ec.to_api_repr()
         exp_resource = {

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -60,8 +60,8 @@ class TestSchemaField(unittest.TestCase):
         self.assertEqual(field._mode, "NULLABLE")
         self.assertIsNone(field._description)
         self.assertEqual(len(field._fields), 2)
-        self.assertIs(field._fields[0], sub_field1)
-        self.assertIs(field._fields[1], sub_field2)
+        self.assertEqual(field._fields[0], sub_field1)
+        self.assertEqual(field._fields[1], sub_field2)
 
     def test_constructor_with_policy_tags(self):
         from google.cloud.bigquery.schema import PolicyTagList
@@ -168,17 +168,17 @@ class TestSchemaField(unittest.TestCase):
     def test_name_property(self):
         name = "lemon-ness"
         schema_field = self._make_one(name, "INTEGER")
-        self.assertIs(schema_field.name, name)
+        self.assertEqual(schema_field.name, name)
 
     def test_field_type_property(self):
         field_type = "BOOLEAN"
         schema_field = self._make_one("whether", field_type)
-        self.assertIs(schema_field.field_type, field_type)
+        self.assertEqual(schema_field.field_type, field_type)
 
     def test_mode_property(self):
         mode = "REPEATED"
         schema_field = self._make_one("again", "FLOAT", mode=mode)
-        self.assertIs(schema_field.mode, mode)
+        self.assertEqual(schema_field.mode, mode)
 
     def test_is_nullable(self):
         mode = "NULLABLE"
@@ -193,14 +193,14 @@ class TestSchemaField(unittest.TestCase):
     def test_description_property(self):
         description = "It holds some data."
         schema_field = self._make_one("do", "TIMESTAMP", description=description)
-        self.assertIs(schema_field.description, description)
+        self.assertEqual(schema_field.description, description)
 
     def test_fields_property(self):
         sub_field1 = self._make_one("one", "STRING")
         sub_field2 = self._make_one("fish", "INTEGER")
         fields = (sub_field1, sub_field2)
         schema_field = self._make_one("boat", "RECORD", fields=fields)
-        self.assertIs(schema_field.fields, fields)
+        self.assertEqual(schema_field.fields, fields)
 
     def test_to_standard_sql_simple_type(self):
         sql_type = self._get_standard_sql_data_type_class()

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -35,19 +35,19 @@ class TestSchemaField(unittest.TestCase):
 
     def test_constructor_defaults(self):
         field = self._make_one("test", "STRING")
-        self.assertEqual(field._name, "test")
-        self.assertEqual(field._field_type, "STRING")
-        self.assertEqual(field._mode, "NULLABLE")
-        self.assertIsNone(field._description)
-        self.assertEqual(field._fields, ())
+        self.assertEqual(field.name, "test")
+        self.assertEqual(field.field_type, "STRING")
+        self.assertEqual(field.mode, "NULLABLE")
+        self.assertIsNone(field.description)
+        self.assertEqual(field.fields, ())
 
     def test_constructor_explicit(self):
         field = self._make_one("test", "STRING", mode="REQUIRED", description="Testing")
-        self.assertEqual(field._name, "test")
-        self.assertEqual(field._field_type, "STRING")
-        self.assertEqual(field._mode, "REQUIRED")
-        self.assertEqual(field._description, "Testing")
-        self.assertEqual(field._fields, ())
+        self.assertEqual(field.name, "test")
+        self.assertEqual(field.field_type, "STRING")
+        self.assertEqual(field.mode, "REQUIRED")
+        self.assertEqual(field.description, "Testing")
+        self.assertEqual(field.fields, ())
 
     def test_constructor_subfields(self):
         sub_field1 = self._make_one("area_code", "STRING")
@@ -55,13 +55,13 @@ class TestSchemaField(unittest.TestCase):
         field = self._make_one(
             "phone_number", "RECORD", fields=[sub_field1, sub_field2]
         )
-        self.assertEqual(field._name, "phone_number")
-        self.assertEqual(field._field_type, "RECORD")
-        self.assertEqual(field._mode, "NULLABLE")
-        self.assertIsNone(field._description)
-        self.assertEqual(len(field._fields), 2)
-        self.assertEqual(field._fields[0], sub_field1)
-        self.assertEqual(field._fields[1], sub_field2)
+        self.assertEqual(field.name, "phone_number")
+        self.assertEqual(field.field_type, "RECORD")
+        self.assertEqual(field.mode, "NULLABLE")
+        self.assertIsNone(field.description)
+        self.assertEqual(len(field.fields), 2)
+        self.assertEqual(field.fields[0], sub_field1)
+        self.assertEqual(field.fields[1], sub_field2)
 
     def test_constructor_with_policy_tags(self):
         from google.cloud.bigquery.schema import PolicyTagList
@@ -70,12 +70,12 @@ class TestSchemaField(unittest.TestCase):
         field = self._make_one(
             "test", "STRING", mode="REQUIRED", description="Testing", policy_tags=policy
         )
-        self.assertEqual(field._name, "test")
-        self.assertEqual(field._field_type, "STRING")
-        self.assertEqual(field._mode, "REQUIRED")
-        self.assertEqual(field._description, "Testing")
-        self.assertEqual(field._fields, ())
-        self.assertEqual(field._policy_tags, policy)
+        self.assertEqual(field.name, "test")
+        self.assertEqual(field.field_type, "STRING")
+        self.assertEqual(field.mode, "REQUIRED")
+        self.assertEqual(field.description, "Testing")
+        self.assertEqual(field.fields, ())
+        self.assertEqual(field.policy_tags, policy)
 
     def test_to_api_repr(self):
         from google.cloud.bigquery.schema import PolicyTagList
@@ -92,7 +92,6 @@ class TestSchemaField(unittest.TestCase):
                 "mode": "NULLABLE",
                 "name": "foo",
                 "type": "INTEGER",
-                "description": None,
                 "policyTags": {"names": ["foo", "bar"]},
             },
         )
@@ -104,18 +103,10 @@ class TestSchemaField(unittest.TestCase):
             self.assertEqual(
                 field.to_api_repr(),
                 {
-                    "fields": [
-                        {
-                            "mode": "NULLABLE",
-                            "name": "bar",
-                            "type": "INTEGER",
-                            "description": None,
-                        }
-                    ],
+                    "fields": [{"mode": "NULLABLE", "name": "bar", "type": "INTEGER"}],
                     "mode": "REQUIRED",
                     "name": "foo",
                     "type": record_type,
-                    "description": None,
                 },
             )
 
@@ -532,17 +523,10 @@ class Test_build_schema_resource(unittest.TestCase, _SchemaBase):
         resource = self._call_fut([full_name, age])
         self.assertEqual(len(resource), 2)
         self.assertEqual(
-            resource[0],
-            {
-                "name": "full_name",
-                "type": "STRING",
-                "mode": "REQUIRED",
-                "description": None,
-            },
+            resource[0], {"name": "full_name", "type": "STRING", "mode": "REQUIRED"},
         )
         self.assertEqual(
-            resource[1],
-            {"name": "age", "type": "INTEGER", "mode": "REQUIRED", "description": None},
+            resource[1], {"name": "age", "type": "INTEGER", "mode": "REQUIRED"}
         )
 
     def test_w_description(self):
@@ -552,7 +536,13 @@ class Test_build_schema_resource(unittest.TestCase, _SchemaBase):
         full_name = SchemaField(
             "full_name", "STRING", mode="REQUIRED", description=DESCRIPTION
         )
-        age = SchemaField("age", "INTEGER", mode="REQUIRED")
+        age = SchemaField(
+            "age",
+            "INTEGER",
+            mode="REQUIRED",
+            # Explicitly unset description.
+            description=None,
+        )
         resource = self._call_fut([full_name, age])
         self.assertEqual(len(resource), 2)
         self.assertEqual(
@@ -581,13 +571,7 @@ class Test_build_schema_resource(unittest.TestCase, _SchemaBase):
         resource = self._call_fut([full_name, phone])
         self.assertEqual(len(resource), 2)
         self.assertEqual(
-            resource[0],
-            {
-                "name": "full_name",
-                "type": "STRING",
-                "mode": "REQUIRED",
-                "description": None,
-            },
+            resource[0], {"name": "full_name", "type": "STRING", "mode": "REQUIRED"},
         )
         self.assertEqual(
             resource[1],
@@ -595,20 +579,9 @@ class Test_build_schema_resource(unittest.TestCase, _SchemaBase):
                 "name": "phone",
                 "type": "RECORD",
                 "mode": "REPEATED",
-                "description": None,
                 "fields": [
-                    {
-                        "name": "type",
-                        "type": "STRING",
-                        "mode": "REQUIRED",
-                        "description": None,
-                    },
-                    {
-                        "name": "number",
-                        "type": "STRING",
-                        "mode": "REQUIRED",
-                        "description": None,
-                    },
+                    {"name": "type", "type": "STRING", "mode": "REQUIRED"},
+                    {"name": "number", "type": "STRING", "mode": "REQUIRED"},
                 ],
             },
         )


### PR DESCRIPTION
In internal issue 182204971, as customer is encountering a 403 error for missing permissions to set policy tags on a table when trying to append a dataframe to a table with `load_table_from_dataframe`. This is because we get the schema from the table and then pass it back to the API. We only need to set the field names (and maybe type + mode) in this case.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes internal bug 182204971 🦕
