### PR TITLE
fix(deps): require google-api-core >= 1.31.5, >= 2.3.2 on v1 release

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -206,7 +206,7 @@ def blacken(session):
 def docs(session):
     """Build the docs."""
 
-    session.install("ipython", "recommonmark", "sphinx", "sphinx_rtd_theme")
+    session.install("ipython", "recommonmark", "sphinx<3.0.0", "sphinx_rtd_theme")
     session.install("google-cloud-storage")
     session.install("-e", ".[all]")
 
@@ -216,39 +216,6 @@ def docs(session):
         "-W",  # warnings as errors
         "-T",  # show full traceback on exception
         "-N",  # no colors
-        "-b",
-        "html",
-        "-d",
-        os.path.join("docs", "_build", "doctrees", ""),
-        os.path.join("docs", ""),
-        os.path.join("docs", "_build", "html", ""),
-    )
-
-
-@nox.session(python="3.8")
-def docfx(session):
-    """Build the docfx yaml files for this library."""
-
-    session.install("-e", ".")
-    session.install("sphinx", "alabaster", "recommonmark", "sphinx-docfx-yaml")
-
-    shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
-    session.run(
-        "sphinx-build",
-        "-T",  # show full traceback on exception
-        "-N",  # no colors
-        "-D",
-        (
-            "extensions=sphinx.ext.autodoc,"
-            "sphinx.ext.autosummary,"
-            "docfx_yaml.extension,"
-            "sphinx.ext.intersphinx,"
-            "sphinx.ext.coverage,"
-            "sphinx.ext.napoleon,"
-            "sphinx.ext.todo,"
-            "sphinx.ext.viewcode,"
-            "recommonmark"
-        ),
         "-b",
         "html",
         "-d",

--- a/samples/update_dataset_access.py
+++ b/samples/update_dataset_access.py
@@ -28,8 +28,8 @@ def update_dataset_access(dataset_id):
 
     entry = bigquery.AccessEntry(
         role="READER",
-        entity_type="userByEmail",
-        entity_id="sample.bigquery.dev@gmail.com",
+        entity_type="groupByEmail",
+        entity_id="cloud-developer-relations@google.com",
     )
 
     entries = list(dataset.access_entries)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     'enum34; python_version < "3.4"',
     "google-api-core >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
-    "google-cloud-core >= 1.4.1, < 2.0dev",
+    "google-cloud-core >= 1.4.1, < 3.0dev",
     "google-resumable-media >= 0.6.0, < 2.0dev",
     "six >=1.13.0,< 2.0.0dev",
 ]

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ version = "1.28.0"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     'enum34; python_version < "3.4"',
-    "google-api-core >= 1.21.0, < 2.0dev",
+    "google-api-core >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
     "google-cloud-core >= 1.4.1, < 2.0dev",
     "google-resumable-media >= 0.6.0, < 2.0dev",
     "six >=1.13.0,< 2.0.0dev",

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -35,15 +35,33 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
+        from six.moves.urllib.parse import parse_qsl
+        from six.moves.urllib.parse import urlsplit
+
         conn = self._make_one(object())
-        URI = "/".join([conn.DEFAULT_API_ENDPOINT, "bigquery", conn.API_VERSION, "foo"])
-        self.assertEqual(conn.build_api_url("/foo"), URI)
+        uri = conn.build_api_url("/foo")
+        scheme, netloc, path, qs, _ = urlsplit(uri)
+        self.assertEqual("%s://%s" % (scheme, netloc), conn.API_BASE_URL)
+        self.assertEqual(path, "/".join(["", "bigquery", conn.API_VERSION, "foo"]))
+        parms = dict(parse_qsl(qs))
+        pretty_print = parms.pop("prettyPrint", "false")
+        self.assertEqual(pretty_print, "false")
+        self.assertEqual(parms, {})
 
     def test_build_api_url_w_custom_endpoint(self):
-        custom_endpoint = "https://www.foo-googleapis.com"
+        from six.moves.urllib.parse import parse_qsl
+        from six.moves.urllib.parse import urlsplit
+
+        custom_endpoint = "https://foo-bigquery.googleapis.com"
         conn = self._make_one(object(), api_endpoint=custom_endpoint)
-        URI = "/".join([custom_endpoint, "bigquery", conn.API_VERSION, "foo"])
-        self.assertEqual(conn.build_api_url("/foo"), URI)
+        uri = conn.build_api_url("/foo")
+        scheme, netloc, path, qs, _ = urlsplit(uri)
+        self.assertEqual("%s://%s" % (scheme, netloc), custom_endpoint)
+        self.assertEqual(path, "/".join(["", "bigquery", conn.API_VERSION, "foo"]))
+        parms = dict(parse_qsl(qs))
+        pretty_print = parms.pop("prettyPrint", "false")
+        self.assertEqual(pretty_print, "false")
+        self.assertEqual(parms, {})
 
     def test_build_api_url_w_extra_query_params(self):
         from six.moves.urllib.parse import parse_qsl


### PR DESCRIPTION
Allow google-api-core<3.0.0dev on previous release of library. This will be followed by a release PR.