### PR TITLE
test: avoid flake if connections were already open at start

### DIFF
--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -1725,7 +1725,7 @@ class TestBigQuery(unittest.TestCase):
 
         connection.close()
         conn_count_end = len(current_process.connections())
-        self.assertEqual(conn_count_end, conn_count_start)
+        self.assertLessEqual(conn_count_end, conn_count_start)
 
     def _load_table_for_dml(self, rows, dataset_id, table_id):
         from google.cloud._testing import _NamedTemporaryFile


### PR DESCRIPTION
Addresses flakes such as https://source.cloud.google.com/results/invocations/bb7ce2a8-d410-45bd-af12-7c04bb8cbb25/targets/cloud-devrel%2Fclient-libraries%2Fpython%2Fgoogleapis%2Fpython-bigquery%2Fpresubmit%2Fsystem-3.10/log

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
