### PR TITLE
chore: add second protection rule for v3 branch

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -3,7 +3,16 @@
 branchProtectionRules:
 # Identifies the protection rule pattern. Name of the branch to be protected.
 # Defaults to `master`
-- pattern: '{master,v3}'
+- pattern: master
+  requiredStatusCheckContexts:
+    - 'Kokoro'
+    - 'Kokoro snippets-3.8'
+    - 'cla/google'
+    - 'Samples - Lint'
+    - 'Samples - Python 3.6'
+    - 'Samples - Python 3.7'
+    - 'Samples - Python 3.8'
+- pattern: v3
   requiredStatusCheckContexts:
     - 'Kokoro'
     - 'Kokoro snippets-3.8'


### PR DESCRIPTION
Follow-up to https://github.com/googleapis/python-bigquery/pull/816

GitHub uses `fnmatch` syntax (https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule), but from my manual testing, it hasn't enabled the `File::FNM_EXTGLOB`. To protect branches with the same rule that don't have a common prefix/infix/suffix, I think we need to duplicate the rule.