### PR TITLE
chore: update docs nox session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -402,7 +402,7 @@ def blacken(session):
     session.run("black", *BLACK_PATHS)
 
 
-@nox.session(python=DEFAULT_PYTHON_VERSION)
+@nox.session(python="3.9")
 def docs(session):
     """Build the docs."""
 


### PR DESCRIPTION
Seems that the image does not have a 3.8 interpreter and was using 3.10 default version for other jobs, causing `docs` job to fail as well. Fixing this so that docs can generate fine, confirmed that the generation works in https://source.cloud.google.com/results/invocations/309be161-7465-4f61-b050-607cb4c040f2/targets/cloud-devrel%2Fclient-libraries%2Fpython%2Fgoogleapis%2Fpython-bigquery%2Fdocs%2Fdocs/log

Continuation from #1594.

Fixes b/289001353 🦕
