### PR TITLE
fix: corrects test for non-existent attribute

### DIFF
--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -40,6 +40,7 @@ else:
 
 try:
     import shapely  # type: ignore
+    from shapely import wkt  # type: ignore
 except ImportError:
     shapely = None
 else:

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -44,7 +44,7 @@ try:
 except ImportError:
     shapely = None
 else:
-    _read_wkt = shapely.wkt.loads
+    _read_wkt = wkt.loads
 
 import google.api_core.exceptions
 from google.api_core.page_iterator import HTTPIterator

--- a/samples/geography/requirements.txt
+++ b/samples/geography/requirements.txt
@@ -10,7 +10,7 @@ db-dtypes==1.0.4
 Fiona==1.8.22
 geojson==2.5.0
 geopandas===0.10.2; python_version == '3.7'
-geopandas==0.11.1; python_version >= '3.8'
+geopandas==0.12.1; python_version >= '3.8'
 google-api-core==2.10.2
 google-auth==2.13.0
 google-cloud-bigquery==3.3.5

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -1971,9 +1971,9 @@ class Test_EmptyRowIterator(unittest.TestCase):
         self.assertIsInstance(df, geopandas.GeoDataFrame)
         self.assertEqual(len(df), 0)  # verify the number of rows
         if version_info.major == 3 and version_info.minor > 7:
-            assert not hasattr(df, "crs")  # used with Python == 3.7
+            assert not hasattr(df, "crs")  # used with Python > 3.7
         else:
-            self.assertIsNone(df.crs)  # used with Python > 3.7
+            self.assertIsNone(df.crs)  # used with Python == 3.7
 
 
 class TestRowIterator(unittest.TestCase):

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -1969,7 +1969,7 @@ class Test_EmptyRowIterator(unittest.TestCase):
         df = row_iterator.to_geodataframe(create_bqstorage_client=False)
         self.assertIsInstance(df, geopandas.GeoDataFrame)
         self.assertEqual(len(df), 0)  # verify the number of rows
-        self.assertIsNone(df.crs)
+        assert not hasattr(df, "crs")
 
 
 class TestRowIterator(unittest.TestCase):

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -15,6 +15,7 @@
 import datetime
 import logging
 import re
+from sys import version_info
 import time
 import types
 import unittest
@@ -1969,7 +1970,10 @@ class Test_EmptyRowIterator(unittest.TestCase):
         df = row_iterator.to_geodataframe(create_bqstorage_client=False)
         self.assertIsInstance(df, geopandas.GeoDataFrame)
         self.assertEqual(len(df), 0)  # verify the number of rows
-        assert not hasattr(df, "crs")
+        if version_info.major == 3 and version_info.minor > 7:
+            assert not hasattr(df, "crs")  # used with Python == 3.7
+        else:
+            self.assertIsNone(df.crs)  # used with Python > 3.7
 
 
 class TestRowIterator(unittest.TestCase):


### PR DESCRIPTION
A test was failing because we were attempting to access an attribute that does not exist (NOTE it is not supposed to exist for this test).

Our test was supposed to detect that the failing attribute did not exist by using an `assertIsNone()` test method, when we should have been asserting that the attribute does not exist, because within the `assertIsNone()` method, if the attribute does not exist when you call it, it raises an `AttributeError` instead of returning `None`.

