### PR TITLE
fix: skip geography_as_object conversion for REPEATED fields

### DIFF
--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -1982,7 +1982,7 @@ class RowIterator(HTTPIterator):
 
         if geography_as_object:
             for field in self.schema:
-                if field.field_type.upper() == "GEOGRAPHY":
+                if field.field_type.upper() == "GEOGRAPHY" and field.mode != "REPEATED":
                     df[field.name] = df[field.name].dropna().apply(_read_wkt)
 
         return df


### PR DESCRIPTION
Fixes #1213 🦕

I looked into adding a test for this specific case but the existing test data helpers don't seem to support REPEATED fields from what I could tell, sooooo I gave up...
