### PR TITLE
cleanup: get rid of unit test warnings caused by our code

### DIFF
--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -2251,7 +2251,10 @@ class _EmptyRowIterator(RowIterator):
         """
         if geopandas is None:
             raise ValueError(_NO_GEOPANDAS_ERROR)
-        return geopandas.GeoDataFrame(crs=_COORDINATE_REFERENCE_SYSTEM)
+
+        # Since an empty GeoDataFrame has no geometry column, we do not CRS on it,
+        # because that's deprecated.
+        return geopandas.GeoDataFrame()
 
     def to_dataframe_iterable(
         self,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -54,3 +54,8 @@ def disable_add_server_timeout_header(request):
             noop_add_server_timeout_header,
         ):
             yield
+
+
+def pytest_configure(config):
+    # Explicitly register custom test markers to avoid warnings.
+    config.addinivalue_line("markers", "enable_add_server_timeout_header")

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -1866,8 +1866,7 @@ class Test_EmptyRowIterator(unittest.TestCase):
         df = row_iterator.to_geodataframe(create_bqstorage_client=False)
         self.assertIsInstance(df, geopandas.GeoDataFrame)
         self.assertEqual(len(df), 0)  # verify the number of rows
-        self.assertEqual(df.crs.srs, "EPSG:4326")
-        self.assertEqual(df.crs.name, "WGS 84")
+        self.assertIsNone(df.crs)
 
 
 class TestRowIterator(unittest.TestCase):
@@ -4027,8 +4026,14 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(df.name.dtype.name, "object")
         self.assertEqual(df.geog.dtype.name, "geometry")
         self.assertIsInstance(df.geog, geopandas.GeoSeries)
-        self.assertEqual(list(map(str, df.area)), ["0.0", "nan", "0.5"])
-        self.assertEqual(list(map(str, df.geog.area)), ["0.0", "nan", "0.5"])
+
+        with warnings.catch_warnings():
+            # Computing the area on a GeoDataFrame that uses a geographic Coordinate
+            # Reference System (CRS) produces a warning that we are not interested in.
+            warnings.filterwarnings("ignore", category=UserWarning)
+            self.assertEqual(list(map(str, df.area)), ["0.0", "nan", "0.5"])
+            self.assertEqual(list(map(str, df.geog.area)), ["0.0", "nan", "0.5"])
+
         self.assertEqual(df.crs.srs, "EPSG:4326")
         self.assertEqual(df.crs.name, "WGS 84")
         self.assertEqual(df.geog.crs.srs, "EPSG:4326")
@@ -4099,8 +4104,14 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(df.geog.dtype.name, "geometry")
         self.assertEqual(df.geog2.dtype.name, "object")
         self.assertIsInstance(df.geog, geopandas.GeoSeries)
-        self.assertEqual(list(map(str, df.area)), ["0.0", "nan", "0.5"])
-        self.assertEqual(list(map(str, df.geog.area)), ["0.0", "nan", "0.5"])
+
+        with warnings.catch_warnings():
+            # Computing the area on a GeoDataFrame that uses a geographic Coordinate
+            # Reference System (CRS) produces a warning that we are not interested in.
+            warnings.filterwarnings("ignore", category=UserWarning)
+            self.assertEqual(list(map(str, df.area)), ["0.0", "nan", "0.5"])
+            self.assertEqual(list(map(str, df.geog.area)), ["0.0", "nan", "0.5"])
+
         self.assertEqual(
             [v.__class__.__name__ for v in df.geog], ["Point", "NoneType", "Polygon"]
         )
@@ -4110,10 +4121,14 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(
             [v.__class__.__name__ for v in df.geog2], ["Point", "Point", "Point"]
         )
+
         # and can easily be converted to a GeoSeries
-        self.assertEqual(
-            list(map(str, geopandas.GeoSeries(df.geog2).area)), ["0.0", "0.0", "0.0"]
-        )
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=UserWarning)
+            self.assertEqual(
+                list(map(str, geopandas.GeoSeries(df.geog2).area)),
+                ["0.0", "0.0", "0.0"],
+            )
 
     @unittest.skipIf(geopandas is None, "Requires `geopandas`")
     @mock.patch("google.cloud.bigquery.table.RowIterator.to_dataframe")
@@ -4165,8 +4180,14 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(df.name.dtype.name, "object")
         self.assertEqual(df.g.dtype.name, "geometry")
         self.assertIsInstance(df.g, geopandas.GeoSeries)
-        self.assertEqual(list(map(str, df.area)), ["0.0"])
-        self.assertEqual(list(map(str, df.g.area)), ["0.0"])
+
+        with warnings.catch_warnings():
+            # Computing the area on a GeoDataFrame that uses a geographic Coordinate
+            # Reference System (CRS) produces a warning that we are not interested in.
+            warnings.filterwarnings("ignore", category=UserWarning)
+            self.assertEqual(list(map(str, df.area)), ["0.0"])
+            self.assertEqual(list(map(str, df.g.area)), ["0.0"])
+
         self.assertEqual([v.__class__.__name__ for v in df.g], ["Point"])
 
 


### PR DESCRIPTION
Fixes #957.

This PR should get rid of almost all warnings when running unit tests, except from the one that seems to come from `geopandas` internals.

I initially read a few things on the geographic coordinate systems to understand the problem, and then tried to convert the resulting geodataframes to a different CRS. But that turned out to be a bad idea, because we actually want to actual dataframes in `EPSG:4326`, thus I reverted to just ignoring the user warnings in the test code.

**PR checklist:**
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


