### PR TITLE
docs: Remove < 3.11 reference from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ dependencies.
 
 Supported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-Python >= 3.7, < 3.11
+Python >= 3.7
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
With #1413, python < 4 are all supported. Updating the README to communicate this change (I had to look around the repo to verify this info before upgrading to 3.11)

Follow up on #1412