### PR TITLE
feat: support BI Engine statistics in query job

### DIFF
--- a/google/cloud/bigquery/enums.py
+++ b/google/cloud/bigquery/enums.py
@@ -28,6 +28,46 @@ class AutoRowIDs(enum.Enum):
     GENERATE_UUID = enum.auto()
 
 
+class BiEngineReasonCode(enum.Enum):
+    """Specifies reason why BI Engine did not accelerate query"""
+
+    CODE_UNSPECIFIED = enum.auto()
+    """BiEngineReason not specified."""
+
+    NO_RESERVATION = enum.auto()
+    """No reservation available for BI Engine acceleration."""
+
+    INSUFFICIENT_RESERVATION = enum.auto()
+    """Not enough memory available for BI Engine acceleration."""
+
+    UNCACHED = enum.auto()
+    """Data is not-cached and could not be accelerated by BI Engine."""
+
+    UNSUPPORTED_SQL_TEXT = enum.auto()
+    """This particular SQL text is not supported for acceleration by BI Engine."""
+
+    INPUT_TOO_LARGE = enum.auto()
+    """Input too large for acceleration by BI Engine."""
+
+    OTHER_REASON = enum.auto()
+    """Catch-all code for all other cases for partial or disabled acceleration."""
+
+    TABLE_EXCLUDED = enum.auto()
+    """One or more tables were not eligible for BI Engine acceleration."""
+
+
+class BiEngineMode(enum.Enum):
+    """Specifies which mode of BI Engine acceleration was performed"""
+
+    ACCELERATION_MODE_UNSPECIFIED = enum.auto()
+
+    DISABLED = enum.auto()
+
+    PARTIAL = enum.auto()
+
+    FULL = enum.auto()
+
+
 class Compression(object):
     """The compression type to use for exported files. The default value is
     :attr:`NONE`.

--- a/google/cloud/bigquery/enums.py
+++ b/google/cloud/bigquery/enums.py
@@ -28,46 +28,6 @@ class AutoRowIDs(enum.Enum):
     GENERATE_UUID = enum.auto()
 
 
-class BiEngineReasonCode(enum.Enum):
-    """Specifies reason why BI Engine did not accelerate query"""
-
-    CODE_UNSPECIFIED = enum.auto()
-    """BiEngineReason not specified."""
-
-    NO_RESERVATION = enum.auto()
-    """No reservation available for BI Engine acceleration."""
-
-    INSUFFICIENT_RESERVATION = enum.auto()
-    """Not enough memory available for BI Engine acceleration."""
-
-    UNCACHED = enum.auto()
-    """Data is not-cached and could not be accelerated by BI Engine."""
-
-    UNSUPPORTED_SQL_TEXT = enum.auto()
-    """This particular SQL text is not supported for acceleration by BI Engine."""
-
-    INPUT_TOO_LARGE = enum.auto()
-    """Input too large for acceleration by BI Engine."""
-
-    OTHER_REASON = enum.auto()
-    """Catch-all code for all other cases for partial or disabled acceleration."""
-
-    TABLE_EXCLUDED = enum.auto()
-    """One or more tables were not eligible for BI Engine acceleration."""
-
-
-class BiEngineMode(enum.Enum):
-    """Specifies which mode of BI Engine acceleration was performed"""
-
-    ACCELERATION_MODE_UNSPECIFIED = enum.auto()
-
-    DISABLED = enum.auto()
-
-    PARTIAL = enum.auto()
-
-    FULL = enum.auto()
-
-
 class Compression(object):
     """The compression type to use for exported files. The default value is
     :attr:`NONE`.

--- a/google/cloud/bigquery/job/query.py
+++ b/google/cloud/bigquery/job/query.py
@@ -153,13 +153,9 @@ class BiEngineStats(typing.NamedTuple):
     @classmethod
     def from_api_repr(cls, stats: Dict[str, str]) -> "BiEngineStats":
         mode = stats.get("biEngineMode")
-        reasons = stats.get("biEngineReasons")
-
-        if reasons is None:
-            reasons = []
-        else:
-            reasons = [BiEngineReason.from_api_repr(r) for r in reasons]
-
+        reasons = [
+            BiEngineReason.from_api_repr(r) for r in stats.get("biEngineReasons", [])
+        ]
         return cls(mode, reasons)
 
 
@@ -1237,7 +1233,7 @@ class QueryJob(_AsyncJob):
     def bi_engine_stats(self) -> Optional[BiEngineStats]:
         stats = self._job_statistics().get("biEngineStatistics")
 
-        if stats is not None:
+        if stats is None:
             return None
         else:
             return BiEngineStats.from_api_repr(stats)

--- a/google/cloud/bigquery/job/query.py
+++ b/google/cloud/bigquery/job/query.py
@@ -133,7 +133,7 @@ class BiEngineReason(typing.NamedTuple):
 
     @classmethod
     def from_api_repr(cls, reason: Dict[str, str]) -> "BiEngineReason":
-        return cls(reason.get("code"), reason.get("message"))
+        return cls(reason.get("code", "CODE_UNSPECIFIED"), reason.get("message", ""))
 
 
 class BiEngineStats(typing.NamedTuple):
@@ -151,8 +151,8 @@ class BiEngineStats(typing.NamedTuple):
     """
 
     @classmethod
-    def from_api_repr(cls, stats: Dict[str, str]) -> "BiEngineStats":
-        mode = stats.get("biEngineMode")
+    def from_api_repr(cls, stats: Dict[str, Any]) -> "BiEngineStats":
+        mode = stats.get("biEngineMode", "ACCELERATION_MODE_UNSPECIFIED")
         reasons = [
             BiEngineReason.from_api_repr(r) for r in stats.get("biEngineReasons", [])
         ]

--- a/google/cloud/bigquery/job/query.py
+++ b/google/cloud/bigquery/job/query.py
@@ -29,7 +29,6 @@ from google.cloud.bigquery.dataset import DatasetListItem
 from google.cloud.bigquery.dataset import DatasetReference
 from google.cloud.bigquery.encryption_configuration import EncryptionConfiguration
 from google.cloud.bigquery.enums import KeyResultStatementKind
-from google.cloud.bigquery.enums import BiEngineMode, BiEngineReasonCode
 from google.cloud.bigquery.external_config import ExternalConfig
 from google.cloud.bigquery import _helpers
 from google.cloud.bigquery.query import (
@@ -128,13 +127,13 @@ class BiEngineReason(typing.NamedTuple):
     https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#bienginereason
     """
 
-    code: BiEngineReasonCode = BiEngineReasonCode.CODE_UNSPECIFIED
+    code: str = "CODE_UNSPECIFIED"
 
     reason: str = ""
 
     @classmethod
     def from_api_repr(cls, reason: Dict[str, str]) -> "BiEngineReason":
-        return cls(BiEngineReasonCode[reason.get("code")], reason.get("message"))
+        return cls(reason.get("code"), reason.get("message"))
 
 
 class BiEngineStats(typing.NamedTuple):
@@ -143,7 +142,7 @@ class BiEngineStats(typing.NamedTuple):
     https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#bienginestatistics
     """
 
-    mode: BiEngineMode = BiEngineMode.ACCELERATION_MODE_UNSPECIFIED
+    mode: str = "ACCELERATION_MODE_UNSPECIFIED"
     """ Specifies which mode of BI Engine acceleration was performed (if any)
     """
 
@@ -153,15 +152,13 @@ class BiEngineStats(typing.NamedTuple):
 
     @classmethod
     def from_api_repr(cls, stats: Dict[str, str]) -> "BiEngineStats":
-        biEngineMode = stats.get("biEngineMode")
-        biEngineReasons = stats.get("biEngineReasons")
+        mode = stats.get("biEngineMode")
+        reasons = stats.get("biEngineReasons")
 
-        mode = BiEngineMode[biEngineMode]
-
-        if biEngineReasons is None:
+        if reasons is None:
             reasons = []
         else:
-            reasons = [BiEngineReason.from_api_repr(r) for r in biEngineReasons]
+            reasons = [BiEngineReason.from_api_repr(r) for r in reasons]
 
         return cls(mode, reasons)
 

--- a/tests/unit/job/test_query.py
+++ b/tests/unit/job/test_query.py
@@ -877,6 +877,23 @@ class TestQueryJob(_Base):
         query_stats["estimatedBytesProcessed"] = str(est_bytes)
         self.assertEqual(job.estimated_bytes_processed, est_bytes)
 
+    def test_bi_engine_stats(self):
+        from google.cloud.bigquery.job.query import BiEngineStats
+
+        client = _make_client(project=self.PROJECT)
+        job = self._make_one(self.JOB_ID, self.QUERY, client)
+        assert job.bi_engine_stats is None
+
+        statistics = job._properties["statistics"] = {}
+        assert job.bi_engine_stats is None
+
+        query_stats = statistics["query"] = {}
+        assert job.bi_engine_stats is None
+
+        query_stats["biEngineStatistics"] = {"biEngineMode": "FULL"}
+        assert isinstance(job.bi_engine_stats, BiEngineStats)
+        assert job.bi_engine_stats.mode == "FULL"
+
     def test_dml_stats(self):
         from google.cloud.bigquery.job.query import DmlStats
 

--- a/tests/unit/job/test_query_stats.py
+++ b/tests/unit/job/test_query_stats.py
@@ -13,6 +13,63 @@
 # limitations under the License.
 
 from .helpers import _Base
+from google.cloud.bigquery.enums import BiEngineMode, BiEngineReasonCode
+
+
+class TestBiEngineStats:
+    @staticmethod
+    def _get_target_class():
+        from google.cloud.bigquery.job.query import BiEngineStats
+
+        return BiEngineStats
+
+    def _make_one(self, *args, **kw):
+        return self._get_target_class()(*args, **kw)
+
+    def test_ctor_defaults(self):
+        bi_engine_stats = self._make_one()
+        assert bi_engine_stats.mode == BiEngineMode.ACCELERATION_MODE_UNSPECIFIED
+        assert bi_engine_stats.reasons == []
+
+    def test_from_api_repr_unspecified(self):
+        klass = self._get_target_class()
+        result = klass.from_api_repr({"biEngineMode": "ACCELERATION_MODE_UNSPECIFIED"})
+
+        assert isinstance(result, klass)
+        assert result.mode == BiEngineMode.ACCELERATION_MODE_UNSPECIFIED
+        assert result.reasons == []
+
+    def test_from_api_repr_full(self):
+        klass = self._get_target_class()
+        result = klass.from_api_repr({"biEngineMode": "FULL"})
+
+        assert isinstance(result, klass)
+        assert result.mode == BiEngineMode.FULL
+        assert result.reasons == []
+
+    def test_from_api_repr_disabled(self):
+        klass = self._get_target_class()
+        result = klass.from_api_repr(
+            {
+                "biEngineMode": "DISABLED",
+                "biEngineReasons": [
+                    {
+                        "code": "OTHER_REASON",
+                        "message": "Unable to support input table xyz due to an internal error.",
+                    }
+                ],
+            }
+        )
+
+        assert isinstance(result, klass)
+        assert result.mode == BiEngineMode.DISABLED
+
+        reason = result.reasons[0]
+        assert reason.code == BiEngineReasonCode.OTHER_REASON
+        assert (
+            reason.reason
+            == "Unable to support input table xyz due to an internal error."
+        )
 
 
 class TestDmlStats:

--- a/tests/unit/job/test_query_stats.py
+++ b/tests/unit/job/test_query_stats.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from .helpers import _Base
-from google.cloud.bigquery.enums import BiEngineMode, BiEngineReasonCode
 
 
 class TestBiEngineStats:
@@ -28,7 +27,7 @@ class TestBiEngineStats:
 
     def test_ctor_defaults(self):
         bi_engine_stats = self._make_one()
-        assert bi_engine_stats.mode == BiEngineMode.ACCELERATION_MODE_UNSPECIFIED
+        assert bi_engine_stats.mode == "ACCELERATION_MODE_UNSPECIFIED"
         assert bi_engine_stats.reasons == []
 
     def test_from_api_repr_unspecified(self):
@@ -36,7 +35,7 @@ class TestBiEngineStats:
         result = klass.from_api_repr({"biEngineMode": "ACCELERATION_MODE_UNSPECIFIED"})
 
         assert isinstance(result, klass)
-        assert result.mode == BiEngineMode.ACCELERATION_MODE_UNSPECIFIED
+        assert result.mode == "ACCELERATION_MODE_UNSPECIFIED"
         assert result.reasons == []
 
     def test_from_api_repr_full(self):
@@ -44,7 +43,7 @@ class TestBiEngineStats:
         result = klass.from_api_repr({"biEngineMode": "FULL"})
 
         assert isinstance(result, klass)
-        assert result.mode == BiEngineMode.FULL
+        assert result.mode == "FULL"
         assert result.reasons == []
 
     def test_from_api_repr_disabled(self):
@@ -62,10 +61,10 @@ class TestBiEngineStats:
         )
 
         assert isinstance(result, klass)
-        assert result.mode == BiEngineMode.DISABLED
+        assert result.mode == "DISABLED"
 
         reason = result.reasons[0]
-        assert reason.code == BiEngineReasonCode.OTHER_REASON
+        assert reason.code == "OTHER_REASON"
         assert (
             reason.reason
             == "Unable to support input table xyz due to an internal error."


### PR DESCRIPTION
The REST API return BiEngineStatistics which denotes if the query
was accelerated by BI Engine or not. This commit adds the necessary
function to access this information for executed queries.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #1054