### PR TITLE
feat: accept job object as argument to `get_job` and `cancel_job`

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -2971,7 +2971,11 @@ class TestClient(unittest.TestCase):
         QUERY = "SELECT * from test_dataset:test_table"
         ASYNC_QUERY_DATA = {
             "id": "{}:{}".format(self.PROJECT, JOB_ID),
-            "jobReference": {"projectId": self.PROJECT, "jobId": "query_job"},
+            "jobReference": {
+                "projectId": "job-based-proj",
+                "jobId": "query_job",
+                "location": "us-east1",
+            },
             "state": "DONE",
             "configuration": {
                 "query": {
@@ -2989,18 +2993,21 @@ class TestClient(unittest.TestCase):
         creds = _make_credentials()
         client = self._make_one(self.PROJECT, creds)
         conn = client._connection = make_connection(ASYNC_QUERY_DATA)
+        job_from_resource = QueryJob.from_api_repr(ASYNC_QUERY_DATA, client)
 
-        job = client.get_job(JOB_ID, timeout=7.5)
+        job = client.get_job(job_from_resource, timeout=7.5)
 
         self.assertIsInstance(job, QueryJob)
         self.assertEqual(job.job_id, JOB_ID)
+        self.assertEqual(job.project, "job-based-proj")
+        self.assertEqual(job.location, "us-east1")
         self.assertEqual(job.create_disposition, CreateDisposition.CREATE_IF_NEEDED)
         self.assertEqual(job.write_disposition, WriteDisposition.WRITE_TRUNCATE)
 
         conn.api_request.assert_called_once_with(
             method="GET",
-            path="/projects/PROJECT/jobs/query_job",
-            query_params={"projection": "full"},
+            path="/projects/job-based-proj/jobs/query_job",
+            query_params={"projection": "full", "location": "us-east1"},
             timeout=7.5,
         )
 
@@ -3049,7 +3056,11 @@ class TestClient(unittest.TestCase):
         QUERY = "SELECT * from test_dataset:test_table"
         QUERY_JOB_RESOURCE = {
             "id": "{}:{}".format(self.PROJECT, JOB_ID),
-            "jobReference": {"projectId": self.PROJECT, "jobId": "query_job"},
+            "jobReference": {
+                "projectId": "job-based-proj",
+                "jobId": "query_job",
+                "location": "asia-northeast1",
+            },
             "state": "RUNNING",
             "configuration": {"query": {"query": QUERY}},
         }
@@ -3057,17 +3068,20 @@ class TestClient(unittest.TestCase):
         creds = _make_credentials()
         client = self._make_one(self.PROJECT, creds)
         conn = client._connection = make_connection(RESOURCE)
+        job_from_resource = QueryJob.from_api_repr(QUERY_JOB_RESOURCE, client)
 
-        job = client.cancel_job(JOB_ID)
+        job = client.cancel_job(job_from_resource)
 
         self.assertIsInstance(job, QueryJob)
         self.assertEqual(job.job_id, JOB_ID)
+        self.assertEqual(job.project, "job-based-proj")
+        self.assertEqual(job.location, "asia-northeast1")
         self.assertEqual(job.query, QUERY)
 
         conn.api_request.assert_called_once_with(
             method="POST",
-            path="/projects/PROJECT/jobs/query_job/cancel",
-            query_params={"projection": "full"},
+            path="/projects/job-based-proj/jobs/query_job/cancel",
+            query_params={"projection": "full", "location": "asia-northeast1"},
             timeout=None,
         )
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -2933,31 +2933,30 @@ class TestClient(unittest.TestCase):
         conn = client._connection = make_connection()
 
         with self.assertRaises(NotFound):
-            client.get_job(JOB_ID, project=OTHER_PROJECT, location=self.LOCATION)
+            client.get_job(JOB_ID, project=OTHER_PROJECT)
 
         conn.api_request.assert_called_once_with(
             method="GET",
             path="/projects/OTHER_PROJECT/jobs/NONESUCH",
-            query_params={"projection": "full", "location": self.LOCATION},
+            query_params={"projection": "full"},
             timeout=None,
         )
 
     def test_get_job_miss_w_client_location(self):
         from google.cloud.exceptions import NotFound
 
-        OTHER_PROJECT = "OTHER_PROJECT"
         JOB_ID = "NONESUCH"
         creds = _make_credentials()
-        client = self._make_one(self.PROJECT, creds, location=self.LOCATION)
+        client = self._make_one("client-proj", creds, location="client-loc")
         conn = client._connection = make_connection()
 
         with self.assertRaises(NotFound):
-            client.get_job(JOB_ID, project=OTHER_PROJECT)
+            client.get_job(JOB_ID)
 
         conn.api_request.assert_called_once_with(
             method="GET",
-            path="/projects/OTHER_PROJECT/jobs/NONESUCH",
-            query_params={"projection": "full", "location": self.LOCATION},
+            path="/projects/client-proj/jobs/NONESUCH",
+            query_params={"projection": "full", "location": "client-loc"},
             timeout=None,
         )
 
@@ -2972,7 +2971,7 @@ class TestClient(unittest.TestCase):
         ASYNC_QUERY_DATA = {
             "id": "{}:{}".format(self.PROJECT, JOB_ID),
             "jobReference": {
-                "projectId": "job-based-proj",
+                "projectId": "resource-proj",
                 "jobId": "query_job",
                 "location": "us-east1",
             },
@@ -2999,14 +2998,14 @@ class TestClient(unittest.TestCase):
 
         self.assertIsInstance(job, QueryJob)
         self.assertEqual(job.job_id, JOB_ID)
-        self.assertEqual(job.project, "job-based-proj")
+        self.assertEqual(job.project, "resource-proj")
         self.assertEqual(job.location, "us-east1")
         self.assertEqual(job.create_disposition, CreateDisposition.CREATE_IF_NEEDED)
         self.assertEqual(job.write_disposition, WriteDisposition.WRITE_TRUNCATE)
 
         conn.api_request.assert_called_once_with(
             method="GET",
-            path="/projects/job-based-proj/jobs/query_job",
+            path="/projects/resource-proj/jobs/query_job",
             query_params={"projection": "full", "location": "us-east1"},
             timeout=7.5,
         )


### PR DESCRIPTION
This allows one to more easily cancel or get updated metadata for an
existing job from the client class. Ensures that project ID and location
are correctly populated.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #616 🦕
