### PR TITLE
test: make GC check resilient to broken weakrefs

### DIFF
--- a/tests/unit/test_dbapi_connection.py
+++ b/tests/unit/test_dbapi_connection.py
@@ -219,8 +219,14 @@ class TestConnection(unittest.TestCase):
         # Connections should not hold strong references to the Cursor instances
         # they created, unnecessarily keeping them alive.
         gc.collect()
-        cursors = [obj for obj in gc.get_objects() if isinstance(obj, Cursor)]
-        self.assertEqual(len(cursors), 2)
+        cursor_count = 0
+        for obj in gc.get_objects():
+          try:
+            if isinstance(obj, Cursor):
+              cursor_count += 1
+          except ReferenceError:
+            pass
+        self.assertEqual(cursor_count, 2)
 
     def test_commit(self):
         connection = self._make_one(client=self._mock_client())

--- a/tests/unit/test_dbapi_connection.py
+++ b/tests/unit/test_dbapi_connection.py
@@ -221,11 +221,11 @@ class TestConnection(unittest.TestCase):
         gc.collect()
         cursor_count = 0
         for obj in gc.get_objects():
-          try:
-            if isinstance(obj, Cursor):
-              cursor_count += 1
-          except ReferenceError:  # pragma: NO COVER
-            pass
+            try:
+                if isinstance(obj, Cursor):
+                    cursor_count += 1
+            except ReferenceError:  # pragma: NO COVER
+                pass
         self.assertEqual(cursor_count, 2)
 
     def test_commit(self):

--- a/tests/unit/test_dbapi_connection.py
+++ b/tests/unit/test_dbapi_connection.py
@@ -224,7 +224,7 @@ class TestConnection(unittest.TestCase):
           try:
             if isinstance(obj, Cursor):
               cursor_count += 1
-          except ReferenceError:
+          except ReferenceError:  # pragma: NO COVER
             pass
         self.assertEqual(cursor_count, 2)
 


### PR DESCRIPTION
In some python deployments (I believe macOS is one), weakref objects aren't guaranteed to exist across gc collections. The proposed check pattern is also used in tensorflow ([link]) which ran into similar issues a few years ago.

[link]: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/framework/errors_test.py#L33