### PR TITLE
feat: add max_results parameter to some of the QueryJob methods

### DIFF
--- a/google/cloud/bigquery/_tqdm_helpers.py
+++ b/google/cloud/bigquery/_tqdm_helpers.py
@@ -17,7 +17,7 @@
 import concurrent.futures
 import time
 import typing
-from typing import Any, Optional
+from typing import Optional
 import warnings
 
 try:
@@ -27,6 +27,7 @@ except ImportError:  # pragma: NO COVER
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.bigquery import QueryJob
+    from google.cloud.bigquery.table import RowIterator
 
 _NO_TQDM_ERROR = (
     "A progress bar was requested, but there was an error loading the tqdm "
@@ -62,7 +63,7 @@ def wait_for_query(
     query_job: "QueryJob",
     progress_bar_type: Optional[str] = None,
     max_results: Optional[int] = None,
-) -> Any:
+) -> "RowIterator":
     """Return query result and display a progress bar while the query running, if tqdm is installed.
 
     Args:

--- a/google/cloud/bigquery/_tqdm_helpers.py
+++ b/google/cloud/bigquery/_tqdm_helpers.py
@@ -16,12 +16,19 @@
 
 import concurrent.futures
 import time
+import typing
+from typing import Optional, Union
 import warnings
 
 try:
     import tqdm
 except ImportError:  # pragma: NO COVER
     tqdm = None
+
+if typing.TYPE_CHECKING:  # pragma: NO COVER
+    from google.cloud.bigquery import QueryJob
+    from google.cloud.bigquery.table import _EmptyRowIterator
+    from google.cloud.bigquery.table import RowIterator
 
 _NO_TQDM_ERROR = (
     "A progress bar was requested, but there was an error loading the tqdm "
@@ -32,7 +39,7 @@ _PROGRESS_BAR_UPDATE_INTERVAL = 0.5
 
 
 def get_progress_bar(progress_bar_type, description, total, unit):
-    """Construct a tqdm progress bar object, if tqdm is     ."""
+    """Construct a tqdm progress bar object, if tqdm is installed."""
     if tqdm is None:
         if progress_bar_type is not None:
             warnings.warn(_NO_TQDM_ERROR, UserWarning, stacklevel=3)
@@ -53,16 +60,34 @@ def get_progress_bar(progress_bar_type, description, total, unit):
     return None
 
 
-def wait_for_query(query_job, progress_bar_type=None):
-    """Return query result and display a progress bar while the query running, if tqdm is installed."""
+def wait_for_query(
+    query_job: "QueryJob",
+    progress_bar_type: Optional[str] = None,
+    max_results: Optional[int] = None,
+) -> Union["RowIterator", "_EmptyRowIterator"]:
+    """Return query result and display a progress bar while the query running, if tqdm is installed.
+
+    Args:
+        query_job:
+            The job representing the execution of the query on the server.
+        progress_bar_type:
+            The type of progress bar to use to show query progress.
+        max_results:
+            The maximum number of rows the row iterator should return.
+
+    Returns:
+        A row iterator over the query results.
+    """
     default_total = 1
     current_stage = None
     start_time = time.time()
+
     progress_bar = get_progress_bar(
         progress_bar_type, "Query is running", default_total, "query"
     )
     if progress_bar is None:
-        return query_job.result()
+        return query_job.result(max_results=max_results)
+
     i = 0
     while True:
         if query_job.query_plan:
@@ -75,7 +100,9 @@ def wait_for_query(query_job, progress_bar_type=None):
                 ),
             )
         try:
-            query_result = query_job.result(timeout=_PROGRESS_BAR_UPDATE_INTERVAL)
+            query_result = query_job.result(
+                timeout=_PROGRESS_BAR_UPDATE_INTERVAL, max_results=max_results
+            )
             progress_bar.update(default_total)
             progress_bar.set_description(
                 "Query complete after {:0.2f}s".format(time.time() - start_time),
@@ -89,5 +116,6 @@ def wait_for_query(query_job, progress_bar_type=None):
                         progress_bar.update(i + 1)
                         i += 1
             continue
+
     progress_bar.close()
     return query_result

--- a/google/cloud/bigquery/_tqdm_helpers.py
+++ b/google/cloud/bigquery/_tqdm_helpers.py
@@ -17,7 +17,7 @@
 import concurrent.futures
 import time
 import typing
-from typing import Optional, Union
+from typing import Any, Optional
 import warnings
 
 try:
@@ -27,8 +27,6 @@ except ImportError:  # pragma: NO COVER
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.bigquery import QueryJob
-    from google.cloud.bigquery.table import _EmptyRowIterator
-    from google.cloud.bigquery.table import RowIterator
 
 _NO_TQDM_ERROR = (
     "A progress bar was requested, but there was an error loading the tqdm "
@@ -64,7 +62,7 @@ def wait_for_query(
     query_job: "QueryJob",
     progress_bar_type: Optional[str] = None,
     max_results: Optional[int] = None,
-) -> Union["RowIterator", "_EmptyRowIterator"]:
+) -> Any:
     """Return query result and display a progress bar while the query running, if tqdm is installed.
 
     Args:

--- a/google/cloud/bigquery/job/query.py
+++ b/google/cloud/bigquery/job/query.py
@@ -1300,12 +1300,14 @@ class QueryJob(_AsyncJob):
         return rows
 
     # If changing the signature of this method, make sure to apply the same
-    # changes to table.RowIterator.to_arrow()
+    # changes to table.RowIterator.to_arrow(), except for the max_results parameter
+    # that should only exist here in the QueryJob method.
     def to_arrow(
         self,
         progress_bar_type: str = None,
         bqstorage_client: "bigquery_storage.BigQueryReadClient" = None,
         create_bqstorage_client: bool = True,
+        max_results: Optional[int] = None,
     ) -> "pyarrow.Table":
         """[Beta] Create a class:`pyarrow.Table` by loading all pages of a
         table or query.
@@ -1349,6 +1351,11 @@ class QueryJob(_AsyncJob):
 
                 ..versionadded:: 1.24.0
 
+            max_results (Optional[int]):
+                Maximum number of rows to include in the result. No limit by default.
+
+                ..versionadded:: 2.21.0
+
         Returns:
             pyarrow.Table
                 A :class:`pyarrow.Table` populated with row data and column
@@ -1361,7 +1368,7 @@ class QueryJob(_AsyncJob):
 
         ..versionadded:: 1.17.0
         """
-        query_result = wait_for_query(self, progress_bar_type)
+        query_result = wait_for_query(self, progress_bar_type, max_results=max_results)
         return query_result.to_arrow(
             progress_bar_type=progress_bar_type,
             bqstorage_client=bqstorage_client,
@@ -1369,7 +1376,8 @@ class QueryJob(_AsyncJob):
         )
 
     # If changing the signature of this method, make sure to apply the same
-    # changes to table.RowIterator.to_dataframe()
+    # changes to table.RowIterator.to_dataframe(), except for the max_results parameter
+    # that should only exist here in the QueryJob method.
     def to_dataframe(
         self,
         bqstorage_client: "bigquery_storage.BigQueryReadClient" = None,
@@ -1377,6 +1385,7 @@ class QueryJob(_AsyncJob):
         progress_bar_type: str = None,
         create_bqstorage_client: bool = True,
         date_as_object: bool = True,
+        max_results: Optional[int] = None,
     ) -> "pandas.DataFrame":
         """Return a pandas DataFrame from a QueryJob
 
@@ -1423,6 +1432,11 @@ class QueryJob(_AsyncJob):
 
                 ..versionadded:: 1.26.0
 
+            max_results (Optional[int]):
+                Maximum number of rows to include in the result. No limit by default.
+
+                ..versionadded:: 2.21.0
+
         Returns:
             A :class:`~pandas.DataFrame` populated with row data and column
             headers from the query results. The column headers are derived
@@ -1431,7 +1445,7 @@ class QueryJob(_AsyncJob):
         Raises:
             ValueError: If the `pandas` library cannot be imported.
         """
-        query_result = wait_for_query(self, progress_bar_type)
+        query_result = wait_for_query(self, progress_bar_type, max_results=max_results)
         return query_result.to_dataframe(
             bqstorage_client=bqstorage_client,
             dtypes=dtypes,

--- a/tests/unit/test_signature_compatibility.py
+++ b/tests/unit/test_signature_compatibility.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import OrderedDict
 import inspect
 
 import pytest
@@ -32,12 +33,30 @@ def row_iterator_class():
 
 
 def test_to_arrow_method_signatures_match(query_job_class, row_iterator_class):
-    sig = inspect.signature(query_job_class.to_arrow)
-    sig2 = inspect.signature(row_iterator_class.to_arrow)
-    assert sig == sig2
+    query_job_sig = inspect.signature(query_job_class.to_arrow)
+    iterator_sig = inspect.signature(row_iterator_class.to_arrow)
+
+    assert "max_results" in query_job_sig.parameters
+
+    # Compare the signatures while ignoring the max_results parameter, which is
+    # specific to the method on QueryJob.
+    params = OrderedDict(query_job_sig.parameters)
+    del params["max_results"]
+    query_job_sig = query_job_sig.replace(parameters=params.values())
+
+    assert query_job_sig == iterator_sig
 
 
 def test_to_dataframe_method_signatures_match(query_job_class, row_iterator_class):
-    sig = inspect.signature(query_job_class.to_dataframe)
-    sig2 = inspect.signature(row_iterator_class.to_dataframe)
-    assert sig == sig2
+    query_job_sig = inspect.signature(query_job_class.to_dataframe)
+    iterator_sig = inspect.signature(row_iterator_class.to_dataframe)
+
+    assert "max_results" in query_job_sig.parameters
+
+    # Compare the signatures while ignoring the max_results parameter, which is
+    # specific to the method on QueryJob.
+    params = OrderedDict(query_job_sig.parameters)
+    del params["max_results"]
+    query_job_sig = query_job_sig.replace(parameters=params.values())
+
+    assert query_job_sig == iterator_sig

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -1571,6 +1571,25 @@ class Test_EmptyRowIterator(unittest.TestCase):
         self.assertIsInstance(df, pandas.DataFrame)
         self.assertEqual(len(df), 0)  # verify the number of rows
 
+    @mock.patch("google.cloud.bigquery.table.pandas", new=None)
+    def test_to_dataframe_iterable_error_if_pandas_is_none(self):
+        row_iterator = self._make_one()
+        with self.assertRaises(ValueError):
+            row_iterator.to_dataframe_iterable()
+
+    @unittest.skipIf(pandas is None, "Requires `pandas`")
+    def test_to_dataframe_iterable(self):
+        row_iterator = self._make_one()
+        df_iter = row_iterator.to_dataframe_iterable()
+
+        result = list(df_iter)
+
+        self.assertEqual(len(result), 1)
+        df = result[0]
+        self.assertIsInstance(df, pandas.DataFrame)
+        self.assertEqual(len(df), 0)  # Verify the number of rows.
+        self.assertEqual(len(df.columns), 0)
+
 
 class TestRowIterator(unittest.TestCase):
     def _class_under_test(self):


### PR DESCRIPTION
Closes #296.

It is now possible to cap the number of result rows returned when invoking `to_dataframe()` or `to_arrow()` method on a `QueryJob` instance.

**PR checklist:**:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

