### PR TITLE
feat: Add py.typed for PEP 561 compliance

### DIFF
--- a/google/cloud/bigquery/py.typed
+++ b/google/cloud/bigquery/py.typed
@@ -1,0 +1,2 @@
+# Marker file for PEP 561.
+# The google-cloud-bigquery package uses inline types.


### PR DESCRIPTION
Type annotations were added in commit
f8d4aaa335a0eef915e73596fc9b43b11d11be9f. For these annotations to be
useful by library users, the package should install a py.typed file.
This tells mypy and other tools to consume and use these types.

For more details, see:
https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages