### PR TITLE
feat: add `ExternalConfig.connection_id` property to connect to external sources

### DIFF
--- a/google/cloud/bigquery/external_config.py
+++ b/google/cloud/bigquery/external_config.py
@@ -774,7 +774,7 @@ class ExternalConfig(object):
         return self._properties.get("connectionId")
 
     @connection_id.setter
-    def connectionid(self, value):
+    def connection_id(self, value):
         self._properties["connectionId"] = value
 
     @schema.setter

--- a/google/cloud/bigquery/external_config.py
+++ b/google/cloud/bigquery/external_config.py
@@ -762,6 +762,15 @@ class ExternalConfig(object):
 
     @property
     def connection_id(self):
+        """Optional[str]: [Experimental] ID of a BigQuery Connection API
+        resource.
+
+        .. WARNING::
+
+           This feature is experimental. Pre-GA features may have limited
+           support, and changes to pre-GA features may not be compatible with
+           other pre-GA versions.
+        """
         return self._properties.get("connectionId")
 
     @connection_id.setter

--- a/google/cloud/bigquery/external_config.py
+++ b/google/cloud/bigquery/external_config.py
@@ -760,6 +760,14 @@ class ExternalConfig(object):
         prop = self._properties.get("schema", {})
         return [SchemaField.from_api_repr(field) for field in prop.get("fields", [])]
 
+    @property
+    def connection_id(self):
+        return self._properties.get("connectionId")
+
+    @connection_id.setter
+    def connectionid(self, value):
+        self._properties["connectionId"] = value
+
     @schema.setter
     def schema(self, value):
         prop = value

--- a/tests/unit/test_external_config.py
+++ b/tests/unit/test_external_config.py
@@ -74,6 +74,7 @@ class TestExternalConfig(unittest.TestCase):
         ec.autodetect = True
         ec.ignore_unknown_values = False
         ec.compression = "compression"
+        ec.connection_id = "path/to/connection"
         ec.schema = [schema.SchemaField("full_name", "STRING", mode="REQUIRED")]
 
         exp_schema = {
@@ -94,9 +95,16 @@ class TestExternalConfig(unittest.TestCase):
             "autodetect": True,
             "ignoreUnknownValues": False,
             "compression": "compression",
+            "connectionId": "path/to/connection",
             "schema": exp_schema,
         }
         self.assertEqual(got_resource, exp_resource)
+
+    def test_connection_di(self):
+        ec = external_config.ExternalConfig("")
+        self.assertIsNone(ec.connection_id)
+        ec.connection_id = "path/to/connection"
+        self.assertEqual(ec.connection_id, "path/to/connection")
 
     def test_schema_None(self):
         ec = external_config.ExternalConfig("")

--- a/tests/unit/test_external_config.py
+++ b/tests/unit/test_external_config.py
@@ -93,7 +93,7 @@ class TestExternalConfig(unittest.TestCase):
         }
         self.assertEqual(got_resource, exp_resource)
 
-    def test_connection_di(self):
+    def test_connection_id(self):
         ec = external_config.ExternalConfig("")
         self.assertIsNone(ec.connection_id)
         ec.connection_id = "path/to/connection"


### PR DESCRIPTION
In response to internal issue b/182112589.

