### PR TITLE
fix: consistent percents handling in DB API query

### DIFF
--- a/google/cloud/bigquery/dbapi/cursor.py
+++ b/google/cloud/bigquery/dbapi/cursor.py
@@ -389,7 +389,7 @@ def _format_operation_list(operation, parameters):
 
     try:
         return operation % tuple(formatted_params)
-    except TypeError as exc:
+    except (TypeError, ValueError) as exc:
         raise exceptions.ProgrammingError(exc)
 
 
@@ -419,7 +419,7 @@ def _format_operation_dict(operation, parameters):
 
     try:
         return operation % formatted_params
-    except KeyError as exc:
+    except (KeyError, ValueError) as exc:
         raise exceptions.ProgrammingError(exc)
 
 
@@ -441,7 +441,7 @@ def _format_operation(operation, parameters=None):
             ``parameters`` argument.
     """
     if parameters is None or len(parameters) == 0:
-        return operation
+        return operation.replace("%%", "%")  # Still do precents de-escaping.
 
     if isinstance(parameters, collections_abc.Mapping):
         return _format_operation_dict(operation, parameters)

--- a/google/cloud/bigquery/dbapi/cursor.py
+++ b/google/cloud/bigquery/dbapi/cursor.py
@@ -419,7 +419,7 @@ def _format_operation_dict(operation, parameters):
 
     try:
         return operation % formatted_params
-    except (KeyError, ValueError) as exc:
+    except (KeyError, ValueError, TypeError) as exc:
         raise exceptions.ProgrammingError(exc)
 
 

--- a/google/cloud/bigquery/dbapi/cursor.py
+++ b/google/cloud/bigquery/dbapi/cursor.py
@@ -441,7 +441,7 @@ def _format_operation(operation, parameters=None):
             ``parameters`` argument.
     """
     if parameters is None or len(parameters) == 0:
-        return operation.replace("%%", "%")  # Still do precents de-escaping.
+        return operation.replace("%%", "%")  # Still do percent de-escaping.
 
     if isinstance(parameters, collections_abc.Mapping):
         return _format_operation_dict(operation, parameters)

--- a/tests/unit/test_dbapi_cursor.py
+++ b/tests/unit/test_dbapi_cursor.py
@@ -633,6 +633,14 @@ class TestCursor(unittest.TestCase):
             {"somevalue-not-here": "hi", "othervalue": "world"},
         )
 
+    def test__format_operation_w_redundant_dict_key(self):
+        from google.cloud.bigquery.dbapi import cursor
+
+        formatted_operation = cursor._format_operation(
+            "SELECT %(somevalue)s;", {"somevalue": "foo", "value-not-used": "bar"}
+        )
+        self.assertEqual(formatted_operation, "SELECT @`somevalue`;")
+
     def test__format_operation_w_sequence(self):
         from google.cloud.bigquery.dbapi import cursor
 
@@ -652,8 +660,53 @@ class TestCursor(unittest.TestCase):
             ("hello",),
         )
 
+    def test__format_operation_w_too_long_sequence(self):
+        from google.cloud.bigquery import dbapi
+        from google.cloud.bigquery.dbapi import cursor
+
+        self.assertRaises(
+            dbapi.ProgrammingError,
+            cursor._format_operation,
+            "SELECT %s, %s;",
+            ("hello", "world", "everyone"),
+        )
+
     def test__format_operation_w_empty_dict(self):
         from google.cloud.bigquery.dbapi import cursor
 
         formatted_operation = cursor._format_operation("SELECT '%f'", {})
         self.assertEqual(formatted_operation, "SELECT '%f'")
+
+    def test__format_operation_wo_params_single_percent(self):
+        from google.cloud.bigquery.dbapi import cursor
+
+        formatted_operation = cursor._format_operation("SELECT '%'", {})
+        self.assertEqual(formatted_operation, "SELECT '%'")
+
+    def test__format_operation_wo_params_double_percents(self):
+        from google.cloud.bigquery.dbapi import cursor
+
+        formatted_operation = cursor._format_operation("SELECT '%%'", {})
+        self.assertEqual(formatted_operation, "SELECT '%'")
+
+    def test__format_operation_unescaped_percent_w_dict_param(self):
+        from google.cloud.bigquery import dbapi
+        from google.cloud.bigquery.dbapi import cursor
+
+        self.assertRaises(
+            dbapi.ProgrammingError,
+            cursor._format_operation,
+            "SELECT '100 %';",
+            {"foo": "bar"},
+        )
+
+    def test__format_operation_unescaped_percent_w_list_param(self):
+        from google.cloud.bigquery import dbapi
+        from google.cloud.bigquery.dbapi import cursor
+
+        self.assertRaises(
+            dbapi.ProgrammingError,
+            cursor._format_operation,
+            "SELECT '100 %';",
+            ["foo", "bar"],
+        )

--- a/tests/unit/test_dbapi_cursor.py
+++ b/tests/unit/test_dbapi_cursor.py
@@ -696,7 +696,7 @@ class TestCursor(unittest.TestCase):
         self.assertRaises(
             dbapi.ProgrammingError,
             cursor._format_operation,
-            "SELECT '100 %';",
+            "SELECT %(foo)s, '100 %';",
             {"foo": "bar"},
         )
 
@@ -707,6 +707,6 @@ class TestCursor(unittest.TestCase):
         self.assertRaises(
             dbapi.ProgrammingError,
             cursor._format_operation,
-            "SELECT '100 %';",
+            "SELECT %s, %s, '100 %';",
             ["foo", "bar"],
         )


### PR DESCRIPTION
Fixes #608.

Percents in the query string are now always de-escaped, regardless of whether any query parameters are passed or not.

In addition, misformatting placeholders that don't match parameter values now consistently raise `ProgrammingError`.

**PR checklist:**
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

