### PR TITLE
chore: updates minimum version of bqstorage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras = {
     # Keep the no-op bqstorage extra for backward compatibility.
     # See: https://github.com/googleapis/python-bigquery/issues/757
     "bqstorage": [
-        "google-cloud-bigquery-storage >= 2.0.0, <3.0.0dev",
+        "google-cloud-bigquery-storage >= 2.6.0, <3.0.0dev",
         # Due to an issue in pip's dependency resolver, the `grpc` extra is not
         # installed, even though `google-cloud-bigquery-storage` specifies it
         # as `google-api-core[grpc]`. We thus need to explicitly specify it here.

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -8,7 +8,7 @@
 db-dtypes==0.3.0
 geopandas==0.9.0
 google-api-core==1.31.5
-google-cloud-bigquery-storage==2.0.0
+google-cloud-bigquery-storage==2.6.0
 google-cloud-core==1.6.0
 google-resumable-media==0.6.0
 grpcio==1.47.0

--- a/tests/unit/job/test_query_pandas.py
+++ b/tests/unit/job/test_query_pandas.py
@@ -62,8 +62,8 @@ def table_read_options_kwarg():
     # Create a BigQuery Storage table read options object with pyarrow compression
     # enabled if a recent-enough version of google-cloud-bigquery-storage dependency is
     # installed to support the compression.
-    if not hasattr(bigquery_storage, "ArrowSerializationOptions"):
-        return {}
+    #if not hasattr(bigquery_storage, "ArrowSerializationOptions"):
+    #    return {}
 
     read_options = bigquery_storage.ReadSession.TableReadOptions(
         arrow_serialization_options=bigquery_storage.ArrowSerializationOptions(

--- a/tests/unit/job/test_query_pandas.py
+++ b/tests/unit/job/test_query_pandas.py
@@ -59,12 +59,6 @@ except ImportError:  # pragma: NO COVER
 
 @pytest.fixture
 def table_read_options_kwarg():
-    # Create a BigQuery Storage table read options object with pyarrow compression
-    # enabled if a recent-enough version of google-cloud-bigquery-storage dependency is
-    # installed to support the compression.
-    #if not hasattr(bigquery_storage, "ArrowSerializationOptions"):
-    #    return {}
-
     read_options = bigquery_storage.ReadSession.TableReadOptions(
         arrow_serialization_options=bigquery_storage.ArrowSerializationOptions(
             buffer_compression=bigquery_storage.ArrowSerializationOptions.CompressionCodec.LZ4_FRAME


### PR DESCRIPTION
Updates the minimum version of `google-cloud-bigquery-storage`. 
The advantage to this is:

> 2.6.0 makes `read_session` optional to `rows()` (used in pandas connector).

Fixes #747 🦕
