### PR TITLE
docs: link to stable pandas docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -366,7 +366,7 @@ intersphinx_mapping = {
     "grpc": ("https://grpc.github.io/grpc/python/", None),
     "proto-plus": ("https://proto-plus-python.readthedocs.io/en/latest/", None),
     "protobuf": ("https://googleapis.dev/python/protobuf/latest/", None),
-    "pandas": ("http://pandas.pydata.org/pandas-docs/dev", None),
+    "pandas": ("http://pandas.pydata.org/pandas-docs/stable", None),
     "geopandas": ("https://geopandas.org/", None),
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -366,7 +366,7 @@ intersphinx_mapping = {
     "grpc": ("https://grpc.github.io/grpc/python/", None),
     "proto-plus": ("https://proto-plus-python.readthedocs.io/en/latest/", None),
     "protobuf": ("https://googleapis.dev/python/protobuf/latest/", None),
-    "pandas": ("http://pandas.pydata.org/pandas-docs/stable", None),
+    "pandas": ("http://pandas.pydata.org/pandas-docs/stable/", None),
     "geopandas": ("https://geopandas.org/", None),
 }
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -98,7 +98,7 @@ templated_files = common.py_library(
     microgenerator=True,
     split_system_tests=True,
     intersphinx_dependencies={
-        "pandas": "http://pandas.pydata.org/pandas-docs/stable",
+        "pandas": "http://pandas.pydata.org/pandas-docs/stable/",
         "geopandas": "https://geopandas.org/",
     },
 )

--- a/owlbot.py
+++ b/owlbot.py
@@ -98,7 +98,7 @@ templated_files = common.py_library(
     microgenerator=True,
     split_system_tests=True,
     intersphinx_dependencies={
-        "pandas": "http://pandas.pydata.org/pandas-docs/dev",
+        "pandas": "http://pandas.pydata.org/pandas-docs/stable",
         "geopandas": "https://geopandas.org/",
     },
 )


### PR DESCRIPTION
I noticed these were linking to the development (HEAD) version, not the latest release.