### PR TITLE
Fix: Refactors code to account for a tdqm code deprecation

### DIFF
--- a/google/cloud/bigquery/_tqdm_helpers.py
+++ b/google/cloud/bigquery/_tqdm_helpers.py
@@ -49,7 +49,7 @@ def get_progress_bar(progress_bar_type, description, total, unit):
         if progress_bar_type == "tqdm":
             return tqdm.tqdm(desc=description, total=total, unit=unit)
         elif progress_bar_type == "tqdm_notebook":
-            return tqdm.tqdm_notebook(desc=description, total=total, unit=unit)
+            return tqdm.notebook.tqdm(desc=description, total=total, unit=unit)
         elif progress_bar_type == "tqdm_gui":
             return tqdm.tqdm_gui(desc=description, total=total, unit=unit)
     except (KeyError, TypeError):

--- a/google/cloud/bigquery/_tqdm_helpers.py
+++ b/google/cloud/bigquery/_tqdm_helpers.py
@@ -22,6 +22,7 @@ import warnings
 
 try:
     import tqdm  # type: ignore
+    from tqdm import notebook
 except ImportError:  # pragma: NO COVER
     tqdm = None
 

--- a/google/cloud/bigquery/_tqdm_helpers.py
+++ b/google/cloud/bigquery/_tqdm_helpers.py
@@ -22,7 +22,7 @@ import warnings
 
 try:
     import tqdm  # type: ignore
-    from tqdm import notebook
+
 except ImportError:  # pragma: NO COVER
     tqdm = None
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -178,7 +178,7 @@ def system(session):
     session.install("google-cloud-datacatalog", "-c", constraints_path)
 
     if session.python == "3.10":
-        extras = "[bqstorage,pandas,tqdm,opentelemetry]"
+        extras = "[bqstorage,pandas,tqdm,ipywidgets,opentelemetry]"
     else:
         extras = "[all]"
     session.install("-e", f".{extras}", "-c", constraints_path)

--- a/noxfile.py
+++ b/noxfile.py
@@ -178,7 +178,7 @@ def system(session):
     session.install("google-cloud-datacatalog", "-c", constraints_path)
 
     if session.python == "3.10":
-        extras = "[bqstorage,pandas,tqdm,ipywidgets,opentelemetry]"
+        extras = "[bqstorage,pandas,tqdm,opentelemetry]"
     else:
         extras = "[all]"
     session.install("-e", f".{extras}", "-c", constraints_path)

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -47,7 +47,7 @@ except (ImportError, AttributeError):  # pragma: NO COVER
 try:
     import tqdm
     from tqdm import notebook
-    from tqdm.std import TqdmDeprecationWarning 
+    from tqdm.std import TqdmDeprecationWarning
 
 except (ImportError, AttributeError):  # pragma: NO COVER
     tqdm = None
@@ -3284,7 +3284,10 @@ class TestRowIterator(unittest.TestCase):
             # Warn that a progress bar was requested, but creating the tqdm
             # progress bar failed.
             for warning in warned:
-                self.assertIn(warning.category, [UserWarning, DeprecationWarning, TqdmDeprecationWarning])
+                self.assertIn(
+                    warning.category,
+                    [UserWarning, DeprecationWarning, TqdmDeprecationWarning],
+                )
 
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_w_empty_results(self):

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -45,7 +45,9 @@ except (ImportError, AttributeError):  # pragma: NO COVER
     geopandas = None
 
 try:
-    from tqdm import tqdm
+    import tqdm
+    from tqdm import notebook
+
 except (ImportError, AttributeError):  # pragma: NO COVER
     tqdm = None
 
@@ -2798,7 +2800,7 @@ class TestRowIterator(unittest.TestCase):
 
     @unittest.skipIf(tqdm is None, "Requires `tqdm`")
     @mock.patch("tqdm.tqdm_gui")
-    @mock.patch("tqdm.tqdm_notebook")
+    @mock.patch("tqdm.notebook.tqdm")
     @mock.patch("tqdm.tqdm")
     def test_to_arrow_progress_bar(self, tqdm_mock, tqdm_notebook_mock, tqdm_gui_mock):
         from google.cloud.bigquery.schema import SchemaField
@@ -3146,7 +3148,7 @@ class TestRowIterator(unittest.TestCase):
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     @unittest.skipIf(tqdm is None, "Requires `tqdm`")
     @mock.patch("tqdm.tqdm_gui")
-    @mock.patch("tqdm.tqdm_notebook")
+    @mock.patch("tqdm.notebook.tqdm")
     @mock.patch("tqdm.tqdm")
     def test_to_dataframe_progress_bar(
         self, tqdm_mock, tqdm_notebook_mock, tqdm_gui_mock
@@ -3249,7 +3251,7 @@ class TestRowIterator(unittest.TestCase):
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     @unittest.skipIf(tqdm is None, "Requires `tqdm`")
     @mock.patch("tqdm.tqdm_gui", new=None)  # will raise TypeError on call
-    @mock.patch("tqdm.tqdm_notebook", new=None)  # will raise TypeError on call
+    @mock.patch("tqdm.notebook.tqdm", new=None)  # will raise TypeError on call
     @mock.patch("tqdm.tqdm", new=None)  # will raise TypeError on call
     def test_to_dataframe_tqdm_error(self):
         from google.cloud.bigquery.schema import SchemaField

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -46,7 +46,6 @@ except (ImportError, AttributeError):  # pragma: NO COVER
 
 try:
     import tqdm
-    from tqdm import notebook
     from tqdm.std import TqdmDeprecationWarning
 
 except (ImportError, AttributeError):  # pragma: NO COVER

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -47,6 +47,7 @@ except (ImportError, AttributeError):  # pragma: NO COVER
 try:
     import tqdm
     from tqdm import notebook
+    from tqdm.std import TqdmDeprecationWarning 
 
 except (ImportError, AttributeError):  # pragma: NO COVER
     tqdm = None
@@ -3283,7 +3284,7 @@ class TestRowIterator(unittest.TestCase):
             # Warn that a progress bar was requested, but creating the tqdm
             # progress bar failed.
             for warning in warned:
-                self.assertIs(warning.category, UserWarning)
+                self.assertIn(warning.category, [UserWarning, DeprecationWarning, TqdmDeprecationWarning])
 
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_w_empty_results(self):


### PR DESCRIPTION
`tqdm` has changed elements of their codebase and issued a deprecation warning. This change implements several refactors to account for those changes and mitigate the deprecation warning.

The `tdqm` library would issue the following deprecation warning:

```Please use `tqdm.notebook.tqdm` instead of `tqdm.tqdm_notebook
```

This PR:

* revises our code and tests to point at the new file/function
* alters the import statements accordingly
* accounts for potential differences in warnings that appear when errors happen in the tests

Fixes #1146 🦕
