### PR TITLE
fix: inserting non-finite floats with insert_rows()

### DIFF
--- a/google/cloud/bigquery/_helpers.py
+++ b/google/cloud/bigquery/_helpers.py
@@ -17,6 +17,7 @@
 import base64
 import datetime
 import decimal
+import math
 import re
 
 from google.cloud._helpers import UTC
@@ -305,7 +306,12 @@ def _int_to_json(value):
 
 def _float_to_json(value):
     """Coerce 'value' to an JSON-compatible representation."""
-    return value if value is None else float(value)
+    if value is None:
+        return None
+    elif math.isnan(value) or math.isinf(value):
+        return str(value)
+    else:
+        return float(value)
 
 
 def _decimal_to_json(value):

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -656,8 +656,23 @@ class Test_float_to_json(unittest.TestCase):
 
         return _float_to_json(value)
 
+    def test_w_none(self):
+        self.assertEqual(self._call_fut(None), None)
+
     def test_w_float(self):
         self.assertEqual(self._call_fut(1.23), 1.23)
+
+    def test_w_nan(self):
+        result = self._call_fut(float("nan"))
+        self.assertEqual(result.lower(), "nan")
+
+    def test_w_infinity(self):
+        result = self._call_fut(float("inf"))
+        self.assertEqual(result.lower(), "inf")
+
+    def test_w_negative_infinity(self):
+        result = self._call_fut(float("-inf"))
+        self.assertEqual(result.lower(), "-inf")
 
 
 class Test_decimal_to_json(unittest.TestCase):


### PR DESCRIPTION
Fixes #696.

This PR fixes inserting `Nan` and non-finite floats with the `client.insert_rows()` method.

**PR checklist:**
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


