### PR TITLE
fix(deps): require requests>=2.21.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ dependencies = [
     "protobuf>=3.19.5,<5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",  # For the legacy proto-based types.
     "python-dateutil >= 2.7.2, <3.0dev",
     "pyarrow >= 3.0.0, < 10.0dev",
-    "requests >= 2.18.0, < 3.0.0dev",
+    "requests >= 2.21.0, < 3.0.0dev",
 ]
 extras = {
     # Keep the no-op bqstorage extra for backward compatibility.

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -22,7 +22,7 @@ proto-plus==1.22.0
 protobuf==3.19.5
 pyarrow==3.0.0
 python-dateutil==2.7.3
-requests==2.18.0
+requests==2.21.0
 Shapely==1.6.4.post2
 six==1.13.0
 tqdm==4.7.4


### PR DESCRIPTION
This fixes an issue where the Python 3.7 Kokoro job is timing out on `main`.

```
nox > Running session unit-3.7
nox > Creating virtual environment (virtualenv) using python3.7 in .nox/unit-3-7
nox > python -m pip install mock pytest google-cloud-testutils pytest-cov freezegun -c /tmpfs/src/github/python-bigquery/testing/constraints-3.7.txt
nox > python -m pip install -e '.[all]' -c /tmpfs/src/github/python-bigquery/testing/constraints-3.7.txt


ERROR: Aborting VM command due to timeout of 10800 seconds
```
See [build log](https://source.cloud.google.com/results/invocations/dfb82b0e-4a1f-4436-bd9d-ec8988ea974e/log)