### PR TITLE
feat: enable unsetting policy tags on schema fields

### DIFF
--- a/google/cloud/bigquery/schema.py
+++ b/google/cloud/bigquery/schema.py
@@ -105,7 +105,11 @@ class SchemaField(object):
         if max_length is not _DEFAULT_VALUE:
             self._properties["maxLength"] = max_length
         self._fields = tuple(fields)
-        self._policy_tags = policy_tags
+
+        if policy_tags is None:
+            self._policy_tags = PolicyTagList()
+        else:
+            self._policy_tags = policy_tags
 
     @staticmethod
     def __get_int(api_repr, name):
@@ -201,7 +205,7 @@ class SchemaField(object):
 
     @property
     def policy_tags(self):
-        """Optional[google.cloud.bigquery.schema.PolicyTagList]: Policy tag list
+        """google.cloud.bigquery.schema.PolicyTagList: Policy tag list
         definition for this field.
         """
         return self._policy_tags
@@ -219,9 +223,8 @@ class SchemaField(object):
         if self.field_type.upper() in _STRUCT_TYPES:
             answer["fields"] = [f.to_api_repr() for f in self.fields]
 
-        # If this contains a policy tag definition, include that as well:
-        if self.policy_tags is not None:
-            answer["policyTags"] = self.policy_tags.to_api_repr()
+        # Also include policy tag definition, even if empty.
+        answer["policyTags"] = self.policy_tags.to_api_repr()
 
         # Done; return the serialized dictionary.
         return answer
@@ -251,7 +254,7 @@ class SchemaField(object):
             self.mode.upper(),  # pytype: disable=attribute-error
             self.description,
             self._fields,
-            self._policy_tags,
+            tuple(sorted(self._policy_tags.names)),
         )
 
     def to_standard_sql(self) -> types.StandardSqlField:

--- a/tests/unit/job/test_load_config.py
+++ b/tests/unit/job/test_load_config.py
@@ -434,11 +434,13 @@ class TestLoadJobConfig(_Base):
             "name": "full_name",
             "type": "STRING",
             "mode": "REQUIRED",
+            "policyTags": {"names": []},
         }
         age_repr = {
             "name": "age",
             "type": "INTEGER",
             "mode": "REQUIRED",
+            "policyTags": {"names": []},
         }
         self.assertEqual(
             config._properties["load"]["schema"], {"fields": [full_name_repr, age_repr]}
@@ -451,11 +453,13 @@ class TestLoadJobConfig(_Base):
             "name": "full_name",
             "type": "STRING",
             "mode": "REQUIRED",
+            "policyTags": {"names": []},
         }
         age_repr = {
             "name": "age",
             "type": "INTEGER",
             "mode": "REQUIRED",
+            "policyTags": {"names": []},
         }
         schema = [full_name_repr, age_repr]
         config.schema = schema

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -7718,18 +7718,21 @@ class TestClientUpload(object):
                 "description": "quarter",
                 "mode": "REQUIRED",
                 "name": "qtr",
+                "policyTags": {"names": []},
                 "type": "STRING",
             },
             {
                 "description": "sales representative",
                 "mode": "NULLABLE",
                 "name": "rep",
+                "policyTags": {"names": []},
                 "type": "STRING",
             },
             {
                 "description": "total sales",
                 "mode": "NULLABLE",
                 "name": "sales",
+                "policyTags": {"names": []},
                 "type": "FLOAT",
             },
         ]
@@ -7762,18 +7765,21 @@ class TestClientUpload(object):
                 "description": "quarter",
                 "mode": "REQUIRED",
                 "name": "qtr",
+                "policyTags": {"names": []},
                 "type": "STRING",
             },
             {
                 "description": "sales representative",
                 "mode": "NULLABLE",
                 "name": "rep",
+                "policyTags": {"names": []},
                 "type": "STRING",
             },
             {
                 "description": "total sales",
                 "mode": "NULLABLE",
                 "name": "sales",
+                "policyTags": {"names": []},
                 "type": "FLOAT",
             },
         ]

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1019,8 +1019,18 @@ class TestClient(unittest.TestCase):
             {
                 "schema": {
                     "fields": [
-                        {"name": "full_name", "type": "STRING", "mode": "REQUIRED"},
-                        {"name": "age", "type": "INTEGER", "mode": "REQUIRED"},
+                        {
+                            "name": "full_name",
+                            "type": "STRING",
+                            "mode": "REQUIRED",
+                            "policyTags": {"names": []},
+                        },
+                        {
+                            "name": "age",
+                            "type": "INTEGER",
+                            "mode": "REQUIRED",
+                            "policyTags": {"names": []},
+                        },
                     ]
                 },
                 "view": {"query": query},
@@ -1054,8 +1064,18 @@ class TestClient(unittest.TestCase):
                 },
                 "schema": {
                     "fields": [
-                        {"name": "full_name", "type": "STRING", "mode": "REQUIRED"},
-                        {"name": "age", "type": "INTEGER", "mode": "REQUIRED"},
+                        {
+                            "name": "full_name",
+                            "type": "STRING",
+                            "mode": "REQUIRED",
+                            "policyTags": {"names": []},
+                        },
+                        {
+                            "name": "age",
+                            "type": "INTEGER",
+                            "mode": "REQUIRED",
+                            "policyTags": {"names": []},
+                        },
                     ]
                 },
                 "view": {"query": query, "useLegacySql": False},
@@ -2000,12 +2020,14 @@ class TestClient(unittest.TestCase):
                             "type": "STRING",
                             "mode": "REQUIRED",
                             "description": None,
+                            "policyTags": {"names": []},
                         },
                         {
                             "name": "age",
                             "type": "INTEGER",
                             "mode": "REQUIRED",
                             "description": "New field description",
+                            "policyTags": {"names": []},
                         },
                     ]
                 },
@@ -2047,12 +2069,14 @@ class TestClient(unittest.TestCase):
                         "type": "STRING",
                         "mode": "REQUIRED",
                         "description": None,
+                        "policyTags": {"names": []},
                     },
                     {
                         "name": "age",
                         "type": "INTEGER",
                         "mode": "REQUIRED",
                         "description": "New field description",
+                        "policyTags": {"names": []},
                     },
                 ]
             },
@@ -2173,14 +2197,21 @@ class TestClient(unittest.TestCase):
                     "type": "STRING",
                     "mode": "REQUIRED",
                     "description": None,
+                    "policyTags": {"names": []},
                 },
                 {
                     "name": "age",
                     "type": "INTEGER",
                     "mode": "REQUIRED",
                     "description": "this is a column",
+                    "policyTags": {"names": []},
                 },
-                {"name": "country", "type": "STRING", "mode": "NULLABLE"},
+                {
+                    "name": "country",
+                    "type": "STRING",
+                    "mode": "NULLABLE",
+                    "policyTags": {"names": []},
+                },
             ]
         }
         schema = [
@@ -6516,10 +6547,10 @@ class TestClientUpload(object):
             assert field["type"] == table_field.field_type
             assert field["mode"] == table_field.mode
             assert len(field.get("fields", [])) == len(table_field.fields)
+            assert field["policyTags"]["names"] == []
             # Omit unnecessary fields when they come from getting the table
             # (not passed in via job_config)
             assert "description" not in field
-            assert "policyTags" not in field
 
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")

--- a/tests/unit/test_external_config.py
+++ b/tests/unit/test_external_config.py
@@ -78,7 +78,14 @@ class TestExternalConfig(unittest.TestCase):
         ec.schema = [schema.SchemaField("full_name", "STRING", mode="REQUIRED")]
 
         exp_schema = {
-            "fields": [{"name": "full_name", "type": "STRING", "mode": "REQUIRED"}]
+            "fields": [
+                {
+                    "name": "full_name",
+                    "type": "STRING",
+                    "mode": "REQUIRED",
+                    "policyTags": {"names": []},
+                }
+            ]
         }
         got_resource = ec.to_api_repr()
         exp_resource = {

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from google.cloud.bigquery.schema import PolicyTagList
 import unittest
 
 import mock
@@ -41,6 +42,7 @@ class TestSchemaField(unittest.TestCase):
         self.assertEqual(field.mode, "NULLABLE")
         self.assertIsNone(field.description)
         self.assertEqual(field.fields, ())
+        self.assertEqual(field.policy_tags, PolicyTagList())
 
     def test_constructor_explicit(self):
         field = self._make_one("test", "STRING", mode="REQUIRED", description="Testing")
@@ -104,10 +106,18 @@ class TestSchemaField(unittest.TestCase):
             self.assertEqual(
                 field.to_api_repr(),
                 {
-                    "fields": [{"mode": "NULLABLE", "name": "bar", "type": "INTEGER"}],
+                    "fields": [
+                        {
+                            "mode": "NULLABLE",
+                            "name": "bar",
+                            "type": "INTEGER",
+                            "policyTags": {"names": []},
+                        }
+                    ],
                     "mode": "REQUIRED",
                     "name": "foo",
                     "type": record_type,
+                    "policyTags": {"names": []},
                 },
             )
 
@@ -404,6 +414,23 @@ class TestSchemaField(unittest.TestCase):
         other = self._make_one("test", "RECORD", fields=[sub1, sub2])
         self.assertEqual(field, other)
 
+    def test___eq___hit_w_policy_tags(self):
+        field = self._make_one(
+            "test",
+            "STRING",
+            mode="REQUIRED",
+            description="Testing",
+            policy_tags=PolicyTagList(names=["foo", "bar"]),
+        )
+        other = self._make_one(
+            "test",
+            "STRING",
+            mode="REQUIRED",
+            description="Testing",
+            policy_tags=PolicyTagList(names=["bar", "foo"]),
+        )
+        self.assertEqual(field, other)  # Policy tags order does not matter.
+
     def test___ne___wrong_type(self):
         field = self._make_one("toast", "INTEGER")
         other = object()
@@ -426,6 +453,23 @@ class TestSchemaField(unittest.TestCase):
         )
         self.assertNotEqual(field1, field2)
 
+    def test___ne___different_policy_tags(self):
+        field = self._make_one(
+            "test",
+            "STRING",
+            mode="REQUIRED",
+            description="Testing",
+            policy_tags=PolicyTagList(names=["foo", "bar"]),
+        )
+        other = self._make_one(
+            "test",
+            "STRING",
+            mode="REQUIRED",
+            description="Testing",
+            policy_tags=PolicyTagList(names=["foo", "baz"]),
+        )
+        self.assertNotEqual(field, other)
+
     def test___hash__set_equality(self):
         sub1 = self._make_one("sub1", "STRING")
         sub2 = self._make_one("sub2", "STRING")
@@ -446,7 +490,7 @@ class TestSchemaField(unittest.TestCase):
 
     def test___repr__(self):
         field1 = self._make_one("field1", "STRING")
-        expected = "SchemaField('field1', 'STRING', 'NULLABLE', None, (), None)"
+        expected = "SchemaField('field1', 'STRING', 'NULLABLE', None, (), ())"
         self.assertEqual(repr(field1), expected)
 
 
@@ -524,10 +568,22 @@ class Test_build_schema_resource(unittest.TestCase, _SchemaBase):
         resource = self._call_fut([full_name, age])
         self.assertEqual(len(resource), 2)
         self.assertEqual(
-            resource[0], {"name": "full_name", "type": "STRING", "mode": "REQUIRED"},
+            resource[0],
+            {
+                "name": "full_name",
+                "type": "STRING",
+                "mode": "REQUIRED",
+                "policyTags": {"names": []},
+            },
         )
         self.assertEqual(
-            resource[1], {"name": "age", "type": "INTEGER", "mode": "REQUIRED"}
+            resource[1],
+            {
+                "name": "age",
+                "type": "INTEGER",
+                "mode": "REQUIRED",
+                "policyTags": {"names": []},
+            },
         )
 
     def test_w_description(self):
@@ -553,11 +609,18 @@ class Test_build_schema_resource(unittest.TestCase, _SchemaBase):
                 "type": "STRING",
                 "mode": "REQUIRED",
                 "description": DESCRIPTION,
+                "policyTags": {"names": []},
             },
         )
         self.assertEqual(
             resource[1],
-            {"name": "age", "type": "INTEGER", "mode": "REQUIRED", "description": None},
+            {
+                "name": "age",
+                "type": "INTEGER",
+                "mode": "REQUIRED",
+                "description": None,
+                "policyTags": {"names": []},
+            },
         )
 
     def test_w_subfields(self):
@@ -572,7 +635,13 @@ class Test_build_schema_resource(unittest.TestCase, _SchemaBase):
         resource = self._call_fut([full_name, phone])
         self.assertEqual(len(resource), 2)
         self.assertEqual(
-            resource[0], {"name": "full_name", "type": "STRING", "mode": "REQUIRED"},
+            resource[0],
+            {
+                "name": "full_name",
+                "type": "STRING",
+                "mode": "REQUIRED",
+                "policyTags": {"names": []},
+            },
         )
         self.assertEqual(
             resource[1],
@@ -580,9 +649,20 @@ class Test_build_schema_resource(unittest.TestCase, _SchemaBase):
                 "name": "phone",
                 "type": "RECORD",
                 "mode": "REPEATED",
+                "policyTags": {"names": []},
                 "fields": [
-                    {"name": "type", "type": "STRING", "mode": "REQUIRED"},
-                    {"name": "number", "type": "STRING", "mode": "REQUIRED"},
+                    {
+                        "name": "type",
+                        "type": "STRING",
+                        "mode": "REQUIRED",
+                        "policyTags": {"names": []},
+                    },
+                    {
+                        "name": "number",
+                        "type": "STRING",
+                        "mode": "REQUIRED",
+                        "policyTags": {"names": []},
+                    },
                 ],
             },
         )
@@ -794,43 +874,83 @@ def test_from_api_repr_parameterized(api, expect, key2):
     [
         (
             dict(name="n", field_type="NUMERIC"),
-            dict(name="n", type="NUMERIC", mode="NULLABLE"),
+            dict(name="n", type="NUMERIC", mode="NULLABLE", policyTags={"names": []}),
         ),
         (
             dict(name="n", field_type="NUMERIC", precision=9),
-            dict(name="n", type="NUMERIC", mode="NULLABLE", precision=9),
+            dict(
+                name="n",
+                type="NUMERIC",
+                mode="NULLABLE",
+                precision=9,
+                policyTags={"names": []},
+            ),
         ),
         (
             dict(name="n", field_type="NUMERIC", precision=9, scale=2),
-            dict(name="n", type="NUMERIC", mode="NULLABLE", precision=9, scale=2),
+            dict(
+                name="n",
+                type="NUMERIC",
+                mode="NULLABLE",
+                precision=9,
+                scale=2,
+                policyTags={"names": []},
+            ),
         ),
         (
             dict(name="n", field_type="BIGNUMERIC"),
-            dict(name="n", type="BIGNUMERIC", mode="NULLABLE"),
+            dict(
+                name="n", type="BIGNUMERIC", mode="NULLABLE", policyTags={"names": []}
+            ),
         ),
         (
             dict(name="n", field_type="BIGNUMERIC", precision=40),
-            dict(name="n", type="BIGNUMERIC", mode="NULLABLE", precision=40),
+            dict(
+                name="n",
+                type="BIGNUMERIC",
+                mode="NULLABLE",
+                precision=40,
+                policyTags={"names": []},
+            ),
         ),
         (
             dict(name="n", field_type="BIGNUMERIC", precision=40, scale=2),
-            dict(name="n", type="BIGNUMERIC", mode="NULLABLE", precision=40, scale=2),
+            dict(
+                name="n",
+                type="BIGNUMERIC",
+                mode="NULLABLE",
+                precision=40,
+                scale=2,
+                policyTags={"names": []},
+            ),
         ),
         (
             dict(name="n", field_type="STRING"),
-            dict(name="n", type="STRING", mode="NULLABLE"),
+            dict(name="n", type="STRING", mode="NULLABLE", policyTags={"names": []}),
         ),
         (
             dict(name="n", field_type="STRING", max_length=9),
-            dict(name="n", type="STRING", mode="NULLABLE", maxLength=9),
+            dict(
+                name="n",
+                type="STRING",
+                mode="NULLABLE",
+                maxLength=9,
+                policyTags={"names": []},
+            ),
         ),
         (
             dict(name="n", field_type="BYTES"),
-            dict(name="n", type="BYTES", mode="NULLABLE"),
+            dict(name="n", type="BYTES", mode="NULLABLE", policyTags={"names": []}),
         ),
         (
             dict(name="n", field_type="BYTES", max_length=9),
-            dict(name="n", type="BYTES", mode="NULLABLE", maxLength=9),
+            dict(
+                name="n",
+                type="BYTES",
+                mode="NULLABLE",
+                maxLength=9,
+                policyTags={"names": []},
+            ),
         ),
     ],
 )

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -117,7 +117,6 @@ class TestSchemaField(unittest.TestCase):
                     "mode": "REQUIRED",
                     "name": "foo",
                     "type": record_type,
-                    "policyTags": {"names": []},
                 },
             )
 
@@ -649,7 +648,6 @@ class Test_build_schema_resource(unittest.TestCase, _SchemaBase):
                 "name": "phone",
                 "type": "RECORD",
                 "mode": "REPEATED",
-                "policyTags": {"names": []},
                 "fields": [
                     {
                         "name": "type",


### PR DESCRIPTION
Closes #558.

This PR enables unsetting policy tags on schema fields.

(FWIW, it it already possible to unset the description, this PR just includes that detail in one of the system tests)

**PR checklist:**
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

