### PR TITLE
chore: revert update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "bigquery",
     "name_pretty": "Google Cloud BigQuery",
     "product_documentation": "https://cloud.google.com/bigquery",
-    "client_documentation": "https://cloud.google.com/python/docs/reference/bigquery/latest",
+    "client_documentation": "https://googleapis.dev/python/bigquery/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559654",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ processing power of Google's infrastructure.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery.svg
    :target: https://pypi.org/project/google-cloud-bigquery/
 .. _BigQuery: https://cloud.google.com/bigquery/what-is-bigquery
-.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigquery/latest
+.. _Client Library Documentation: https://googleapis.dev/python/bigquery/latest
 .. _Product Documentation: https://cloud.google.com/bigquery/docs/reference/v2/
 
 Quick Start


### PR DESCRIPTION
Reverts googleapis/python-bigquery#1062

Intersphinx or even normal intra-sphinx links to related classes and functions do not work. Many formatting problems on https://cloud.google.com/python/docs/reference/bigquery/latest/google.cloud.bigquery.client.Client