### PR TITLE
samples: remove browser option from user credentials sample

### DIFF
--- a/samples/snippets/user_credentials.py
+++ b/samples/snippets/user_credentials.py
@@ -37,7 +37,7 @@ def main(project):
     # SSH or a remote Jupyter notebook, this flow will not work. Use the
     # `gcloud auth application-default login --no-browser` command or workload
     # identity federation to get authentication tokens, instead.
-    # 
+    #
     appflow.run_local_server()
 
     credentials = appflow.credentials

--- a/samples/snippets/user_credentials.py
+++ b/samples/snippets/user_credentials.py
@@ -23,26 +23,16 @@ your application.
 import argparse
 
 
-def main(project, launch_browser=True):
+def main(project):
     # [START bigquery_auth_user_flow]
     from google_auth_oauthlib import flow
 
-    # TODO: Uncomment the line below to set the `launch_browser` variable.
-    # launch_browser = True
-    #
-    # The `launch_browser` boolean variable indicates if a local server is used
-    # as the callback URL in the auth flow. A value of `True` is recommended,
-    # but a local server does not work if accessing the application remotely,
-    # such as over SSH or from a remote Jupyter notebook.
-
+    # A local server is used as the callback URL in the auth flow.
     appflow = flow.InstalledAppFlow.from_client_secrets_file(
         "client_secrets.json", scopes=["https://www.googleapis.com/auth/bigquery"]
     )
 
-    if launch_browser:
-        appflow.run_local_server()
-    else:
-        appflow.run_console()
+    appflow.run_local_server()
 
     credentials = appflow.credentials
     # [END bigquery_auth_user_flow]

--- a/samples/snippets/user_credentials.py
+++ b/samples/snippets/user_credentials.py
@@ -32,6 +32,12 @@ def main(project):
         "client_secrets.json", scopes=["https://www.googleapis.com/auth/bigquery"]
     )
 
+    # This launches a local server to be used as the callback URL in the desktop
+    # app auth flow. If you are accessing the application remotely, such as over
+    # SSH or a remote Jupyter notebook, this flow will not work. Use the
+    # `gcloud auth application-default login --no-browser` command or workload
+    # identity federation to get authentication tokens, instead.
+    # 
     appflow.run_local_server()
 
     credentials = appflow.credentials

--- a/samples/snippets/user_credentials_test.py
+++ b/samples/snippets/user_credentials_test.py
@@ -35,7 +35,7 @@ def mock_flow():
 
 
 def test_auth_query_console(mock_flow, capsys):
-    main(PROJECT, launch_browser=False)
+    main(PROJECT)
     out, _ = capsys.readouterr()
     # Fun fact: William P. Wood was the 1st director of the US Secret Service.
     assert "William" in out


### PR DESCRIPTION
`run_console` uses the OAuth out-of-band flow, which will stop working for new clients on February 28, 2022 and stop working for all clients on October 3, 2022.

https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html?m=1#disallowed-oob

> OAuth [out-of-band](https://developers.google.com/identity/protocols/oauth2/native-app#manual-copypaste) (OOB) is a legacy flow developed to support native clients which do not have a redirect URI like web apps to accept the credentials after a user approves an OAuth consent request. The OOB flow poses a remote phishing risk and clients must migrate to an alternative method to protect against this vulnerability. New clients will be unable to use this flow starting on Feb 28, 2022.
