### PR TITLE
Add "timeout" to retryable reasons

### DIFF
--- a/google/cloud/bigquery/retry.py
+++ b/google/cloud/bigquery/retry.py
@@ -19,7 +19,7 @@ import requests.exceptions
 
 
 _RETRYABLE_REASONS = frozenset(
-    ["rateLimitExceeded", "backendError", "internalError", "badGateway"]
+    ["rateLimitExceeded", "backendError", "internalError", "badGateway", "timeout"]
 )
 
 _UNSTRUCTURED_RETRYABLE_TYPES = (


### PR DESCRIPTION
Fixes #779

ℹ️  This modifies the default retry used for all the API calls. Should I instead make a retry object dedicated to the streaming inserts?