### PR TITLE
fix: use pandas function to check for NaN

### DIFF
--- a/google/cloud/bigquery/_pandas_helpers.py
+++ b/google/cloud/bigquery/_pandas_helpers.py
@@ -780,7 +780,7 @@ def dataframe_to_json_generator(dataframe):
         output = {}
         for column, value in zip(dataframe.columns, row):
             # Omit NaN values.
-            if value != value:
+            if pandas.isna(value):
                 continue
             output[column] = value
         yield output

--- a/tests/unit/test__pandas_helpers.py
+++ b/tests/unit/test__pandas_helpers.py
@@ -19,6 +19,7 @@ import functools
 import operator
 import queue
 import warnings
+import pkg_resources
 
 import mock
 
@@ -46,6 +47,14 @@ try:
     from google.cloud import bigquery_storage
 except ImportError:  # pragma: NO COVER
     bigquery_storage = None
+
+PANDAS_MINIUM_VERSION = pkg_resources.parse_version("1.0.0")
+
+if pandas is not None:
+    PANDAS_INSTALLED_VERSION = pkg_resources.get_distribution("pandas").parsed_version
+else:
+    # Set to less than MIN version.
+    PANDAS_INSTALLED_VERSION = pkg_resources.parse_version("0.0.0")
 
 
 skip_if_no_bignumeric = pytest.mark.skipif(
@@ -734,7 +743,10 @@ def test_list_columns_and_indexes_with_named_index_same_as_column_name(
     assert columns_and_indexes == expected
 
 
-@pytest.mark.skipif(pandas is None, reason="Requires `pandas`")
+@pytest.mark.skipIf(
+    pandas is None or PANDAS_INSTALLED_VERSION < PANDAS_MINIUM_VERSION,
+    reason="Requires `pandas version >= 1.0.0` which introduces pandas.NA",
+)
 def test_dataframe_to_json_generator(module_under_test):
     utcnow = datetime.datetime.utcnow()
     df_data = collections.OrderedDict(

--- a/tests/unit/test__pandas_helpers.py
+++ b/tests/unit/test__pandas_helpers.py
@@ -771,8 +771,7 @@ def test_dataframe_to_json_generator(module_under_test):
         {"a_series": 3, "b_series": 0.3, "d_series": utcnow, "e_series": True},
         {"a_series": 4, "b_series": 0.4, "c_series": "d"},
     ]
-    for row, expect in zip(rows, expected):
-        assert row == expect
+    assert list(rows) == expected
 
 
 @pytest.mark.skipif(pandas is None, reason="Requires `pandas`")

--- a/tests/unit/test__pandas_helpers.py
+++ b/tests/unit/test__pandas_helpers.py
@@ -735,6 +735,35 @@ def test_list_columns_and_indexes_with_named_index_same_as_column_name(
 
 
 @pytest.mark.skipif(pandas is None, reason="Requires `pandas`")
+def test_dataframe_to_json_generator(module_under_test):
+    utcnow = datetime.datetime.utcnow()
+    df_data = collections.OrderedDict(
+        [
+            ("a_series", [pandas.NA, 2, 3, 4]),
+            ("b_series", [0.1, float("NaN"), 0.3, 0.4]),
+            ("c_series", ["a", "b", pandas.NA, "d"]),
+            ("d_series", [utcnow, utcnow, utcnow, pandas.NaT]),
+            ("e_series", [True, False, True, None]),
+        ]
+    )
+    dataframe = pandas.DataFrame(
+        df_data, index=pandas.Index([4, 5, 6, 7], name="a_index")
+    )
+
+    dataframe = dataframe.astype({"a_series": pandas.Int64Dtype()})
+
+    rows = module_under_test.dataframe_to_json_generator(dataframe)
+    expected = [
+        {"b_series": 0.1, "c_series": "a", "d_series": utcnow, "e_series": True},
+        {"a_series": 2, "c_series": "b", "d_series": utcnow, "e_series": False},
+        {"a_series": 3, "b_series": 0.3, "d_series": utcnow, "e_series": True},
+        {"a_series": 4, "b_series": 0.4, "c_series": "d"},
+    ]
+    for row, expect in zip(rows, expected):
+        assert row == expect
+
+
+@pytest.mark.skipif(pandas is None, reason="Requires `pandas`")
 def test_list_columns_and_indexes_with_named_index(module_under_test):
     df_data = collections.OrderedDict(
         [

--- a/tests/unit/test__pandas_helpers.py
+++ b/tests/unit/test__pandas_helpers.py
@@ -743,7 +743,7 @@ def test_list_columns_and_indexes_with_named_index_same_as_column_name(
     assert columns_and_indexes == expected
 
 
-@pytest.mark.skipIf(
+@pytest.mark.skipif(
     pandas is None or PANDAS_INSTALLED_VERSION < PANDAS_MINIUM_VERSION,
     reason="Requires `pandas version >= 1.0.0` which introduces pandas.NA",
 )


### PR DESCRIPTION
Starting with pandas 1.0, an experimental `pandas.NA` value (singleton) is available to represent scalar missing values as
opposed to `numpy.nan`. Comparing the variable with itself results in a `pandas.NA` value that doesn't support type-casting
to boolean. Using the build-in `pandas.isna` function handles all pandas supported NaN values (`None`, `pd.NA`, `np.nan`, `NaT`).

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #729 
