### PR TITLE
feat: add configurable max size for the queue holding the result pages streamed over the BQ Storage API

### DIFF
--- a/google/cloud/bigquery/_pandas_helpers.py
+++ b/google/cloud/bigquery/_pandas_helpers.py
@@ -721,12 +721,7 @@ def _download_table_bqstorage(
 
 
 def download_arrow_bqstorage(
-    project_id,
-    table,
-    bqstorage_client,
-    preserve_order=False,
-    selected_fields=None,
-    max_queue_size=_DEFAULT_MAX_QUEUE_SIZE,
+    project_id, table, bqstorage_client, preserve_order=False, selected_fields=None,
 ):
     return _download_table_bqstorage(
         project_id,
@@ -735,7 +730,6 @@ def download_arrow_bqstorage(
         preserve_order=preserve_order,
         selected_fields=selected_fields,
         page_to_item=_bqstorage_page_to_arrow,
-        max_queue_size=max_queue_size,
     )
 
 

--- a/google/cloud/bigquery/_pandas_helpers.py
+++ b/google/cloud/bigquery/_pandas_helpers.py
@@ -703,15 +703,12 @@ def _download_table_bqstorage(
                     continue
 
             # Return any remaining values after the workers finished.
-            while not worker_queue.empty():  # pragma: NO COVER
+            while True:  # pragma: NO COVER
                 try:
-                    # Include a timeout because even though the queue is
-                    # non-empty, it doesn't guarantee that a subsequent call to
-                    # get() will not block.
-                    frame = worker_queue.get(timeout=_PROGRESS_INTERVAL)
+                    frame = worker_queue.get_nowait()
                     yield frame
                 except queue.Empty:  # pragma: NO COVER
-                    continue
+                    break
         finally:
             # No need for a lock because reading/replacing a variable is
             # defined to be an atomic operation in the Python language

--- a/google/cloud/bigquery/job/query.py
+++ b/google/cloud/bigquery/job/query.py
@@ -28,7 +28,6 @@ from google.cloud.bigquery.dataset import DatasetReference
 from google.cloud.bigquery.encryption_configuration import EncryptionConfiguration
 from google.cloud.bigquery.external_config import ExternalConfig
 from google.cloud.bigquery import _helpers
-from google.cloud.bigquery import _pandas_helpers
 from google.cloud.bigquery.query import _query_param_from_api_repr
 from google.cloud.bigquery.query import ArrayQueryParameter
 from google.cloud.bigquery.query import ScalarQueryParameter
@@ -1200,7 +1199,6 @@ class QueryJob(_AsyncJob):
         progress_bar_type=None,
         bqstorage_client=None,
         create_bqstorage_client=True,
-        max_queue_size=_pandas_helpers._DEFAULT_MAX_QUEUE_SIZE,
     ):
         """[Beta] Create a class:`pyarrow.Table` by loading all pages of a
         table or query.
@@ -1244,13 +1242,6 @@ class QueryJob(_AsyncJob):
 
                 ..versionadded:: 1.24.0
 
-            max_queue_size (Optional[int]):
-                The maximum number of result pages to hold in the internal queue when
-                streaming query results over the BigQuery Storage API. Ignored if
-                Storage API is not used.
-
-                ..versionadded:: 2.14.0
-
         Returns:
             pyarrow.Table
                 A :class:`pyarrow.Table` populated with row data and column
@@ -1268,7 +1259,6 @@ class QueryJob(_AsyncJob):
             progress_bar_type=progress_bar_type,
             bqstorage_client=bqstorage_client,
             create_bqstorage_client=create_bqstorage_client,
-            max_queue_size=max_queue_size,
         )
 
     # If changing the signature of this method, make sure to apply the same
@@ -1280,7 +1270,6 @@ class QueryJob(_AsyncJob):
         progress_bar_type=None,
         create_bqstorage_client=True,
         date_as_object=True,
-        max_queue_size=_pandas_helpers._DEFAULT_MAX_QUEUE_SIZE,
     ):
         """Return a pandas DataFrame from a QueryJob
 
@@ -1327,13 +1316,6 @@ class QueryJob(_AsyncJob):
 
                 ..versionadded:: 1.26.0
 
-            max_queue_size (Optional[int]):
-                The maximum number of result pages to hold in the internal queue when
-                streaming query results over the BigQuery Storage API. Ignored if
-                Storage API is not used.
-
-                ..versionadded:: 2.14.0
-
         Returns:
             A :class:`~pandas.DataFrame` populated with row data and column
             headers from the query results. The column headers are derived
@@ -1349,7 +1331,6 @@ class QueryJob(_AsyncJob):
             progress_bar_type=progress_bar_type,
             create_bqstorage_client=create_bqstorage_client,
             date_as_object=date_as_object,
-            max_queue_size=max_queue_size,
         )
 
     def __iter__(self):

--- a/google/cloud/bigquery/job/query.py
+++ b/google/cloud/bigquery/job/query.py
@@ -28,6 +28,7 @@ from google.cloud.bigquery.dataset import DatasetReference
 from google.cloud.bigquery.encryption_configuration import EncryptionConfiguration
 from google.cloud.bigquery.external_config import ExternalConfig
 from google.cloud.bigquery import _helpers
+from google.cloud.bigquery import _pandas_helpers
 from google.cloud.bigquery.query import _query_param_from_api_repr
 from google.cloud.bigquery.query import ArrayQueryParameter
 from google.cloud.bigquery.query import ScalarQueryParameter
@@ -1199,6 +1200,7 @@ class QueryJob(_AsyncJob):
         progress_bar_type=None,
         bqstorage_client=None,
         create_bqstorage_client=True,
+        max_queue_size=_pandas_helpers._DEFAULT_MAX_QUEUE_SIZE,
     ):
         """[Beta] Create a class:`pyarrow.Table` by loading all pages of a
         table or query.
@@ -1242,6 +1244,13 @@ class QueryJob(_AsyncJob):
 
                 ..versionadded:: 1.24.0
 
+            max_queue_size (Optional[int]):
+                The maximum number of result pages to hold in the internal queue when
+                streaming query results over the BigQuery Storage API. Ignored if
+                Storage API is not used.
+
+                ..versionadded:: 2.14.0
+
         Returns:
             pyarrow.Table
                 A :class:`pyarrow.Table` populated with row data and column
@@ -1259,6 +1268,7 @@ class QueryJob(_AsyncJob):
             progress_bar_type=progress_bar_type,
             bqstorage_client=bqstorage_client,
             create_bqstorage_client=create_bqstorage_client,
+            max_queue_size=max_queue_size,
         )
 
     # If changing the signature of this method, make sure to apply the same
@@ -1270,6 +1280,7 @@ class QueryJob(_AsyncJob):
         progress_bar_type=None,
         create_bqstorage_client=True,
         date_as_object=True,
+        max_queue_size=_pandas_helpers._DEFAULT_MAX_QUEUE_SIZE,
     ):
         """Return a pandas DataFrame from a QueryJob
 
@@ -1316,6 +1327,13 @@ class QueryJob(_AsyncJob):
 
                 ..versionadded:: 1.26.0
 
+            max_queue_size (Optional[int]):
+                The maximum number of result pages to hold in the internal queue when
+                streaming query results over the BigQuery Storage API. Ignored if
+                Storage API is not used.
+
+                ..versionadded:: 2.14.0
+
         Returns:
             A :class:`~pandas.DataFrame` populated with row data and column
             headers from the query results. The column headers are derived
@@ -1331,6 +1349,7 @@ class QueryJob(_AsyncJob):
             progress_bar_type=progress_bar_type,
             create_bqstorage_client=create_bqstorage_client,
             date_as_object=date_as_object,
+            max_queue_size=max_queue_size,
         )
 
     def __iter__(self):

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -1497,11 +1497,7 @@ class RowIterator(HTTPIterator):
         )
         yield from result_pages
 
-    def _to_arrow_iterable(
-        self,
-        bqstorage_client=None,
-        max_queue_size=_pandas_helpers._DEFAULT_MAX_QUEUE_SIZE,
-    ):
+    def _to_arrow_iterable(self, bqstorage_client=None):
         """Create an iterable of arrow RecordBatches, to process the table as a stream."""
         bqstorage_download = functools.partial(
             _pandas_helpers.download_arrow_bqstorage,
@@ -1510,7 +1506,6 @@ class RowIterator(HTTPIterator):
             bqstorage_client,
             preserve_order=self._preserve_order,
             selected_fields=self._selected_fields,
-            max_queue_size=max_queue_size,
         )
         tabledata_list_download = functools.partial(
             _pandas_helpers.download_arrow_row_iterator, iter(self.pages), self.schema
@@ -1528,7 +1523,6 @@ class RowIterator(HTTPIterator):
         progress_bar_type=None,
         bqstorage_client=None,
         create_bqstorage_client=True,
-        max_queue_size=_pandas_helpers._DEFAULT_MAX_QUEUE_SIZE,
     ):
         """[Beta] Create a class:`pyarrow.Table` by loading all pages of a
         table or query.
@@ -1572,13 +1566,6 @@ class RowIterator(HTTPIterator):
 
                 ..versionadded:: 1.24.0
 
-            max_queue_size (Optional[int]):
-                The maximum number of result pages to hold in the internal queue when
-                streaming query results over the BigQuery Storage API. Ignored if
-                Storage API is not used.
-
-                ..versionadded:: 2.14.0
-
         Returns:
             pyarrow.Table
                 A :class:`pyarrow.Table` populated with row data and column
@@ -1609,7 +1596,7 @@ class RowIterator(HTTPIterator):
 
             record_batches = []
             for record_batch in self._to_arrow_iterable(
-                bqstorage_client=bqstorage_client, max_queue_size=max_queue_size,
+                bqstorage_client=bqstorage_client
             ):
                 record_batches.append(record_batch)
 
@@ -1712,7 +1699,6 @@ class RowIterator(HTTPIterator):
         progress_bar_type=None,
         create_bqstorage_client=True,
         date_as_object=True,
-        max_queue_size=_pandas_helpers._DEFAULT_MAX_QUEUE_SIZE,
     ):
         """Create a pandas DataFrame by loading all pages of a query.
 
@@ -1801,7 +1787,6 @@ class RowIterator(HTTPIterator):
             progress_bar_type=progress_bar_type,
             bqstorage_client=bqstorage_client,
             create_bqstorage_client=create_bqstorage_client,
-            max_queue_size=max_queue_size,
         )
 
         # When converting timestamp values to nanosecond precision, the result
@@ -1849,7 +1834,6 @@ class _EmptyRowIterator(object):
         progress_bar_type=None,
         bqstorage_client=None,
         create_bqstorage_client=True,
-        max_queue_size=_pandas_helpers._DEFAULT_MAX_QUEUE_SIZE,
     ):
         """[Beta] Create an empty class:`pyarrow.Table`.
 
@@ -1857,7 +1841,6 @@ class _EmptyRowIterator(object):
             progress_bar_type (str): Ignored. Added for compatibility with RowIterator.
             bqstorage_client (Any): Ignored. Added for compatibility with RowIterator.
             create_bqstorage_client (bool): Ignored. Added for compatibility with RowIterator.
-            max_queue_size (int): Ignored. Added for compatibility with RowIterator.
 
         Returns:
             pyarrow.Table: An empty :class:`pyarrow.Table`.
@@ -1873,7 +1856,6 @@ class _EmptyRowIterator(object):
         progress_bar_type=None,
         create_bqstorage_client=True,
         date_as_object=True,
-        max_queue_size=_pandas_helpers._DEFAULT_MAX_QUEUE_SIZE,
     ):
         """Create an empty dataframe.
 
@@ -1883,7 +1865,6 @@ class _EmptyRowIterator(object):
             progress_bar_type (Any): Ignored. Added for compatibility with RowIterator.
             create_bqstorage_client (bool): Ignored. Added for compatibility with RowIterator.
             date_as_object (bool): Ignored. Added for compatibility with RowIterator.
-            max_queue_size (int): Ignored. Added for compatibility with RowIterator.
 
         Returns:
             pandas.DataFrame: An empty :class:`~pandas.DataFrame`.

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -1498,7 +1498,11 @@ class RowIterator(HTTPIterator):
         for item in tabledata_list_download():
             yield item
 
-    def _to_arrow_iterable(self, bqstorage_client=None):
+    def _to_arrow_iterable(
+        self,
+        bqstorage_client=None,
+        max_queue_size=_pandas_helpers._DEFAULT_MAX_QUEUE_SIZE,
+    ):
         """Create an iterable of arrow RecordBatches, to process the table as a stream."""
         bqstorage_download = functools.partial(
             _pandas_helpers.download_arrow_bqstorage,
@@ -1507,6 +1511,7 @@ class RowIterator(HTTPIterator):
             bqstorage_client,
             preserve_order=self._preserve_order,
             selected_fields=self._selected_fields,
+            max_queue_size=max_queue_size,
         )
         tabledata_list_download = functools.partial(
             _pandas_helpers.download_arrow_row_iterator, iter(self.pages), self.schema
@@ -1524,6 +1529,7 @@ class RowIterator(HTTPIterator):
         progress_bar_type=None,
         bqstorage_client=None,
         create_bqstorage_client=True,
+        max_queue_size=_pandas_helpers._DEFAULT_MAX_QUEUE_SIZE,
     ):
         """[Beta] Create a class:`pyarrow.Table` by loading all pages of a
         table or query.
@@ -1567,6 +1573,13 @@ class RowIterator(HTTPIterator):
 
                 ..versionadded:: 1.24.0
 
+            max_queue_size (Optional[int]):
+                The maximum number of result pages to hold in the internal queue when
+                streaming query results over the BigQuery Storage API. Ignored if
+                Storage API is not used.
+
+                ..versionadded:: 2.14.0
+
         Returns:
             pyarrow.Table
                 A :class:`pyarrow.Table` populated with row data and column
@@ -1597,7 +1610,7 @@ class RowIterator(HTTPIterator):
 
             record_batches = []
             for record_batch in self._to_arrow_iterable(
-                bqstorage_client=bqstorage_client
+                bqstorage_client=bqstorage_client, max_queue_size=max_queue_size,
             ):
                 record_batches.append(record_batch)
 
@@ -1622,7 +1635,12 @@ class RowIterator(HTTPIterator):
             arrow_schema = _pandas_helpers.bq_to_arrow_schema(self._schema)
             return pyarrow.Table.from_batches(record_batches, schema=arrow_schema)
 
-    def to_dataframe_iterable(self, bqstorage_client=None, dtypes=None):
+    def to_dataframe_iterable(
+        self,
+        bqstorage_client=None,
+        dtypes=None,
+        max_queue_size=_pandas_helpers._DEFAULT_MAX_QUEUE_SIZE,
+    ):
         """Create an iterable of pandas DataFrames, to process the table as a stream.
 
         Args:
@@ -1641,6 +1659,13 @@ class RowIterator(HTTPIterator):
                 A dictionary of column names pandas ``dtype``s. The provided
                 ``dtype`` is used when constructing the series for the column
                 specified. Otherwise, the default pandas behavior is used.
+
+            max_queue_size (Optional[int]):
+                The maximum number of result pages to hold in the internal queue when
+                streaming query results over the BigQuery Storage API. Ignored if
+                Storage API is not used.
+
+                ..versionadded:: 2.14.0
 
         Returns:
             pandas.DataFrame:
@@ -1665,6 +1690,7 @@ class RowIterator(HTTPIterator):
             dtypes,
             preserve_order=self._preserve_order,
             selected_fields=self._selected_fields,
+            max_queue_size=max_queue_size,
         )
         tabledata_list_download = functools.partial(
             _pandas_helpers.download_dataframe_row_iterator,
@@ -1687,6 +1713,7 @@ class RowIterator(HTTPIterator):
         progress_bar_type=None,
         create_bqstorage_client=True,
         date_as_object=True,
+        max_queue_size=_pandas_helpers._DEFAULT_MAX_QUEUE_SIZE,
     ):
         """Create a pandas DataFrame by loading all pages of a query.
 
@@ -1742,6 +1769,13 @@ class RowIterator(HTTPIterator):
 
                 ..versionadded:: 1.26.0
 
+            max_queue_size (Optional[int]):
+                The maximum number of result pages to hold in the internal queue when
+                streaming query results over the BigQuery Storage API. Ignored if
+                Storage API is not used.
+
+                ..versionadded:: 2.14.0
+
         Returns:
             pandas.DataFrame:
                 A :class:`~pandas.DataFrame` populated with row data and column
@@ -1768,6 +1802,7 @@ class RowIterator(HTTPIterator):
             progress_bar_type=progress_bar_type,
             bqstorage_client=bqstorage_client,
             create_bqstorage_client=create_bqstorage_client,
+            max_queue_size=max_queue_size,
         )
 
         # When converting timestamp values to nanosecond precision, the result
@@ -1815,6 +1850,7 @@ class _EmptyRowIterator(object):
         progress_bar_type=None,
         bqstorage_client=None,
         create_bqstorage_client=True,
+        max_queue_size=_pandas_helpers._DEFAULT_MAX_QUEUE_SIZE,
     ):
         """[Beta] Create an empty class:`pyarrow.Table`.
 
@@ -1822,6 +1858,7 @@ class _EmptyRowIterator(object):
             progress_bar_type (str): Ignored. Added for compatibility with RowIterator.
             bqstorage_client (Any): Ignored. Added for compatibility with RowIterator.
             create_bqstorage_client (bool): Ignored. Added for compatibility with RowIterator.
+            max_queue_size (int): Ignored. Added for compatibility with RowIterator.
 
         Returns:
             pyarrow.Table: An empty :class:`pyarrow.Table`.
@@ -1837,6 +1874,7 @@ class _EmptyRowIterator(object):
         progress_bar_type=None,
         create_bqstorage_client=True,
         date_as_object=True,
+        max_queue_size=_pandas_helpers._DEFAULT_MAX_QUEUE_SIZE,
     ):
         """Create an empty dataframe.
 
@@ -1846,6 +1884,7 @@ class _EmptyRowIterator(object):
             progress_bar_type (Any): Ignored. Added for compatibility with RowIterator.
             create_bqstorage_client (bool): Ignored. Added for compatibility with RowIterator.
             date_as_object (bool): Ignored. Added for compatibility with RowIterator.
+            max_queue_size (int): Ignored. Added for compatibility with RowIterator.
 
         Returns:
             pandas.DataFrame: An empty :class:`~pandas.DataFrame`.

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -1490,13 +1490,12 @@ class RowIterator(HTTPIterator):
         if not self._validate_bqstorage(bqstorage_client, False):
             bqstorage_client = None
 
-        if bqstorage_client is not None:
-            for item in bqstorage_download():
-                yield item
-            return
-
-        for item in tabledata_list_download():
-            yield item
+        result_pages = (
+            bqstorage_download()
+            if bqstorage_client is not None
+            else tabledata_list_download()
+        )
+        yield from result_pages
 
     def _to_arrow_iterable(
         self,

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -1625,7 +1625,7 @@ class RowIterator(HTTPIterator):
         self,
         bqstorage_client=None,
         dtypes=None,
-        max_queue_size=_pandas_helpers._DEFAULT_MAX_QUEUE_SIZE,
+        max_queue_size=_pandas_helpers._MAX_QUEUE_SIZE_DEFAULT,
     ):
         """Create an iterable of pandas DataFrames, to process the table as a stream.
 
@@ -1650,6 +1650,10 @@ class RowIterator(HTTPIterator):
                 The maximum number of result pages to hold in the internal queue when
                 streaming query results over the BigQuery Storage API. Ignored if
                 Storage API is not used.
+
+                By default, the max queue size is set to the number of BQ Storage streams
+                created by the server. If ``max_queue_size`` is :data:`None`, the queue
+                size is infinite.
 
                 ..versionadded:: 2.14.0
 

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -1758,13 +1758,6 @@ class RowIterator(HTTPIterator):
 
                 ..versionadded:: 1.26.0
 
-            max_queue_size (Optional[int]):
-                The maximum number of result pages to hold in the internal queue when
-                streaming query results over the BigQuery Storage API. Ignored if
-                Storage API is not used.
-
-                ..versionadded:: 2.14.0
-
         Returns:
             pandas.DataFrame:
                 A :class:`~pandas.DataFrame` populated with row data and column


### PR DESCRIPTION
Closes #561.

This PR limits the size of the internal queue that stores result pages when streaming data over the BQ Storage API. It also makes the limit configurable.

Still need to add a few additional unit tests, but that should be it.

**Note:**
The new parameter is _not_ exposed to the `bigquery` Jupyter cell magic - I presume that's fine? I don't think cell magic needs such fine-grained control, since it's not really meant to fetch huge query results into a Jupyter notebook session where any performance difference could actually matter.

**PR checklist:**
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


