### PR TITLE
feat: expose configuration property on CopyJob, ExtractJob, LoadJob, QueryJob

### DIFF
--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -1976,15 +1976,8 @@ class Client(ClientWithProject):
             )
             destination = _get_sub_prop(job_config, ["copy", "destinationTable"])
             destination = TableReference.from_api_repr(destination)
-            sources = []
-            source_configs = _get_sub_prop(job_config, ["copy", "sourceTables"])
-            if source_configs is None:
-                source_configs = [_get_sub_prop(job_config, ["copy", "sourceTable"])]
-            for source_config in source_configs:
-                table_ref = TableReference.from_api_repr(source_config)
-                sources.append(table_ref)
             return self.copy_table(
-                sources,
+                [],  # Source table(s) already in job_config resource.
                 destination,
                 job_config=typing.cast(CopyJobConfig, copy_job_config),
                 retry=retry,

--- a/google/cloud/bigquery/job/copy_.py
+++ b/google/cloud/bigquery/job/copy_.py
@@ -14,6 +14,7 @@
 
 """Classes for copy jobs."""
 
+import typing
 from typing import Optional
 
 from google.cloud.bigquery.encryption_configuration import EncryptionConfiguration
@@ -160,15 +161,13 @@ class CopyJob(_AsyncJob):
     """
 
     _JOB_TYPE = "copy"
+    _CONFIG_CLASS = CopyJobConfig
 
     def __init__(self, job_id, sources, destination, client, job_config=None):
         super(CopyJob, self).__init__(job_id, client)
 
-        if not job_config:
-            job_config = CopyJobConfig()
-
-        self._configuration = job_config
-        self._properties["configuration"] = job_config._properties
+        if job_config is not None:
+            self._properties["configuration"] = job_config._properties
 
         if destination:
             _helpers._set_sub_prop(
@@ -184,6 +183,11 @@ class CopyJob(_AsyncJob):
                 ["configuration", "copy", "sourceTables"],
                 source_resources,
             )
+
+    @property
+    def configuration(self) -> CopyJobConfig:
+        """The configuration for this copy job."""
+        return typing.cast(CopyJobConfig, super().configuration)
 
     @property
     def destination(self):
@@ -223,14 +227,14 @@ class CopyJob(_AsyncJob):
         """See
         :attr:`google.cloud.bigquery.job.CopyJobConfig.create_disposition`.
         """
-        return self._configuration.create_disposition
+        return self.configuration.create_disposition
 
     @property
     def write_disposition(self):
         """See
         :attr:`google.cloud.bigquery.job.CopyJobConfig.write_disposition`.
         """
-        return self._configuration.write_disposition
+        return self.configuration.write_disposition
 
     @property
     def destination_encryption_configuration(self):
@@ -243,7 +247,7 @@ class CopyJob(_AsyncJob):
         See
         :attr:`google.cloud.bigquery.job.CopyJobConfig.destination_encryption_configuration`.
         """
-        return self._configuration.destination_encryption_configuration
+        return self.configuration.destination_encryption_configuration
 
     def to_api_repr(self):
         """Generate a resource for :meth:`_begin`."""

--- a/google/cloud/bigquery/job/extract.py
+++ b/google/cloud/bigquery/job/extract.py
@@ -14,6 +14,8 @@
 
 """Classes for extract (export) jobs."""
 
+import typing
+
 from google.cloud.bigquery import _helpers
 from google.cloud.bigquery.model import ModelReference
 from google.cloud.bigquery.table import Table
@@ -125,15 +127,13 @@ class ExtractJob(_AsyncJob):
     """
 
     _JOB_TYPE = "extract"
+    _CONFIG_CLASS = ExtractJobConfig
 
     def __init__(self, job_id, source, destination_uris, client, job_config=None):
         super(ExtractJob, self).__init__(job_id, client)
 
-        if job_config is None:
-            job_config = ExtractJobConfig()
-
-        self._properties["configuration"] = job_config._properties
-        self._configuration = job_config
+        if job_config is not None:
+            self._properties["configuration"] = job_config._properties
 
         if source:
             source_ref = {"projectId": source.project, "datasetId": source.dataset_id}
@@ -155,6 +155,11 @@ class ExtractJob(_AsyncJob):
                 ["configuration", "extract", "destinationUris"],
                 destination_uris,
             )
+
+    @property
+    def configuration(self) -> ExtractJobConfig:
+        """The configuration for this extract job."""
+        return typing.cast(ExtractJobConfig, super().configuration)
 
     @property
     def source(self):
@@ -189,28 +194,28 @@ class ExtractJob(_AsyncJob):
         """See
         :attr:`google.cloud.bigquery.job.ExtractJobConfig.compression`.
         """
-        return self._configuration.compression
+        return self.configuration.compression
 
     @property
     def destination_format(self):
         """See
         :attr:`google.cloud.bigquery.job.ExtractJobConfig.destination_format`.
         """
-        return self._configuration.destination_format
+        return self.configuration.destination_format
 
     @property
     def field_delimiter(self):
         """See
         :attr:`google.cloud.bigquery.job.ExtractJobConfig.field_delimiter`.
         """
-        return self._configuration.field_delimiter
+        return self.configuration.field_delimiter
 
     @property
     def print_header(self):
         """See
         :attr:`google.cloud.bigquery.job.ExtractJobConfig.print_header`.
         """
-        return self._configuration.print_header
+        return self.configuration.print_header
 
     @property
     def destination_uri_file_counts(self):

--- a/google/cloud/bigquery/job/load.py
+++ b/google/cloud/bigquery/job/load.py
@@ -14,6 +14,7 @@
 
 """Classes for load jobs."""
 
+import typing
 from typing import FrozenSet, List, Iterable, Optional
 
 from google.cloud.bigquery.encryption_configuration import EncryptionConfiguration
@@ -605,15 +606,13 @@ class LoadJob(_AsyncJob):
     """
 
     _JOB_TYPE = "load"
+    _CONFIG_CLASS = LoadJobConfig
 
     def __init__(self, job_id, source_uris, destination, client, job_config=None):
         super(LoadJob, self).__init__(job_id, client)
 
-        if not job_config:
-            job_config = LoadJobConfig()
-
-        self._configuration = job_config
-        self._properties["configuration"] = job_config._properties
+        if job_config is not None:
+            self._properties["configuration"] = job_config._properties
 
         if source_uris is not None:
             _helpers._set_sub_prop(
@@ -626,6 +625,11 @@ class LoadJob(_AsyncJob):
                 ["configuration", "load", "destinationTable"],
                 destination.to_api_repr(),
             )
+
+    @property
+    def configuration(self) -> LoadJobConfig:
+        """The configuration for this load job."""
+        return typing.cast(LoadJobConfig, super().configuration)
 
     @property
     def destination(self):
@@ -654,21 +658,21 @@ class LoadJob(_AsyncJob):
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.allow_jagged_rows`.
         """
-        return self._configuration.allow_jagged_rows
+        return self.configuration.allow_jagged_rows
 
     @property
     def allow_quoted_newlines(self):
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.allow_quoted_newlines`.
         """
-        return self._configuration.allow_quoted_newlines
+        return self.configuration.allow_quoted_newlines
 
     @property
     def autodetect(self):
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.autodetect`.
         """
-        return self._configuration.autodetect
+        return self.configuration.autodetect
 
     @property
     def connection_properties(self) -> List[ConnectionProperty]:
@@ -677,14 +681,14 @@ class LoadJob(_AsyncJob):
 
         .. versionadded:: 3.7.0
         """
-        return self._configuration.connection_properties
+        return self.configuration.connection_properties
 
     @property
     def create_disposition(self):
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.create_disposition`.
         """
-        return self._configuration.create_disposition
+        return self.configuration.create_disposition
 
     @property
     def create_session(self) -> Optional[bool]:
@@ -693,84 +697,84 @@ class LoadJob(_AsyncJob):
 
         .. versionadded:: 3.7.0
         """
-        return self._configuration.create_session
+        return self.configuration.create_session
 
     @property
     def encoding(self):
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.encoding`.
         """
-        return self._configuration.encoding
+        return self.configuration.encoding
 
     @property
     def field_delimiter(self):
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.field_delimiter`.
         """
-        return self._configuration.field_delimiter
+        return self.configuration.field_delimiter
 
     @property
     def ignore_unknown_values(self):
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.ignore_unknown_values`.
         """
-        return self._configuration.ignore_unknown_values
+        return self.configuration.ignore_unknown_values
 
     @property
     def max_bad_records(self):
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.max_bad_records`.
         """
-        return self._configuration.max_bad_records
+        return self.configuration.max_bad_records
 
     @property
     def null_marker(self):
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.null_marker`.
         """
-        return self._configuration.null_marker
+        return self.configuration.null_marker
 
     @property
     def quote_character(self):
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.quote_character`.
         """
-        return self._configuration.quote_character
+        return self.configuration.quote_character
 
     @property
     def reference_file_schema_uri(self):
         """See:
         attr:`google.cloud.bigquery.job.LoadJobConfig.reference_file_schema_uri`.
         """
-        return self._configuration.reference_file_schema_uri
+        return self.configuration.reference_file_schema_uri
 
     @property
     def skip_leading_rows(self):
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.skip_leading_rows`.
         """
-        return self._configuration.skip_leading_rows
+        return self.configuration.skip_leading_rows
 
     @property
     def source_format(self):
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.source_format`.
         """
-        return self._configuration.source_format
+        return self.configuration.source_format
 
     @property
     def write_disposition(self):
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.write_disposition`.
         """
-        return self._configuration.write_disposition
+        return self.configuration.write_disposition
 
     @property
     def schema(self):
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.schema`.
         """
-        return self._configuration.schema
+        return self.configuration.schema
 
     @property
     def destination_encryption_configuration(self):
@@ -783,7 +787,7 @@ class LoadJob(_AsyncJob):
         See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.destination_encryption_configuration`.
         """
-        return self._configuration.destination_encryption_configuration
+        return self.configuration.destination_encryption_configuration
 
     @property
     def destination_table_description(self):
@@ -792,7 +796,7 @@ class LoadJob(_AsyncJob):
         See:
         https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#DestinationTableProperties.FIELDS.description
         """
-        return self._configuration.destination_table_description
+        return self.configuration.destination_table_description
 
     @property
     def destination_table_friendly_name(self):
@@ -801,42 +805,42 @@ class LoadJob(_AsyncJob):
         See:
         https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#DestinationTableProperties.FIELDS.friendly_name
         """
-        return self._configuration.destination_table_friendly_name
+        return self.configuration.destination_table_friendly_name
 
     @property
     def range_partitioning(self):
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.range_partitioning`.
         """
-        return self._configuration.range_partitioning
+        return self.configuration.range_partitioning
 
     @property
     def time_partitioning(self):
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.time_partitioning`.
         """
-        return self._configuration.time_partitioning
+        return self.configuration.time_partitioning
 
     @property
     def use_avro_logical_types(self):
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.use_avro_logical_types`.
         """
-        return self._configuration.use_avro_logical_types
+        return self.configuration.use_avro_logical_types
 
     @property
     def clustering_fields(self):
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.clustering_fields`.
         """
-        return self._configuration.clustering_fields
+        return self.configuration.clustering_fields
 
     @property
     def schema_update_options(self):
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.schema_update_options`.
         """
-        return self._configuration.schema_update_options
+        return self.configuration.schema_update_options
 
     @property
     def input_file_bytes(self):

--- a/google/cloud/bigquery/job/query.py
+++ b/google/cloud/bigquery/job/query.py
@@ -745,17 +745,15 @@ class QueryJob(_AsyncJob):
 
     _JOB_TYPE = "query"
     _UDF_KEY = "userDefinedFunctionResources"
+    _CONFIG_CLASS = QueryJobConfig
 
     def __init__(self, job_id, query, client, job_config=None):
         super(QueryJob, self).__init__(job_id, client)
 
-        if job_config is None:
-            job_config = QueryJobConfig()
-        if job_config.use_legacy_sql is None:
-            job_config.use_legacy_sql = False
-
-        self._properties["configuration"] = job_config._properties
-        self._configuration = job_config
+        if job_config is not None:
+            self._properties["configuration"] = job_config._properties
+        if self.configuration.use_legacy_sql is None:
+            self.configuration.use_legacy_sql = False
 
         if query:
             _helpers._set_sub_prop(
@@ -771,7 +769,12 @@ class QueryJob(_AsyncJob):
         """See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.allow_large_results`.
         """
-        return self._configuration.allow_large_results
+        return self.configuration.allow_large_results
+
+    @property
+    def configuration(self) -> QueryJobConfig:
+        """The configuration for this query job."""
+        return typing.cast(QueryJobConfig, super().configuration)
 
     @property
     def connection_properties(self) -> List[ConnectionProperty]:
@@ -780,14 +783,14 @@ class QueryJob(_AsyncJob):
 
         .. versionadded:: 2.29.0
         """
-        return self._configuration.connection_properties
+        return self.configuration.connection_properties
 
     @property
     def create_disposition(self):
         """See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.create_disposition`.
         """
-        return self._configuration.create_disposition
+        return self.configuration.create_disposition
 
     @property
     def create_session(self) -> Optional[bool]:
@@ -796,21 +799,21 @@ class QueryJob(_AsyncJob):
 
         .. versionadded:: 2.29.0
         """
-        return self._configuration.create_session
+        return self.configuration.create_session
 
     @property
     def default_dataset(self):
         """See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.default_dataset`.
         """
-        return self._configuration.default_dataset
+        return self.configuration.default_dataset
 
     @property
     def destination(self):
         """See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.destination`.
         """
-        return self._configuration.destination
+        return self.configuration.destination
 
     @property
     def destination_encryption_configuration(self):
@@ -823,28 +826,28 @@ class QueryJob(_AsyncJob):
         See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.destination_encryption_configuration`.
         """
-        return self._configuration.destination_encryption_configuration
+        return self.configuration.destination_encryption_configuration
 
     @property
     def dry_run(self):
         """See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.dry_run`.
         """
-        return self._configuration.dry_run
+        return self.configuration.dry_run
 
     @property
     def flatten_results(self):
         """See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.flatten_results`.
         """
-        return self._configuration.flatten_results
+        return self.configuration.flatten_results
 
     @property
     def priority(self):
         """See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.priority`.
         """
-        return self._configuration.priority
+        return self.configuration.priority
 
     @property
     def query(self):
@@ -862,90 +865,90 @@ class QueryJob(_AsyncJob):
         """See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.query_parameters`.
         """
-        return self._configuration.query_parameters
+        return self.configuration.query_parameters
 
     @property
     def udf_resources(self):
         """See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.udf_resources`.
         """
-        return self._configuration.udf_resources
+        return self.configuration.udf_resources
 
     @property
     def use_legacy_sql(self):
         """See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.use_legacy_sql`.
         """
-        return self._configuration.use_legacy_sql
+        return self.configuration.use_legacy_sql
 
     @property
     def use_query_cache(self):
         """See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.use_query_cache`.
         """
-        return self._configuration.use_query_cache
+        return self.configuration.use_query_cache
 
     @property
     def write_disposition(self):
         """See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.write_disposition`.
         """
-        return self._configuration.write_disposition
+        return self.configuration.write_disposition
 
     @property
     def maximum_billing_tier(self):
         """See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.maximum_billing_tier`.
         """
-        return self._configuration.maximum_billing_tier
+        return self.configuration.maximum_billing_tier
 
     @property
     def maximum_bytes_billed(self):
         """See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.maximum_bytes_billed`.
         """
-        return self._configuration.maximum_bytes_billed
+        return self.configuration.maximum_bytes_billed
 
     @property
     def range_partitioning(self):
         """See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.range_partitioning`.
         """
-        return self._configuration.range_partitioning
+        return self.configuration.range_partitioning
 
     @property
     def table_definitions(self):
         """See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.table_definitions`.
         """
-        return self._configuration.table_definitions
+        return self.configuration.table_definitions
 
     @property
     def time_partitioning(self):
         """See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.time_partitioning`.
         """
-        return self._configuration.time_partitioning
+        return self.configuration.time_partitioning
 
     @property
     def clustering_fields(self):
         """See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.clustering_fields`.
         """
-        return self._configuration.clustering_fields
+        return self.configuration.clustering_fields
 
     @property
     def schema_update_options(self):
         """See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.schema_update_options`.
         """
-        return self._configuration.schema_update_options
+        return self.configuration.schema_update_options
 
     def to_api_repr(self):
         """Generate a resource for :meth:`_begin`."""
         # Use to_api_repr to allow for some configuration properties to be set
         # automatically.
-        configuration = self._configuration.to_api_repr()
+        configuration = self.configuration.to_api_repr()
         return {
             "jobReference": self._properties["jobReference"],
             "configuration": configuration,
@@ -1257,7 +1260,7 @@ class QueryJob(_AsyncJob):
         """
         template = "{message}\n\n{header}\n\n{ruler}\n{body}\n{ruler}"
 
-        lines = query.splitlines()
+        lines = query.splitlines() if query is not None else [""]
         max_line_len = max(len(line) for line in lines)
 
         header = "-----Query Job SQL Follows-----"

--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -2455,7 +2455,7 @@ def test_table_clones(dataset_id):
     # Now create a clone before modifying the original table data.
     copy_config = CopyJobConfig()
     copy_config.operation_type = OperationType.CLONE
-    copy_config.write_disposition = bigquery.WriteDisposition.WRITE_TRUNCATE
+    copy_config.write_disposition = bigquery.WriteDisposition.WRITE_EMPTY
 
     copy_job = client.copy_table(
         sources=table_path_source,

--- a/tests/unit/job/test_base.py
+++ b/tests/unit/job/test_base.py
@@ -432,11 +432,19 @@ class Test_AsyncJob(unittest.TestCase):
     def test__set_properties_no_stats(self):
         config = {"test": True}
         resource = {"configuration": config}
+        expected = resource.copy()
+        expected["statistics"] = {}
         job = self._set_properties_job()
+        original_resource = job._properties
 
         job._set_properties(resource)
 
-        self.assertEqual(job._properties, resource)
+        self.assertEqual(job._properties, expected)
+
+        # Make sure we don't mutate the object used in the request, as that
+        # makes debugging more difficult and leads to false positives in unit
+        # tests.
+        self.assertIsNot(job._properties, original_resource)
 
     def test__set_properties_w_creation_time(self):
         now, millis = self._datetime_and_millis()
@@ -546,6 +554,8 @@ class Test_AsyncJob(unittest.TestCase):
             },
             "configuration": {"test": True},
         }
+        expected = resource.copy()
+        expected["statistics"] = {}
         job = self._set_properties_job()
         builder = job.to_api_repr = mock.Mock()
         builder.return_value = resource
@@ -564,7 +574,7 @@ class Test_AsyncJob(unittest.TestCase):
             data=resource,
             timeout=None,
         )
-        self.assertEqual(job._properties, resource)
+        self.assertEqual(job._properties, expected)
 
     def test__begin_explicit(self):
         from google.cloud.bigquery.retry import DEFAULT_RETRY
@@ -578,6 +588,8 @@ class Test_AsyncJob(unittest.TestCase):
             },
             "configuration": {"test": True},
         }
+        expected = resource.copy()
+        expected["statistics"] = {}
         job = self._set_properties_job()
         builder = job.to_api_repr = mock.Mock()
         builder.return_value = resource
@@ -598,7 +610,7 @@ class Test_AsyncJob(unittest.TestCase):
             data=resource,
             timeout=7.5,
         )
-        self.assertEqual(job._properties, resource)
+        self.assertEqual(job._properties, expected)
 
     def test_exists_defaults_miss(self):
         from google.cloud.exceptions import NotFound
@@ -685,6 +697,8 @@ class Test_AsyncJob(unittest.TestCase):
             },
             "configuration": {"test": True},
         }
+        expected = resource.copy()
+        expected["statistics"] = {}
         job = self._set_properties_job()
         job._properties["jobReference"]["location"] = self.LOCATION
         call_api = job._client._call_api = mock.Mock()
@@ -703,7 +717,7 @@ class Test_AsyncJob(unittest.TestCase):
             query_params={"location": self.LOCATION},
             timeout=None,
         )
-        self.assertEqual(job._properties, resource)
+        self.assertEqual(job._properties, expected)
 
     def test_reload_explicit(self):
         from google.cloud.bigquery.retry import DEFAULT_RETRY
@@ -717,6 +731,8 @@ class Test_AsyncJob(unittest.TestCase):
             },
             "configuration": {"test": True},
         }
+        expected = resource.copy()
+        expected["statistics"] = {}
         job = self._set_properties_job()
         client = _make_client(project=other_project)
         call_api = client._call_api = mock.Mock()
@@ -736,7 +752,7 @@ class Test_AsyncJob(unittest.TestCase):
             query_params={},
             timeout=4.2,
         )
-        self.assertEqual(job._properties, resource)
+        self.assertEqual(job._properties, expected)
 
     def test_cancel_defaults(self):
         resource = {
@@ -747,6 +763,8 @@ class Test_AsyncJob(unittest.TestCase):
             },
             "configuration": {"test": True},
         }
+        expected = resource.copy()
+        expected["statistics"] = {}
         response = {"job": resource}
         job = self._set_properties_job()
         job._properties["jobReference"]["location"] = self.LOCATION
@@ -764,7 +782,7 @@ class Test_AsyncJob(unittest.TestCase):
             query_params={"location": self.LOCATION},
             timeout=None,
         )
-        self.assertEqual(job._properties, resource)
+        self.assertEqual(job._properties, expected)
 
     def test_cancel_explicit(self):
         other_project = "other-project-234"
@@ -776,6 +794,8 @@ class Test_AsyncJob(unittest.TestCase):
             },
             "configuration": {"test": True},
         }
+        expected = resource.copy()
+        expected["statistics"] = {}
         response = {"job": resource}
         job = self._set_properties_job()
         client = _make_client(project=other_project)
@@ -797,7 +817,7 @@ class Test_AsyncJob(unittest.TestCase):
             query_params={},
             timeout=7.5,
         )
-        self.assertEqual(job._properties, resource)
+        self.assertEqual(job._properties, expected)
 
     def test_cancel_w_custom_retry(self):
         from google.cloud.bigquery.retry import DEFAULT_RETRY
@@ -811,6 +831,8 @@ class Test_AsyncJob(unittest.TestCase):
             },
             "configuration": {"test": True},
         }
+        expected = resource.copy()
+        expected["statistics"] = {}
         response = {"job": resource}
         job = self._set_properties_job()
 
@@ -830,7 +852,7 @@ class Test_AsyncJob(unittest.TestCase):
             final_attributes.assert_called()
 
         self.assertTrue(result)
-        self.assertEqual(job._properties, resource)
+        self.assertEqual(job._properties, expected)
         self.assertEqual(
             fake_api_request.call_args_list,
             [

--- a/tests/unit/job/test_load.py
+++ b/tests/unit/job/test_load.py
@@ -451,6 +451,7 @@ class TestLoadJob(_Base):
         conn = make_connection(RESOURCE)
         client = _make_client(project=self.PROJECT, connection=conn)
         job = self._make_one(self.JOB_ID, [self.SOURCE1], self.TABLE_REF, client)
+        job.configuration.reference_file_schema_uri = self.REFERENCE_FILE_SCHEMA_URI
         path = "/projects/{}/jobs".format(self.PROJECT)
         with mock.patch(
             "google.cloud.bigquery.opentelemetry_tracing._get_final_span_attributes"
@@ -498,6 +499,7 @@ class TestLoadJob(_Base):
         job = self._make_one(
             self.JOB_ID, [self.SOURCE1], self.TABLE_REF, client, config
         )
+        job.configuration.reference_file_schema_uri = self.REFERENCE_FILE_SCHEMA_URI
         with mock.patch(
             "google.cloud.bigquery.opentelemetry_tracing._get_final_span_attributes"
         ) as final_attributes:
@@ -554,19 +556,18 @@ class TestLoadJob(_Base):
             "sourceFormat": "CSV",
             "useAvroLogicalTypes": True,
             "writeDisposition": WriteDisposition.WRITE_TRUNCATE,
+            "referenceFileSchemaUri": "gs://path/to/reference",
             "schema": {
                 "fields": [
                     {
                         "name": "full_name",
                         "type": "STRING",
                         "mode": "REQUIRED",
-                        "description": None,
                     },
                     {
                         "name": "age",
                         "type": "INTEGER",
                         "mode": "REQUIRED",
-                        "description": None,
                     },
                 ]
             },


### PR DESCRIPTION
Note for google-cloud-bigquery developers: This also refactors these classes so that `_set_properties` does not modify the `_properties` dictionary in-place. Doing so was also mutating the request object, making it difficult to debug what request was _actually_ sent. Before this change, many tests hallucinated that the request was always equal to the response.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

🦕
