### PR TITLE
feat: add sample to list all datasets and tables for a project in a dataframe

### DIFF
--- a/samples/list_all_datasets_and_tables_dataframe.py
+++ b/samples/list_all_datasets_and_tables_dataframe.py
@@ -1,0 +1,86 @@
+# Copyright 2022 Cedarwood Insights Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import typing
+
+if typing.TYPE_CHECKING:
+    import pandas
+
+def list_all_datasets_and_tables_df() -> "pandas.DataFrame":
+    """
+    List all Datasets and Tables for a GCP Project
+    Return the results in a Pandas DataFrame
+    """
+    # [START bigquery_list_all_datasets_and_tables]
+
+    import pandas
+    from google.cloud import bigquery
+
+    # Construct a BigQuery client object.
+    client = bigquery.Client()
+    project = client.project
+
+    # Create empty Python lists
+    dataset_list = []
+    final_table_list = []
+
+    # Grab the Datasets for the Project
+    datasets = list(client.list_datasets())  # Make an API request.
+
+    if datasets:
+
+        # Generate Python list of datasets
+        for dataset in datasets:
+            dataset_list.append(dataset.dataset_id)
+        print (dataset_list)
+
+        # Grab the Tables for the Dataset
+        for dataset_id in dataset_list:
+            full_dataset_id = f"{project}.{dataset_id}"
+            tables = list(client.list_tables(full_dataset_id))  # Make an API request.
+
+            if tables:
+
+                for table in tables:
+                    # Create dictionary for each table
+                    table_dict = {
+                        'project_id': table.project,
+                        'dataset_id': table.dataset_id,
+                        'table_id': table.table_id}
+                    # Append dictionary to final table list
+                    final_table_list.append(table_dict)
+
+            else:
+                table_dict = {
+                    'project_id': project,
+                    'dataset_id': dataset_id,
+                    'table_id': '[NO TABLES]'}
+                # Append dictionary to final table list
+                final_table_list.append(table_dict)
+
+    else:
+        table_dict = {
+            'project_id': project,
+            'dataset_id': '[NO DATASETS]',
+            'table_id': '[NO TABLES]'}
+        # Append dictionary to final table list
+        final_table_list.append(table_dict)
+
+    # Load resulting list of tables into a dataframe
+    dataset_tables_df = pandas.DataFrame(final_table_list)
+    print("Datasets and Tables in project {}:".format(project))
+    print (dataset_tables_df)
+
+    # [END bigquery_list_all_datasets_and_tables]
+    return dataset_tables_df

--- a/samples/tests/test_list_all_datasets_and_tables_dataframe.py
+++ b/samples/tests/test_list_all_datasets_and_tables_dataframe.py
@@ -1,0 +1,37 @@
+# Copyright 2022 Cedarwood Insights Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import typing
+
+import pytest
+
+from .. import list_all_datasets_and_tables_dataframe
+
+if typing.TYPE_CHECKING:
+    from google.cloud import bigquery
+
+pandas = pytest.importorskip("pandas")
+
+
+def test_list_all_datasets_and_tables_dataframe(
+    capsys: "pytest.CaptureFixture[str]", client: "bigquery.Client"
+) -> None:
+    dataset_tables_df = (
+        list_all_datasets_and_tables_dataframe.list_all_datasets_and_tables_df()
+    )
+    out, err = capsys.readouterr()
+    assert "Datasets and Tables in project {}:".format(client.project) in out
+    df = dataset_tables_df
+    assert df.columns.values.tolist() == ["project_id", "dataset_id", "table_id"]
+    assert df["project_id"].iloc[0] == client.project


### PR DESCRIPTION
Both the sample file and the required test file are provided
The sample passed local tests using Nox against Python vers 3-6 3-7 3-8 
3-9 and 3-10
Relates to Issue 1218

Here's some info about the test environment setup used:

### requirements.txt
db-dtypes==1.0.0
google-cloud-bigquery-storage==2.13.1
google-auth-oauthlib==0.5.1
grpcio==1.44.0
ipython===7.0.1; python_version == '3.6'
ipython===7.31.1; python_version == '3.7'
ipython===8.0.1; python_version == '3.8'
ipython==8.2.0; python_version >= '3.9'
pandas==1.0.0; python_version == '3.6'
pandas===1.3.5; python_version == '3.7'
pandas==1.4.2; python_version >= '3.8'
pyarrow==3.0.0; python_version == '3.6'
pyarrow==7.0.0; python_version >= '3.7'
pytz==2022.1
typing-extensions==4.1.1
google-cloud-bigquery==3.0.1

### requirements-test.txt
google-cloud-testutils==1.3.1
pytest==7.0.1; python_version == '3.6'
pytest==7.1.1; python_version >= '3.7'
mock==4.0.3

### conftest.py
The original source file used for this is here in the bigquery repo: [conftest.py](https://github.com/googleapis/python-bigquery/blob/main/samples/tests/conftest.py).

In my copy of this file I modified the order of loading the modules so that it would pass the lint checks. The modified order used was:

import datetime
from typing import Iterator
import uuid

import google.auth
from google.cloud import bigquery

import mock
import pytest

### Test Results
nox > Running session readmegen
nox > Session readmegen skipped: This session had no parameters available..
nox > Ran multiple sessions:
nox > * lint: success
nox > * blacken: success
nox > * py-3.6: success
nox > * py-3.7: success
nox > * py-3.8: success
nox > * py-3.9: success
nox > * py-3.10: success
nox > * readmegen: skipped

Kind regards
Mike

