### PR TITLE
docs: add/reformat return types for cloud RAD docs

### DIFF
--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -1934,7 +1934,7 @@ class Client(ClientWithProject):
 
         Returns:
             Union[job.CopyJob, job.ExtractJob, job.LoadJob, job.QueryJob, job.UnknownJob]:
-                The :class:`~google.cloud.bigquery.job` instance, constructed via the resource.
+                The job instance, constructed via the resource.
         """
         config = resource.get("configuration", {})
         if "load" in config:
@@ -2067,7 +2067,7 @@ class Client(ClientWithProject):
 
         Returns:
             Union[job.LoadJob, job.CopyJob, job.ExtractJob, job.QueryJob, job.UnknownJob]:
-                :class:`~google.cloud.bigquery.job` instance, based on the resource returned by the API.
+                Job instance, based on the resource returned by the API.
         """
         extra_params = {"projection": "full"}
 

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -327,7 +327,8 @@ class Client(ClientWithProject):
                 before using ``retry``.
 
         Returns:
-            str: service account email address
+            str:
+                service account email address
 
         Example:
 
@@ -1932,7 +1933,8 @@ class Client(ClientWithProject):
             resource (Dict): one job resource from API response
 
         Returns:
-            The job instance, constructed via the resource.
+            Union[job.CopyJob, job.ExtractJob, job.LoadJob, job.QueryJob, job.UnknownJob]:
+                The :class:`~google.cloud.bigquery.job` instance, constructed via the resource.
         """
         config = resource.get("configuration", {})
         if "load" in config:
@@ -2064,7 +2066,8 @@ class Client(ClientWithProject):
                 before using ``retry``.
 
         Returns:
-            Job instance, based on the resource returned by the API.
+            Union[job.LoadJob, job.CopyJob, job.ExtractJob, job.QueryJob, job.UnknownJob]:
+                :class:`~google.cloud.bigquery.job` instance, based on the resource returned by the API.
         """
         extra_params = {"projection": "full"}
 
@@ -3954,12 +3957,13 @@ class Client(ClientWithProject):
         """
         json.dump(schema_list, file_obj, indent=2, sort_keys=True)
 
-    def schema_from_json(self, file_or_path: "PathType"):
+    def schema_from_json(self, file_or_path: "PathType") -> List[SchemaField]:
         """Takes a file object or file path that contains json that describes
         a table schema.
 
         Returns:
-            List of schema field objects.
+            List[SchemaField]:
+                List of :class:`~google.cloud.bigquery.schema.SchemaField` objects.
         """
         if isinstance(file_or_path, io.IOBase):
             return self._schema_from_json_file_object(file_or_path)


### PR DESCRIPTION
- In order for the Return table to show up in the docs, the type of the return object must be in the Returns docstring
- I also removed two examples from docstrings - they don't format properly in our docs and I felt they were encompassed in other samples. If we want to keep them we can, I'll just need to reach out to the Cloud RAD team to understand how they need to be formatted

Fixes #1438 once the Cloud RAD job runs after this is merged 😄 