### PR TITLE
fix: remove py.typed since package fails mypy check

### DIFF
--- a/google/cloud/bigquery/py.typed
+++ b/google/cloud/bigquery/py.typed
@@ -1,2 +1,0 @@
-# Marker file for PEP 561.
-# The google-cloud-bigquery package uses inline types.


### PR DESCRIPTION
Reverts googleapis/python-bigquery#976

Context: https://issues.apache.org/jira/browse/BEAM-12975