### PR TITLE
chore: update noxfile for docfx job

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -425,13 +425,16 @@ def docs(session):
     )
 
 
-@nox.session(python=DEFAULT_PYTHON_VERSION)
+@nox.session(python="3.9")
 def docfx(session):
     """Build the docfx yaml files for this library."""
 
     session.install("-e", ".")
     session.install(
-        "sphinx==4.0.2", "alabaster", "recommonmark", "gcp-sphinx-docfx-yaml"
+        "sphinx==4.0.2",
+        "alabaster",
+        "recommonmark",
+        "gcp-sphinx-docfx-yaml",
     )
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -431,10 +431,9 @@ def docfx(session):
 
     session.install("-e", ".")
     session.install(
-        "sphinx==4.0.2",
+        "gcp-sphinx-docfx-yaml",
         "alabaster",
         "recommonmark",
-        "gcp-sphinx-docfx-yaml",
     )
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)


### PR DESCRIPTION
`docfx` _should_ run at `>=3.9`, however I've had some difficulties with some libraries with Sphinx version at 4 and Python 3.10 and above. Pinning to 3.9 for now, while I'm working on fixing this for 3.10 and above. 

Fixes b/289001353 🦕
