### PR TITLE
fix: remove query text from exception message, use `exception.debug_message` instead

### DIFF
--- a/tests/unit/job/test_query.py
+++ b/tests/unit/job/test_query.py
@@ -1360,13 +1360,19 @@ class TestQueryJob(_Base):
         exc_job_instance = getattr(exc_info.exception, "query_job", None)
         self.assertIs(exc_job_instance, job)
 
+        # Query text could contain sensitive information, so it must not be
+        # included in logs / exception representation.
         full_text = str(exc_info.exception)
         assert job.job_id in full_text
-        assert "Query Job SQL Follows" in full_text
+        assert "Query Job SQL Follows" not in full_text
 
+        # It is useful to have query text available, so it is provided in a
+        # debug_message property.
+        debug_message = exc_info.exception.debug_message
+        assert "Query Job SQL Follows" in debug_message
         for i, line in enumerate(query.splitlines(), start=1):
             expected_line = "{}:{}".format(i, line)
-            assert expected_line in full_text
+            assert expected_line in debug_message
 
     def test_result_transport_timeout_error(self):
         query = textwrap.dedent(
@@ -1452,13 +1458,19 @@ class TestQueryJob(_Base):
         exc_job_instance = getattr(exc_info.exception, "query_job", None)
         self.assertIs(exc_job_instance, job)
 
+        # Query text could contain sensitive information, so it must not be
+        # included in logs / exception representation.
         full_text = str(exc_info.exception)
         assert job.job_id in full_text
-        assert "Query Job SQL Follows" in full_text
+        assert "Query Job SQL Follows" not in full_text
 
+        # It is useful to have query text available, so it is provided in a
+        # debug_message property.
+        debug_message = exc_info.exception.debug_message
+        assert "Query Job SQL Follows" in debug_message
         for i, line in enumerate(query.splitlines(), start=1):
             expected_line = "{}:{}".format(i, line)
-            assert expected_line in full_text
+            assert expected_line in debug_message
 
     def test__begin_w_timeout(self):
         PATH = "/projects/%s/jobs" % (self.PROJECT,)


### PR DESCRIPTION
Since query text can potentially contain sensitive information, remove it from
the default exception message. This information is useful for debugging, so
provide a `debug_message` attribute, which is not included in the exception
representation (and thus the logs).

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes internal issue 211616590
🦕
