### PR TITLE
chore: use 3.8 for blacken session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -103,6 +103,10 @@ def unit_noextras(session):
 @nox.session(python=DEFAULT_PYTHON_VERSION)
 def pytype(session):
     """Run type checks."""
+    # An indirect dependecy attrs==21.1.0 breaks the check, and installing a less
+    # recent version avoids the error until a possibly better fix is found.
+    # https://github.com/googleapis/python-bigquery/issues/655
+    session.install("attrs==20.3.0")
     session.install("-e", ".[all]")
     session.install("ipython")
     session.install(PYTYPE_VERSION)

--- a/noxfile.py
+++ b/noxfile.py
@@ -257,15 +257,12 @@ def lint_setup_py(session):
     session.run("python", "setup.py", "check", "--restructuredtext", "--strict")
 
 
-@nox.session(python="3.6")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def blacken(session):
     """Run black.
     Format code to uniform standard.
-
-    This currently uses Python 3.6 due to the automated Kokoro run of synthtool.
-    That run uses an image that doesn't have 3.6 installed. Before updating this
-    check the state of the `gcp_ubuntu_config` we use for that Kokoro run.
     """
+
     session.install(BLACK_VERSION)
     session.run("black", *BLACK_PATHS)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -253,15 +253,12 @@ def lint_setup_py(session):
     session.run("python", "setup.py", "check", "--restructuredtext", "--strict")
 
 
-@nox.session(python="3.6")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def blacken(session):
     """Run black.
     Format code to uniform standard.
-
-    This currently uses Python 3.6 due to the automated Kokoro run of synthtool.
-    That run uses an image that doesn't have 3.6 installed. Before updating this
-    check the state of the `gcp_ubuntu_config` we use for that Kokoro run.
     """
+
     session.install(BLACK_VERSION)
     session.run("black", *BLACK_PATHS)
 


### PR DESCRIPTION
The Autosynth build now has 3.8: https://github.com/googleapis/synthtool/commit/fd33d7df9ecfc79cc6dbe552b497a4fb36f2e635#diff-f80f936e0eac73417c05535c764a44906afd70a37096ea3c58934a9f6f1e7fcd

Should fix unexpected style in #651 
