### PR TITLE
fix: insert_rows() error with floats as strings

### DIFF
--- a/google/cloud/bigquery/_helpers.py
+++ b/google/cloud/bigquery/_helpers.py
@@ -19,6 +19,7 @@ import datetime
 import decimal
 import math
 import re
+from typing import Union
 
 from google.cloud._helpers import UTC
 from google.cloud._helpers import _date_from_iso8601_date
@@ -338,14 +339,15 @@ def _int_to_json(value):
     return value
 
 
-def _float_to_json(value):
+def _float_to_json(value) -> Union[None, str, float]:
     """Coerce 'value' to an JSON-compatible representation."""
     if value is None:
         return None
-    elif math.isnan(value) or math.isinf(value):
-        return str(value)
-    else:
-        return float(value)
+
+    if isinstance(value, str):
+        value = float(value)
+
+    return str(value) if (math.isnan(value) or math.isinf(value)) else float(value)
 
 
 def _decimal_to_json(value):

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -690,19 +690,43 @@ class Test_float_to_json(unittest.TestCase):
     def test_w_none(self):
         self.assertEqual(self._call_fut(None), None)
 
+    def test_w_non_numeric(self):
+        with self.assertRaises(TypeError):
+            self._call_fut(object())
+
+    def test_w_integer(self):
+        result = self._call_fut(123)
+        self.assertIsInstance(result, float)
+        self.assertEqual(result, 123.0)
+
     def test_w_float(self):
         self.assertEqual(self._call_fut(1.23), 1.23)
 
+    def test_w_float_as_string(self):
+        self.assertEqual(self._call_fut("1.23"), 1.23)
+
     def test_w_nan(self):
         result = self._call_fut(float("nan"))
+        self.assertEqual(result.lower(), "nan")
+
+    def test_w_nan_as_string(self):
+        result = self._call_fut("NaN")
         self.assertEqual(result.lower(), "nan")
 
     def test_w_infinity(self):
         result = self._call_fut(float("inf"))
         self.assertEqual(result.lower(), "inf")
 
+    def test_w_infinity_as_string(self):
+        result = self._call_fut("inf")
+        self.assertEqual(result.lower(), "inf")
+
     def test_w_negative_infinity(self):
         result = self._call_fut(float("-inf"))
+        self.assertEqual(result.lower(), "-inf")
+
+    def test_w_negative_infinity_as_string(self):
+        result = self._call_fut("-inf")
         self.assertEqual(result.lower(), "-inf")
 
 


### PR DESCRIPTION
Fixes #818.

As a bonus, passing in special values as strings, e.g. `"-inf"` or `"NaN"`, now also works.

**PR checklist:**
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


