### PR TITLE
Fix: refactor to adapt to changes to shapely dependency

### DIFF
--- a/google/cloud/bigquery/_pandas_helpers.py
+++ b/google/cloud/bigquery/_pandas_helpers.py
@@ -57,7 +57,7 @@ else:
     if pandas is not None:  # pragma: NO COVER
 
         def _to_wkb():
-            from shapely import wkb
+            from shapely import wkb  # type: ignore
 
             write = wkb.dumps
             notnull = pandas.notnull

--- a/google/cloud/bigquery/_pandas_helpers.py
+++ b/google/cloud/bigquery/_pandas_helpers.py
@@ -57,15 +57,9 @@ else:
     if pandas is not None:  # pragma: NO COVER
 
         def _to_wkb():
-            # Create a closure that:
-            # - Adds a not-null check. This allows the returned function to
-            #   be used directly with apply, unlike `shapely.wkb.dumps`.
-            # - Avoid extra work done by `shapely.wkb.dumps` that we don't need.
-            # - Caches the WKBWriter (and write method lookup :) )
-            # - Avoids adding WKBWriter, lgeos, and notnull to the module namespace.
-            from shapely.geos import WKBWriter, lgeos  # type: ignore
+            from shapely import wkb
 
-            write = WKBWriter(lgeos).write
+            write = wkb.dumps
             notnull = pandas.notnull
 
             def _to_wkb(v):

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -39,7 +39,7 @@ else:
     _COORDINATE_REFERENCE_SYSTEM = "EPSG:4326"
 
 try:
-    import shapely # type: ignore
+    import shapely  # type: ignore
 except ImportError:
     shapely = None
 else:

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -43,7 +43,9 @@ try:
 except ImportError:
     shapely = None
 else:
-    _read_wkt = shapely.geos.WKTReader(shapely.geos.lgeos).read
+    #_read_wkt = shapely.geos.WKTReader(shapely.geos.lgeos).read
+    _read_wkt = shapely.io.from_wkt
+
 
 import google.api_core.exceptions
 from google.api_core.page_iterator import HTTPIterator

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -39,7 +39,7 @@ else:
     _COORDINATE_REFERENCE_SYSTEM = "EPSG:4326"
 
 try:
-    import shapely.geos  # type: ignore
+    import shapely # type: ignore
 except ImportError:
     shapely = None
 else:

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -43,7 +43,7 @@ try:
 except ImportError:
     shapely = None
 else:
-    _read_wkt = shapely.io.from_wkt
+    _read_wkt = shapely.wkt.loads
 
 import google.api_core.exceptions
 from google.api_core.page_iterator import HTTPIterator

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -43,9 +43,7 @@ try:
 except ImportError:
     shapely = None
 else:
-    #_read_wkt = shapely.geos.WKTReader(shapely.geos.lgeos).read
     _read_wkt = shapely.io.from_wkt
-
 
 import google.api_core.exceptions
 from google.api_core.page_iterator import HTTPIterator


### PR DESCRIPTION
The `shapely` library has undergone some internal refactoring.
Certain classes, such as `WKTReader` are no longer used, instead, the library relies on some functions that are imported from what appears to be `pygeos`.

This change points at the correct function to replace the outdated method call.

* **NEW**: shapely.wkt.loads()
* **OLD**: shapely.geos.WKTReader(shapely.geos.lgeos).read

Fixes #1364 🦕

**Context**:

This issue appeared when running a test in `python-bigquery-sqlalchemy` ... when running certain tests in that library, the code tried to load the `tests/unit/testconf.py` file from that library which references `table.py` in this library. 

That was causing some failures in tests in the `python-bigquery-sqlalchemy` library.
