### PR TITLE
fix: validate opentelemetry span job attributes have values

### DIFF
--- a/google/cloud/bigquery/opentelemetry_tracing.py
+++ b/google/cloud/bigquery/opentelemetry_tracing.py
@@ -107,10 +107,7 @@ def _set_client_attributes(client):
 def _set_job_attributes(job_ref):
     job_attributes = {
         "db.name": job_ref.project,
-        "location": job_ref.location,
-        "num_child_jobs": job_ref.num_child_jobs,
         "job_id": job_ref.job_id,
-        "parent_job_id": job_ref.parent_job_id,
         "state": job_ref.state,
     }
 
@@ -124,5 +121,14 @@ def _set_job_attributes(job_ref):
 
     if job_ref.ended is not None:
         job_attributes["timeEnded"] = job_ref.ended.isoformat()
+
+    if job_ref.location is not None:
+        job_attributes["location"] = job_ref.location
+
+    if job_ref.parent_job_id is not None:
+        job_attributes["parent_job_id"] = job_ref.parent_job_id
+
+    if job_ref.num_child_jobs is not None:
+        job_attributes["num_child_jobs"] = job_ref.num_child_jobs
 
     return job_attributes

--- a/tests/unit/test_opentelemetry_tracing.py
+++ b/tests/unit/test_opentelemetry_tracing.py
@@ -163,6 +163,7 @@ def test_default_job_attributes(setup):
             assert span.name == TEST_SPAN_NAME
             assert span.attributes == expected_attributes
 
+
 @pytest.mark.skipif(opentelemetry is None, reason="Require `opentelemetry`")
 def test_optional_job_attributes(setup):
     # This test ensures we don't propagate unset values into span attributes
@@ -178,6 +179,8 @@ def test_optional_job_attributes(setup):
         test_job_ref.project = "test_project_id"
         test_job_ref.created = time_created
         test_job_ref.state = "some_job_state"
+        test_job_ref.num_child_jobs = None
+        test_job_ref.parent_job_id = None
 
         with opentelemetry_tracing.create_span(
             TEST_SPAN_NAME, attributes=TEST_SPAN_ATTRIBUTES, job_ref=test_job_ref

--- a/tests/unit/test_opentelemetry_tracing.py
+++ b/tests/unit/test_opentelemetry_tracing.py
@@ -183,7 +183,7 @@ def test_optional_job_attributes(setup):
             TEST_SPAN_NAME, attributes=TEST_SPAN_ATTRIBUTES, job_ref=test_job_ref
         ) as span:
             assert span is not None
-            for key, val in span.attributes:
+            for val in span.attributes.values():
                 assert val is not None
 
 


### PR DESCRIPTION
There are several job properties that are optional.  Existing
opentelemetry instrumentation disallows span attribute keys without
appropriate values, so this change validates value presence before
propagating.

Fixes: https://github.com/googleapis/python-bigquery/issues/1140