### PR TITLE
feat: support using BIGQUERY_EMULATOR_HOST environment variable

### DIFF
--- a/google/cloud/bigquery/_helpers.py
+++ b/google/cloud/bigquery/_helpers.py
@@ -59,7 +59,7 @@ _DEFAULT_HOST = "https://bigquery.googleapis.com"
 """Default host for JSON API."""
 
 
-def _get_host():
+def _get_bigquery_host():
     return os.environ.get(BIGQUERY_EMULATOR_HOST, _DEFAULT_HOST)
 
 

--- a/google/cloud/bigquery/_helpers.py
+++ b/google/cloud/bigquery/_helpers.py
@@ -19,6 +19,7 @@ import datetime
 import decimal
 import math
 import re
+import os
 from typing import Optional, Union
 
 from dateutil import relativedelta
@@ -29,7 +30,6 @@ from google.cloud._helpers import _RFC3339_MICROS
 from google.cloud._helpers import _RFC3339_NO_FRACTION
 from google.cloud._helpers import _to_bytes
 import packaging.version
-
 
 _RFC3339_MICROS_NO_ZULU = "%Y-%m-%dT%H:%M:%S.%f"
 _TIMEONLY_WO_MICROS = "%H:%M:%S"
@@ -51,6 +51,14 @@ _INTERVAL_PATTERN = re.compile(
 
 _BQ_STORAGE_OPTIONAL_READ_SESSION_VERSION = packaging.version.Version("2.6.0")
 
+STORAGE_EMULATOR_ENV_VAR = "STORAGE_EMULATOR_HOST"
+"""Environment variable defining host for Storage emulator."""
+
+_DEFAULT_STORAGE_HOST = "https://storage.googleapis.com"
+"""Default storage host for JSON API."""
+
+def _get_storage_host():
+    return os.environ.get(STORAGE_EMULATOR_ENV_VAR, _DEFAULT_STORAGE_HOST)
 
 class BQStorageVersions:
     """Version comparisons for google-cloud-bigqueyr-storage package."""

--- a/google/cloud/bigquery/_helpers.py
+++ b/google/cloud/bigquery/_helpers.py
@@ -29,6 +29,7 @@ from google.cloud._helpers import _datetime_from_microseconds
 from google.cloud._helpers import _RFC3339_MICROS
 from google.cloud._helpers import _RFC3339_NO_FRACTION
 from google.cloud._helpers import _to_bytes
+
 import packaging.version
 
 _RFC3339_MICROS_NO_ZULU = "%Y-%m-%dT%H:%M:%S.%f"
@@ -51,14 +52,14 @@ _INTERVAL_PATTERN = re.compile(
 
 _BQ_STORAGE_OPTIONAL_READ_SESSION_VERSION = packaging.version.Version("2.6.0")
 
-STORAGE_EMULATOR_ENV_VAR = "STORAGE_EMULATOR_HOST"
-"""Environment variable defining host for Storage emulator."""
+BIGQUERY_EMULATOR_HOST = "BIGQUERY_EMULATOR_HOST"
+"""Environment variable defining host for emulator."""
 
-_DEFAULT_STORAGE_HOST = "https://storage.googleapis.com"
-"""Default storage host for JSON API."""
+_DEFAULT_HOST = "https://bigquery.googleapis.com"
+"""Default host for JSON API."""
 
-def _get_storage_host():
-    return os.environ.get(STORAGE_EMULATOR_ENV_VAR, _DEFAULT_STORAGE_HOST)
+def _get_host():
+    return os.environ.get(BIGQUERY_EMULATOR_HOST, _DEFAULT_HOST)
 
 class BQStorageVersions:
     """Version comparisons for google-cloud-bigqueyr-storage package."""

--- a/google/cloud/bigquery/_helpers.py
+++ b/google/cloud/bigquery/_helpers.py
@@ -58,8 +58,10 @@ BIGQUERY_EMULATOR_HOST = "BIGQUERY_EMULATOR_HOST"
 _DEFAULT_HOST = "https://bigquery.googleapis.com"
 """Default host for JSON API."""
 
+
 def _get_host():
     return os.environ.get(BIGQUERY_EMULATOR_HOST, _DEFAULT_HOST)
+
 
 class BQStorageVersions:
     """Version comparisons for google-cloud-bigqueyr-storage package."""

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -231,6 +231,7 @@ class Client(ClientWithProject):
         )
 
         kw_args = {"client_info": client_info}
+        # 
         storage_host = _get_storage_host()
         kw_args["api_endpoint"] = (
             storage_host if storage_host != _DEFAULT_STORAGE_HOST else None

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -66,7 +66,7 @@ from google.cloud.bigquery._helpers import _get_sub_prop
 from google.cloud.bigquery._helpers import _record_field_to_json
 from google.cloud.bigquery._helpers import _str_or_none
 from google.cloud.bigquery._helpers import _verify_job_config_type
-from google.cloud.bigquery._helpers import _get_host
+from google.cloud.bigquery._helpers import _get_bigquery_host
 from google.cloud.bigquery._helpers import _DEFAULT_HOST
 from google.cloud.bigquery._http import Connection
 from google.cloud.bigquery import _pandas_helpers
@@ -231,10 +231,9 @@ class Client(ClientWithProject):
         )
 
         kw_args = {"client_info": client_info}
-        #
-        storage_host = _get_host()
+        bq_host = _get_bigquery_host()
         kw_args["api_endpoint"] = (
-            storage_host if storage_host != _DEFAULT_HOST else None
+            bq_host if bq_host != _DEFAULT_HOST else None
         )
         if client_options:
             if type(client_options) == dict:

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -66,8 +66,8 @@ from google.cloud.bigquery._helpers import _get_sub_prop
 from google.cloud.bigquery._helpers import _record_field_to_json
 from google.cloud.bigquery._helpers import _str_or_none
 from google.cloud.bigquery._helpers import _verify_job_config_type
-from google.cloud.bigquery._helpers import _get_storage_host
-from google.cloud.bigquery._helpers import _DEFAULT_STORAGE_HOST
+from google.cloud.bigquery._helpers import _get_host
+from google.cloud.bigquery._helpers import _DEFAULT_HOST
 from google.cloud.bigquery._http import Connection
 from google.cloud.bigquery import _pandas_helpers
 from google.cloud.bigquery.dataset import Dataset
@@ -232,7 +232,7 @@ class Client(ClientWithProject):
 
         kw_args = {"client_info": client_info}
         # 
-        storage_host = _get_storage_host()
+        storage_host = _get_host()
         kw_args["api_endpoint"] = (
             storage_host if storage_host != _DEFAULT_STORAGE_HOST else None
         )

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -56,7 +56,6 @@ from google.api_core import retry as retries
 import google.cloud._helpers  # type: ignore
 from google.cloud import exceptions  # pytype: disable=import-error
 from google.cloud.client import ClientWithProject  # type: ignore  # pytype: disable=import-error
-
 from google.cloud.bigquery_storage_v1.services.big_query_read.client import (
     DEFAULT_CLIENT_INFO as DEFAULT_BQSTORAGE_CLIENT_INFO,
 )
@@ -67,6 +66,8 @@ from google.cloud.bigquery._helpers import _get_sub_prop
 from google.cloud.bigquery._helpers import _record_field_to_json
 from google.cloud.bigquery._helpers import _str_or_none
 from google.cloud.bigquery._helpers import _verify_job_config_type
+from google.cloud.bigquery._helpers import _get_storage_host
+from google.cloud.bigquery._helpers import _DEFAULT_STORAGE_HOST
 from google.cloud.bigquery._http import Connection
 from google.cloud.bigquery import _pandas_helpers
 from google.cloud.bigquery.dataset import Dataset
@@ -230,6 +231,10 @@ class Client(ClientWithProject):
         )
 
         kw_args = {"client_info": client_info}
+        storage_host = _get_storage_host()
+        kw_args["api_endpoint"] = (
+            storage_host if storage_host != _DEFAULT_STORAGE_HOST else None
+        )
         if client_options:
             if type(client_options) == dict:
                 client_options = google.api_core.client_options.from_dict(

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -231,10 +231,10 @@ class Client(ClientWithProject):
         )
 
         kw_args = {"client_info": client_info}
-        # 
+        #
         storage_host = _get_host()
         kw_args["api_endpoint"] = (
-            storage_host if storage_host != _DEFAULT_STORAGE_HOST else None
+            storage_host if storage_host != _DEFAULT_HOST else None
         )
         if client_options:
             if type(client_options) == dict:

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -232,9 +232,7 @@ class Client(ClientWithProject):
 
         kw_args = {"client_info": client_info}
         bq_host = _get_bigquery_host()
-        kw_args["api_endpoint"] = (
-            bq_host if bq_host != _DEFAULT_HOST else None
-        )
+        kw_args["api_endpoint"] = bq_host if bq_host != _DEFAULT_HOST else None
         if client_options:
             if type(client_options) == dict:
                 client_options = google.api_core.client_options.from_dict(

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -1315,9 +1315,25 @@ class Test__get_bigquery_host(unittest.TestCase):
 
         self.assertEqual(host, HOST)
 
-    def test_api_val(self):
-        return 
-        #if there is an emulator check that BIGQUERY_EMULATOR_HOST value is passed correctly to api
-        #if there is not an emulator check that _DEFAULT_HOST value is passed correctly to api
-        # where is the value moved to api? 
-        #the endpoint is set in client_options
+    @staticmethod
+    def _get_target_class():
+        from google.cloud.bigquery.client import Client
+
+        return Client
+
+    def _make_one(self, *args, **kw):
+        return self._get_target_class()(*args, **kw)
+
+    def test_default_endpoint(self):
+        from google.cloud.bigquery._helpers import _DEFAULT_HOST
+
+        client = self._make_one()
+
+        self.assertEqual(client._connection.API_BASE_URL, _DEFAULT_HOST)
+
+    def test_bigquery_emulator_host(self):
+        client_options = {"api_endpoint": "https://www.foo-googleapis.com"}
+        client = self._make_one(client_options=client_options)
+        self.assertEqual(
+            client._connection.API_BASE_URL, "https://www.foo-googleapis.com"
+        )

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -1289,6 +1289,7 @@ def test_decimal_as_float_api_repr():
         "name": "x",
     }
 
+
 class Test__get_storage_host(unittest.TestCase):
     @staticmethod
     def _call_fut():
@@ -1308,7 +1309,7 @@ class Test__get_storage_host(unittest.TestCase):
         from google.cloud.bigquery._helpers import BIGQUERY_EMULATOR_HOST
 
         HOST = "https://api.example.com"
-    
+
         with mock.patch("os.environ", {BIGQUERY_EMULATOR_HOST: HOST}):
             host = self._call_fut()
 

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -1288,3 +1288,28 @@ def test_decimal_as_float_api_repr():
         "parameterValue": {"value": 42.0},
         "name": "x",
     }
+
+class Test__get_storage_host(unittest.TestCase):
+    @staticmethod
+    def _call_fut():
+        from google.cloud.storage._helpers import _get_storage_host
+
+        return _get_storage_host()
+
+    def test_wo_env_var(self):
+        from google.cloud.storage._helpers import _DEFAULT_STORAGE_HOST
+
+        with mock.patch("os.environ", {}):
+            host = self._call_fut()
+
+        self.assertEqual(host, _DEFAULT_STORAGE_HOST)
+
+    def test_w_env_var(self):
+        from google.cloud.storage._helpers import STORAGE_EMULATOR_ENV_VAR
+
+        HOST = "https://api.example.com"
+    
+        with mock.patch("os.environ", {STORAGE_EMULATOR_ENV_VAR: HOST}):
+            host = self._call_fut()
+
+        self.assertEqual(host, HOST)

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -1290,12 +1290,12 @@ def test_decimal_as_float_api_repr():
     }
 
 
-class Test__get_storage_host(unittest.TestCase):
+class Test__get_bigquery_host(unittest.TestCase):
     @staticmethod
     def _call_fut():
-        from google.cloud.bigquery._helpers import _get_host
+        from google.cloud.bigquery._helpers import _get_bigquery_host
 
-        return _get_host()
+        return _get_bigquery_host()
 
     def test_wo_env_var(self):
         from google.cloud.bigquery._helpers import _DEFAULT_HOST
@@ -1314,3 +1314,10 @@ class Test__get_storage_host(unittest.TestCase):
             host = self._call_fut()
 
         self.assertEqual(host, HOST)
+
+    def test_api_val(self):
+        return 
+        #if there is an emulator check that BIGQUERY_EMULATOR_HOST value is passed correctly to api
+        #if there is not an emulator check that _DEFAULT_HOST value is passed correctly to api
+        # where is the value moved to api? 
+        #the endpoint is set in client_options

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -1314,26 +1314,3 @@ class Test__get_bigquery_host(unittest.TestCase):
             host = self._call_fut()
 
         self.assertEqual(host, HOST)
-
-    @staticmethod
-    def _get_target_class():
-        from google.cloud.bigquery.client import Client
-
-        return Client
-
-    def _make_one(self, *args, **kw):
-        return self._get_target_class()(*args, **kw)
-
-    def test_default_endpoint(self):
-        from google.cloud.bigquery._helpers import _DEFAULT_HOST
-
-        client = self._make_one()
-
-        self.assertEqual(client._connection.API_BASE_URL, _DEFAULT_HOST)
-
-    def test_bigquery_emulator_host(self):
-        client_options = {"api_endpoint": "https://www.foo-googleapis.com"}
-        client = self._make_one(client_options=client_options)
-        self.assertEqual(
-            client._connection.API_BASE_URL, "https://www.foo-googleapis.com"
-        )

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -1292,24 +1292,24 @@ def test_decimal_as_float_api_repr():
 class Test__get_storage_host(unittest.TestCase):
     @staticmethod
     def _call_fut():
-        from google.cloud.storage._helpers import _get_storage_host
+        from google.cloud.bigquery._helpers import _get_host
 
-        return _get_storage_host()
+        return _get_host()
 
     def test_wo_env_var(self):
-        from google.cloud.storage._helpers import _DEFAULT_STORAGE_HOST
+        from google.cloud.bigquery._helpers import _DEFAULT_HOST
 
         with mock.patch("os.environ", {}):
             host = self._call_fut()
 
-        self.assertEqual(host, _DEFAULT_STORAGE_HOST)
+        self.assertEqual(host, _DEFAULT_HOST)
 
     def test_w_env_var(self):
-        from google.cloud.storage._helpers import STORAGE_EMULATOR_ENV_VAR
+        from google.cloud.bigquery._helpers import BIGQUERY_EMULATOR_HOST
 
         HOST = "https://api.example.com"
     
-        with mock.patch("os.environ", {STORAGE_EMULATOR_ENV_VAR: HOST}):
+        with mock.patch("os.environ", {BIGQUERY_EMULATOR_HOST: HOST}):
             host = self._call_fut()
 
         self.assertEqual(host, HOST)


### PR DESCRIPTION
## What?
Implemented a BIGQUERY_EMULATOR_HOST environment variable to be used to set the api_endpoint in the python-bigquery client constructor.

## Why?
Users have requested this implementation (#1193). Currently there is no logic to check for the existence of a BIGQUERY_EMULATOR_HOST or some similar environment variable

## How?
Logic was applied and code was changed in the _helpers.py and client.py files.
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #1193 🦕
