### PR TITLE
chore: pin sphinx plugin version to working one

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -300,7 +300,7 @@ def docfx(session):
 
     session.install("-e", ".")
     session.install(
-        "sphinx==4.0.1", "alabaster", "recommonmark", "gcp-sphinx-docfx-yaml"
+        "sphinx==4.0.1", "alabaster", "recommonmark", "gcp-sphinx-docfx-yaml==0.2.0"
     )
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)


### PR DESCRIPTION
There's an issue with the current `gcp-sphinx-docfx-yaml` version failing for the following text:

```
        """Union[int, None]: Expiration time in milliseconds for a partition.

        If :attr:`partition_expiration` is set and :attr:`type_` is
        not set, :attr:`type_` will default to
        :attr:`~google.cloud.bigquery.table.TimePartitioningType.DAY`.
        """
```
which gets converted to
```
Union[int, None]: Expiration time in milliseconds for a partition.


If <xref:partition_expiration> is set and <xref:type_> is
not set, <xref:type_> will default to
<xref:google.cloud.bigquery.table.TimePartitioningType.DAY>.
```
which fails on the plugin because it thinks `<xref:type_>` should be a token it needs to process. The docstring is not malformed, the plugin needs additional work.

I'll have a fix for this by the end of the day, but should you need to submit PRs then please merge this one to have yourself unblocked!

Unblocks #698 🦕
