### PR TITLE
docs: note restriction on setting 'LoadJobConfig.time_partitioning'

### DIFF
--- a/google/cloud/bigquery/job/load.py
+++ b/google/cloud/bigquery/job/load.py
@@ -442,6 +442,10 @@ class LoadJobConfig(_JobConfig):
         Only specify at most one of
         :attr:`~google.cloud.bigquery.job.LoadJobConfig.time_partitioning` or
         :attr:`~google.cloud.bigquery.job.LoadJobConfig.range_partitioning`.
+        
+        .. note::
+
+           You can't create partitions in already existing unpartitioned tables.
         """
         prop = self._get_sub_prop("timePartitioning")
         if prop is not None:


### PR DESCRIPTION
Update description of LoadJobConfig.time_partitioning to be more clear about cases like these.
