### PR TITLE
docs: adds snippet for creating table with external data config

### DIFF
--- a/docs/usage/tables.rst
+++ b/docs/usage/tables.rst
@@ -58,6 +58,15 @@ Create an empty table with the
    :start-after: [START bigquery_create_table]
    :end-before: [END bigquery_create_table]
 
+Create a table using an external data source with the
+:func:`~google.cloud.bigquery.client.Client.create_table` method:
+
+.. literalinclude:: ../samples/create_table_external_data_configuration.py
+   :language: python
+   :dedent: 4
+   :start-after: [START bigquery_create_table_external_data_configuration]
+   :end-before: [END bigquery_create_table_external_data_configuration]
+
 Create a clustered table with the
 :func:`~google.cloud.bigquery.client.Client.create_table` method:
 

--- a/samples/create_table_external_data_configuration.py
+++ b/samples/create_table_external_data_configuration.py
@@ -1,0 +1,63 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+
+def create_table_external_data_configuration(
+    table_id: str,
+    source_uris: List[str],
+    external_source_format: str,
+) -> None:
+    """Create a table using an external data source"""
+
+    # [START bigquery_create_table_external_data_configuration]
+    from google.cloud import bigquery
+
+    # Construct a BigQuery client object.
+    client = bigquery.Client()
+
+    """
+    TODO(developer):
+    Set table_id to the ID of the table to create.
+    table_id = "your-project.your_dataset.your_table_name"
+
+    Set the external source format of your table. # Note that the
+    set of allowed values for external data sources is different than the set used
+    for loading data (see :class:`~google.cloud.bigquery.job.SourceFormat`).
+    external_source_format = "your-source-format"
+
+    Set the source_uris to point to your data in Google Cloud
+    source_uris = ["your", "source", "uris"]
+    """
+
+    # Create ExternalConfig object with external source format
+    external_config = bigquery.ExternalConfig(external_source_format)
+    # Set source_uris that point to your data in Google Cloud
+    external_config.source_uris = source_uris
+
+    # You have the option to set a reference_file_schema_uri, which points to
+    # a reference file for the table schema
+    # external_config.reference_file_schema_uri = "path/to/your/reference/file/schema/uri"
+
+    table = bigquery.Table(table_id)
+    # Set the external data configuration of the table
+    table.external_data_configuration = external_config
+    table = client.create_table(table)  # Make an API request.
+
+    print(
+        f"Created table with external source format {table.external_data_configuration.source_format}"
+    )
+
+    # [END bigquery_create_table_external_data_configuration]

--- a/samples/create_table_external_data_configuration.py
+++ b/samples/create_table_external_data_configuration.py
@@ -23,6 +23,7 @@ def create_table_external_data_configuration(
     """Create a table using an external data source"""
 
     # [START bigquery_create_table_external_data_configuration]
+    # [START bigquery_create_external_table_definition]
     from google.cloud import bigquery
 
     # Construct a BigQuery client object.
@@ -50,6 +51,7 @@ def create_table_external_data_configuration(
     # You have the option to set a reference_file_schema_uri, which points to
     # a reference file for the table schema
     # external_config.reference_file_schema_uri = "path/to/your/reference/file/schema/uri"
+    # [END bigquery_create_external_table_definition]
 
     table = bigquery.Table(table_id)
     # Set the external data configuration of the table

--- a/samples/tests/conftest.py
+++ b/samples/tests/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import datetime
-from typing import Iterator
+from typing import Iterator, List
 import uuid
 
 import google.auth
@@ -45,6 +45,16 @@ def random_table_id(dataset_id: str) -> str:
         now.strftime("%Y%m%d%H%M%S"), uuid.uuid4().hex[:8]
     )
     return "{}.{}".format(dataset_id, random_table_id)
+
+
+@pytest.fixture
+def avro_source_uris() -> List[str]:
+    avro_source_uris = [
+        "gs://cloud-samples-data/bigquery/federated-formats-reference-file-schema/a-twitter.avro",
+        "gs://cloud-samples-data/bigquery/federated-formats-reference-file-schema/b-twitter.avro",
+        "gs://cloud-samples-data/bigquery/federated-formats-reference-file-schema/c-twitter.avro",
+    ]
+    return avro_source_uris
 
 
 @pytest.fixture

--- a/samples/tests/test_create_table_external_data_configuration.py
+++ b/samples/tests/test_create_table_external_data_configuration.py
@@ -25,7 +25,7 @@ def test_create_table_external_data_configuration(
     capsys: "pytest.CaptureFixture[str]",
     random_table_id: str,
     avro_source_uris: List[str],
-    external_source_format="AVRO",
+    external_source_format: str = "AVRO",
 ) -> None:
     create_table_external_data_configuration.create_table_external_data_configuration(
         random_table_id, avro_source_uris, external_source_format

--- a/samples/tests/test_create_table_external_data_configuration.py
+++ b/samples/tests/test_create_table_external_data_configuration.py
@@ -1,0 +1,34 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import typing
+from typing import List
+
+from .. import create_table_external_data_configuration
+
+if typing.TYPE_CHECKING:
+    import pytest
+
+
+def test_create_table_external_data_configuration(
+    capsys: "pytest.CaptureFixture[str]",
+    random_table_id: str,
+    avro_source_uris: List[str],
+    external_source_format="AVRO",
+) -> None:
+    create_table_external_data_configuration.create_table_external_data_configuration(
+        random_table_id, avro_source_uris, external_source_format
+    )
+    out, err = capsys.readouterr()
+    assert f"Created table with external source format {external_source_format}" in out


### PR DESCRIPTION
Adds snippet and test for `create_table_external_data_configuration`

- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #773  🦕
