### PR TITLE
fix: avoid possible job already exists error

### DIFF
--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -3225,11 +3225,10 @@ class Client(ClientWithProject):
 
         try:
             query_job._begin(retry=retry, timeout=timeout)
-        except core_exceptions.GoogleAPICallError as create_exc:
-            # Even if create job request fails, it is still possible that the job has
-            # actually been successfully created. We check this by trying to fetch it,
-            # but only if we created a random job ID ourselves (otherwise we might
-            # mistakenly fetch a job created by someone else).
+        except core_exceptions.Conflict as create_exc:
+            # The thought is if someone is providing their own job IDs and they get
+            # their job ID generation wrong, this could end up returning results for
+            # the wrong query. We thus only try to recover if job ID was not given.
             if job_id_given:
                 raise create_exc
 

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -3190,6 +3190,7 @@ class Client(ClientWithProject):
                 If ``job_config`` is not an instance of :class:`~google.cloud.bigquery.job.QueryJobConfig`
                 class.
         """
+        job_id_given = job_id is not None
         job_id = _make_job_id(job_id, job_id_prefix)
 
         if project is None:
@@ -3221,9 +3222,31 @@ class Client(ClientWithProject):
 
         job_ref = job._JobReference(job_id, project=project, location=location)
         query_job = job.QueryJob(job_ref, query, client=self, job_config=job_config)
-        query_job._begin(retry=retry, timeout=timeout)
 
-        return query_job
+        try:
+            query_job._begin(retry=retry, timeout=timeout)
+        except core_exceptions.GoogleAPICallError as create_exc:
+            # Even if create job request fails, it is still possible that the job has
+            # actually been successfully created. We check this by trying to fetch it,
+            # but only if we created a random job ID ourselves (otherwise we might
+            # mistakenly fetch a job created by someone else).
+            if job_id_given:
+                raise create_exc
+
+            try:
+                query_job = self.get_job(
+                    job_id,
+                    project=project,
+                    location=location,
+                    retry=retry,
+                    timeout=timeout,
+                )
+            except core_exceptions.GoogleAPIError:  # (includes RetryError)
+                raise create_exc
+            else:
+                return query_job
+        else:
+            return query_job
 
     def insert_rows(
         self,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -4617,53 +4617,69 @@ class TestClient(unittest.TestCase):
             },
         )
 
-    def test_query_job_rpc_fail_w_job_id_given(self):
-        from google.api_core.exceptions import GoogleAPICallError
+    def test_query_job_rpc_fail_w_random_error(self):
+        from google.api_core.exceptions import Unknown
         from google.cloud.bigquery.job import QueryJob
 
         creds = _make_credentials()
         http = object()
         client = self._make_one(project=self.PROJECT, credentials=creds, _http=http)
 
-        job_create_error = GoogleAPICallError("Dubious oops.")
+        job_create_error = Unknown("Not sure what went wrong.")
         job_begin_patcher = mock.patch.object(
             QueryJob, "_begin", side_effect=job_create_error
         )
         with job_begin_patcher:
-            with pytest.raises(GoogleAPICallError, match="Dubious oops."):
+            with pytest.raises(Unknown, match="Not sure what went wrong."):
                 client.query("SELECT 1;", job_id="123")
 
-    def test_query_job_rpc_fail_w_random_id_job_create_indeed_failed(self):
-        from google.api_core.exceptions import GoogleAPICallError
-        from google.api_core.exceptions import NotFound
+    def test_query_job_rpc_fail_w_conflict_job_id_given(self):
+        from google.api_core.exceptions import Conflict
         from google.cloud.bigquery.job import QueryJob
 
         creds = _make_credentials()
         http = object()
         client = self._make_one(project=self.PROJECT, credentials=creds, _http=http)
 
-        job_create_error = GoogleAPICallError("Dubious oops.")
+        job_create_error = Conflict("Job already exists.")
+        job_begin_patcher = mock.patch.object(
+            QueryJob, "_begin", side_effect=job_create_error
+        )
+        with job_begin_patcher:
+            with pytest.raises(Conflict, match="Job already exists."):
+                client.query("SELECT 1;", job_id="123")
+
+    def test_query_job_rpc_fail_w_conflict_random_id_job_fetch_fails(self):
+        from google.api_core.exceptions import Conflict
+        from google.api_core.exceptions import DataLoss
+        from google.cloud.bigquery.job import QueryJob
+
+        creds = _make_credentials()
+        http = object()
+        client = self._make_one(project=self.PROJECT, credentials=creds, _http=http)
+
+        job_create_error = Conflict("Job already exists.")
         job_begin_patcher = mock.patch.object(
             QueryJob, "_begin", side_effect=job_create_error
         )
         get_job_patcher = mock.patch.object(
-            client, "get_job", side_effect=NotFound("no such job")
+            client, "get_job", side_effect=DataLoss("we lost yor job, sorry")
         )
 
         with job_begin_patcher, get_job_patcher:
             # If get job request fails, the original exception should be raised.
-            with pytest.raises(GoogleAPICallError, match="Dubious oops."):
+            with pytest.raises(Conflict, match="Job already exists."):
                 client.query("SELECT 1;", job_id=None)
 
-    def test_query_job_rpc_fail_w_random_id_job_create_succeeded(self):
-        from google.api_core.exceptions import GoogleAPICallError
+    def test_query_job_rpc_fail_w_conflict_random_id_job_fetch_succeeds(self):
+        from google.api_core.exceptions import Conflict
         from google.cloud.bigquery.job import QueryJob
 
         creds = _make_credentials()
         http = object()
         client = self._make_one(project=self.PROJECT, credentials=creds, _http=http)
 
-        job_create_error = GoogleAPICallError("Dubious oops.")
+        job_create_error = Conflict("Job already exists.")
         job_begin_patcher = mock.patch.object(
             QueryJob, "_begin", side_effect=job_create_error
         )


### PR DESCRIPTION
Fixes #738.

If job create request fails, a query job might still have started successfully. This PR handles this edge case and returns such
query job one can be found.

Based on the [similar fix](https://github.com/googleapis/java-bigquery/blob/e755470ad3699eee8816f55cdec4dd995cf85d52/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java#L385-L401) in the Java client.

**PR checklist:**
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
