### PR TITLE
chore: add unit test nox session without extras installed

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -31,6 +31,7 @@ CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 # 'docfx' is excluded since it only needs to run in 'docs-presubmit'
 nox.options.sessions = [
+    "unit_noextras",
     "unit",
     "system",
     "snippets",
@@ -42,7 +43,7 @@ nox.options.sessions = [
 ]
 
 
-def default(session):
+def default(session, install_extras=True):
     """Default unit test session.
 
     This is intended to be run **without** an interpreter set, so
@@ -65,7 +66,8 @@ def default(session):
         constraints_path,
     )
 
-    session.install("-e", ".[all]", "-c", constraints_path)
+    install_target = ".[all]" if install_extras else "."
+    session.install("-e", install_target, "-c", constraints_path)
 
     session.install("ipython", "-c", constraints_path)
 
@@ -88,6 +90,12 @@ def default(session):
 def unit(session):
     """Run the unit test suite."""
     default(session)
+
+
+@nox.session(python=UNIT_TEST_PYTHON_VERSIONS[-1])
+def unit_noextras(session):
+    """Run the unit test suite."""
+    default(session, install_extras=False)
 
 
 @nox.session(python=SYSTEM_TEST_PYTHON_VERSIONS)

--- a/tests/unit/test__pandas_helpers.py
+++ b/tests/unit/test__pandas_helpers.py
@@ -1464,6 +1464,7 @@ def test_download_dataframe_row_iterator_dict_sequence_schema(module_under_test)
         result = next(results_gen)
 
 
+@pytest.mark.skipif(pandas is None, reason="Requires `pandas`")
 def test_table_data_listpage_to_dataframe_skips_stop_iteration(module_under_test):
     dataframe = module_under_test._row_iterator_page_to_dataframe([], [], {})
     assert isinstance(dataframe, pandas.DataFrame)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -65,7 +65,12 @@ from test_utils.imports import maybe_fail_import
 from tests.unit.helpers import make_connection
 
 PANDAS_MINIUM_VERSION = pkg_resources.parse_version("1.0.0")
-PANDAS_INSTALLED_VERSION = pkg_resources.get_distribution("pandas").parsed_version
+
+if pandas is not None:
+    PANDAS_INSTALLED_VERSION = pkg_resources.get_distribution("pandas").parsed_version
+else:
+    # Set to less than MIN version.
+    PANDAS_INSTALLED_VERSION = pkg_resources.parse_version("0.0.0")
 
 
 def _make_credentials():


### PR DESCRIPTION
Closes #621. 🦕

The new check revealed a few cases where not installing extras caused some of the tests to fail, but that was due to test setup, and not the codebase itself.

**PR checklist:**
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


