### PR TITLE
fix: annotate optional integer parameters with optional type

### DIFF
--- a/google/cloud/bigquery/_http.py
+++ b/google/cloud/bigquery/_http.py
@@ -15,9 +15,7 @@
 """Create / interact with Google BigQuery connections."""
 
 import os
-import packaging.version
 
-import google.cloud.version
 from google.cloud import _http  # type: ignore  # pytype: disable=import-error
 from google.cloud.bigquery import __version__
 

--- a/google/cloud/bigquery/_http.py
+++ b/google/cloud/bigquery/_http.py
@@ -15,19 +15,11 @@
 """Create / interact with Google BigQuery connections."""
 
 import os
-import pkg_resources
+import packaging.version
 
+import google.cloud.version
 from google.cloud import _http  # type: ignore  # pytype: disable=import-error
 from google.cloud.bigquery import __version__
-
-
-# TODO: Increase the minimum version of google-cloud-core to 1.6.0
-# and remove this logic. See:
-# https://github.com/googleapis/python-bigquery/issues/509
-if os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE") == "true":  # pragma: NO COVER
-    release = pkg_resources.get_distribution("google-cloud-core").parsed_version
-    if release < pkg_resources.parse_version("1.6.0"):
-        raise ImportError("google-cloud-core >= 1.6.0 is required to use mTLS feature")
 
 
 class Connection(_http.JSONConnection):

--- a/google/cloud/bigquery/_http.py
+++ b/google/cloud/bigquery/_http.py
@@ -14,8 +14,6 @@
 
 """Create / interact with Google BigQuery connections."""
 
-import os
-
 from google.cloud import _http  # type: ignore  # pytype: disable=import-error
 from google.cloud.bigquery import __version__
 

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -329,11 +329,11 @@ class Client(ClientWithProject):
 
     def list_projects(
         self,
-        max_results: int = None,
+        max_results: Optional[int] = None,
         page_token: str = None,
         retry: retries.Retry = DEFAULT_RETRY,
         timeout: TimeoutType = DEFAULT_TIMEOUT,
-        page_size: int = None,
+        page_size: Optional[int] = None,
     ) -> page_iterator.Iterator:
         """List projects for the project associated with this client.
 
@@ -395,11 +395,11 @@ class Client(ClientWithProject):
         project: str = None,
         include_all: bool = False,
         filter: str = None,
-        max_results: int = None,
+        max_results: Optional[int] = None,
         page_token: str = None,
         retry: retries.Retry = DEFAULT_RETRY,
         timeout: TimeoutType = DEFAULT_TIMEOUT,
-        page_size: int = None,
+        page_size: Optional[int] = None,
     ) -> page_iterator.Iterator:
         """List datasets for the project associated with this client.
 
@@ -1324,11 +1324,11 @@ class Client(ClientWithProject):
     def list_models(
         self,
         dataset: Union[Dataset, DatasetReference, DatasetListItem, str],
-        max_results: int = None,
+        max_results: Optional[int] = None,
         page_token: str = None,
         retry: retries.Retry = DEFAULT_RETRY,
         timeout: TimeoutType = DEFAULT_TIMEOUT,
-        page_size: int = None,
+        page_size: Optional[int] = None,
     ) -> page_iterator.Iterator:
         """[Beta] List models in the dataset.
 
@@ -1401,11 +1401,11 @@ class Client(ClientWithProject):
     def list_routines(
         self,
         dataset: Union[Dataset, DatasetReference, DatasetListItem, str],
-        max_results: int = None,
+        max_results: Optional[int] = None,
         page_token: str = None,
         retry: retries.Retry = DEFAULT_RETRY,
         timeout: TimeoutType = DEFAULT_TIMEOUT,
-        page_size: int = None,
+        page_size: Optional[int] = None,
     ) -> page_iterator.Iterator:
         """[Beta] List routines in the dataset.
 
@@ -1478,11 +1478,11 @@ class Client(ClientWithProject):
     def list_tables(
         self,
         dataset: Union[Dataset, DatasetReference, DatasetListItem, str],
-        max_results: int = None,
+        max_results: Optional[int] = None,
         page_token: str = None,
         retry: retries.Retry = DEFAULT_RETRY,
         timeout: TimeoutType = DEFAULT_TIMEOUT,
-        page_size: int = None,
+        page_size: Optional[int] = None,
     ) -> page_iterator.Iterator:
         """List tables in the dataset.
 
@@ -1838,7 +1838,7 @@ class Client(ClientWithProject):
         job_id: str,
         retry: retries.Retry,
         project: str = None,
-        timeout_ms: int = None,
+        timeout_ms: Optional[int] = None,
         location: str = None,
         timeout: TimeoutType = DEFAULT_TIMEOUT,
     ) -> _QueryResults:
@@ -2163,7 +2163,7 @@ class Client(ClientWithProject):
         self,
         project: str = None,
         parent_job: Optional[Union[QueryJob, str]] = None,
-        max_results: int = None,
+        max_results: Optional[int] = None,
         page_token: str = None,
         all_users: bool = None,
         state_filter: str = None,
@@ -2171,7 +2171,7 @@ class Client(ClientWithProject):
         timeout: TimeoutType = DEFAULT_TIMEOUT,
         min_creation_time: datetime.datetime = None,
         max_creation_time: datetime.datetime = None,
-        page_size: int = None,
+        page_size: Optional[int] = None,
     ) -> page_iterator.Iterator:
         """List jobs for the project associated with this client.
 
@@ -2361,7 +2361,7 @@ class Client(ClientWithProject):
         file_obj: IO[bytes],
         destination: Union[Table, TableReference, TableListItem, str],
         rewind: bool = False,
-        size: int = None,
+        size: Optional[int] = None,
         num_retries: int = _DEFAULT_NUM_RETRIES,
         job_id: str = None,
         job_id_prefix: str = None,
@@ -3729,10 +3729,10 @@ class Client(ClientWithProject):
         self,
         table: Union[Table, TableListItem, TableReference, str],
         selected_fields: Sequence[SchemaField] = None,
-        max_results: int = None,
+        max_results: Optional[int] = None,
         page_token: str = None,
-        start_index: int = None,
-        page_size: int = None,
+        start_index: Optional[int] = None,
+        page_size: Optional[int] = None,
         retry: retries.Retry = DEFAULT_RETRY,
         timeout: TimeoutType = DEFAULT_TIMEOUT,
     ) -> RowIterator:
@@ -3840,11 +3840,11 @@ class Client(ClientWithProject):
         location: str,
         project: str,
         schema: SchemaField,
-        total_rows: int = None,
+        total_rows: Optional[int] = None,
         destination: Union[Table, TableReference, TableListItem, str] = None,
-        max_results: int = None,
-        start_index: int = None,
-        page_size: int = None,
+        max_results: Optional[int] = None,
+        start_index: Optional[int] = None,
+        page_size: Optional[int] = None,
         retry: retries.Retry = DEFAULT_RETRY,
         timeout: TimeoutType = DEFAULT_TIMEOUT,
     ) -> RowIterator:

--- a/google/cloud/bigquery/job/query.py
+++ b/google/cloud/bigquery/job/query.py
@@ -1381,11 +1381,11 @@ class QueryJob(_AsyncJob):
 
     def result(  # type: ignore  # (complaints about the overloaded signature)
         self,
-        page_size: int = None,
-        max_results: int = None,
+        page_size: Optional[int] = None,
+        max_results: Optional[int] = None,
         retry: "retries.Retry" = DEFAULT_RETRY,
         timeout: float = None,
-        start_index: int = None,
+        start_index: Optional[int] = None,
         job_retry: "retries.Retry" = DEFAULT_JOB_RETRY,
     ) -> Union["RowIterator", _EmptyRowIterator]:
         """Start the job and wait for it to complete and get the result.

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ dependencies = [
     # NOTE: Maintainers, please do not require google-cloud-core>=2.x.x
     # Until this issue is closed
     # https://github.com/googleapis/google-cloud-python/issues/10566
-    "google-cloud-core >= 1.4.1, <3.0.0dev",
+    "google-cloud-core >= 1.6.0, <3.0.0dev",
     "google-resumable-media >= 0.6.0, < 3.0dev",
     "packaging >= 20.0.0",
     "protobuf>=3.19.5,<5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",  # For the legacy proto-based types.

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -9,7 +9,7 @@ db-dtypes==0.3.0
 geopandas==0.9.0
 google-api-core==1.31.5
 google-cloud-bigquery-storage==2.0.0
-google-cloud-core==1.4.1
+google-cloud-core==1.6.0
 google-resumable-media==0.6.0
 grpcio==1.47.0
 ipywidgets==7.7.1


### PR DESCRIPTION
I noticed in a project that uses this client that the type annotations for `result` are incorrect.

```
bigframes/dataframe.py:64: error: Argument "max_results" to "result" of "QueryJob" has incompatible type "Optional[int]"; expected "int"  [arg-type]
```

Fixes https://github.com/googleapis/python-bigquery/issues/509
