### PR TITLE
fix: handle case when expirationMs is None

### DIFF
--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -687,7 +687,11 @@ class Table(_TableBase):
 
         if self.time_partitioning is None:
             self._properties[api_field] = {"type": TimePartitioningType.DAY}
-        self._properties[api_field]["expirationMs"] = str(value)
+
+        if value is None:
+            self._properties[api_field]["expirationMs"] = None
+        else:
+            self._properties[api_field]["expirationMs"] = str(value)
 
     @property
     def clustering_fields(self):

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -1189,6 +1189,20 @@ class TestTable(unittest.TestCase, _SchemaBase):
         }
         self.assertEqual(resource, exp_resource)
 
+    def test_to_api_repr_w_unsetting_expiration(self):
+        dataset = DatasetReference(self.PROJECT, self.DS_ID)
+        table_ref = dataset.table(self.TABLE_NAME)
+        table = self._make_one(table_ref)
+        table._properties["timePartitioning"] = {"expirationMs": None}
+        resource = table.to_api_repr()
+
+        exp_resource = {
+            "tableReference": table_ref.to_api_repr(),
+            "labels": {},
+            "timePartitioning": {"expirationMs": None},
+        }
+        self.assertEqual(resource, exp_resource)
+
     def test__build_resource_w_custom_field(self):
         dataset = DatasetReference(self.PROJECT, self.DS_ID)
         table_ref = dataset.table(self.TABLE_NAME)

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -1190,6 +1190,8 @@ class TestTable(unittest.TestCase, _SchemaBase):
         self.assertEqual(resource, exp_resource)
 
     def test_to_api_repr_w_unsetting_expiration(self):
+        from google.cloud.bigquery.table import TimePartitioningType
+
         dataset = DatasetReference(self.PROJECT, self.DS_ID)
         table_ref = dataset.table(self.TABLE_NAME)
         table = self._make_one(table_ref)
@@ -1199,7 +1201,10 @@ class TestTable(unittest.TestCase, _SchemaBase):
         exp_resource = {
             "tableReference": table_ref.to_api_repr(),
             "labels": {},
-            "timePartitioning": {"expirationMs": None},
+            "timePartitioning": {
+                "expirationMs": None,
+                "type": TimePartitioningType.DAY,
+            },
         }
         self.assertEqual(resource, exp_resource)
 

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -1193,7 +1193,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         dataset = DatasetReference(self.PROJECT, self.DS_ID)
         table_ref = dataset.table(self.TABLE_NAME)
         table = self._make_one(table_ref)
-        table._properties["timePartitioning"] = {"expirationMs": None}
+        table.partition_expiration = None
         resource = table.to_api_repr()
 
         exp_resource = {


### PR DESCRIPTION
Right now, unsetting `['timePartitioning']['expirationMs']` on BigQuery table is not supported and raises `google.api_core.exceptions.BadRequest: 400 PATCH https://bigquery.googleapis.com/bigquery/v2/projects/abdelrahmanm-bd-dev/datasets/partition_expiry_test/tables/sample_data_partitioned?prettyPrint=false: Invalid value at 'table.time_partitioning.expiration_ms.value' (TYPE_INT64), "None"`

This happens since the backend doesn't treat "None" (string) as a null. This PR addresses this issue from the client side.



Sample code that fails with the above exception:
```
from google.cloud import bigquery
client = bigquery.Client(project='abdelrahmanm-bd-dev')
table_ref = client.dataset('partition_expiry_test').table('sample_data_partitioned')
table = client.get_table(table_ref)
table.partition_expiration = None # ISSUE HERE!! This get cast to string and the backend returns a 400 as a result.
client.update_table(table, ['partition_expiration'])
```