### PR TITLE
fix: require grpcio >= 1.38.1 to prevent a possible crash

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ description = "Google BigQuery API client library"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
+    "grpcio >= 1.38.1, < 2.0dev",  # https://github.com/googleapis/python-bigquery/issues/695
     "google-api-core[grpc] >= 1.29.0, < 2.0.0dev",
     "proto-plus >= 1.10.0",
     "google-cloud-core >= 1.4.1, < 2.0dev",
@@ -46,7 +47,7 @@ extras = {
         # See: https://github.com/googleapis/python-bigquery/issues/83 The
         # grpc.Channel.close() method isn't added until 1.32.0.
         # https://github.com/grpc/grpc/pull/15254
-        "grpcio >= 1.32.0, < 2.0dev",
+        "grpcio >= 1.38.1, < 2.0dev",
         "pyarrow >= 1.0.0, < 5.0dev",
     ],
     "pandas": ["pandas>=0.23.0", "pyarrow >= 1.0.0, < 5.0dev"],

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -9,7 +9,7 @@ google-api-core==1.29.0
 google-cloud-bigquery-storage==2.0.0
 google-cloud-core==1.4.1
 google-resumable-media==0.6.0
-grpcio==1.32.0
+grpcio==1.38.1
 opentelemetry-api==0.11b0
 opentelemetry-instrumentation==0.11b0
 opentelemetry-sdk==0.11b0


### PR DESCRIPTION
Fixes #695.

See the issue [comment](https://github.com/googleapis/python-bigquery/issues/695#issuecomment-869767605) for more info.


**PR checklist:**
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

