### PR TITLE
fix: export bigquery.HivePartitioningOptions

### DIFF
--- a/google/cloud/bigquery/__init__.py
+++ b/google/cloud/bigquery/__init__.py
@@ -49,6 +49,7 @@ from google.cloud.bigquery.external_config import BigtableColumn
 from google.cloud.bigquery.external_config import CSVOptions
 from google.cloud.bigquery.external_config import GoogleSheetsOptions
 from google.cloud.bigquery.external_config import ExternalSourceFormat
+from google.cloud.bigquery.external_config import HivePartitioningOptions
 from google.cloud.bigquery.format_options import AvroOptions
 from google.cloud.bigquery.format_options import ParquetOptions
 from google.cloud.bigquery.job.base import SessionInfo
@@ -161,6 +162,7 @@ __all__ = [
     "DmlStats",
     "CSVOptions",
     "GoogleSheetsOptions",
+    "HivePartitioningOptions",
     "ParquetOptions",
     "ScriptOptions",
     "TransactionInfo",

--- a/samples/snippets/create_table_external_hive_partitioned.py
+++ b/samples/snippets/create_table_external_hive_partitioned.py
@@ -50,7 +50,7 @@ def create_table_external_hive_partitioned(table_id: str) -> "bigquery.Table":
     external_config.autodetect = True
 
     # Configure partitioning options.
-    hive_partitioning_opts = bigquery.external_config.HivePartitioningOptions()
+    hive_partitioning_opts = bigquery.HivePartitioningOptions()
 
     # The layout of the files in here is compatible with the layout requirements for hive partitioning,
     # so we can add an optional Hive partitioning configuration to leverage the object paths for deriving


### PR DESCRIPTION
(I didn't file an issue for this because it's small) 🦕

My team programmatically creates externally partitioned tables and they hold some of our most core deliverables - they're working great! We followed the sample code here: https://cloud.google.com/bigquery/docs/samples/bigquery-create-table-external-hivepartitioned#bigquery_create_table_external_hivepartitioned-python

But Pylance complains about this line:
```python
hive_partitioning_opts = bigquery.external_config.HivePartitioningOptions()
```
> "external_config" is not a known member of module 

It seems like most of the other `*Options` classes are exported directly, so this does the same for HivePartitioningOptions.