### PR TITLE
feat: widen retry predicate to include ServiceUnavailable

### DIFF
--- a/google/cloud/bigquery/retry.py
+++ b/google/cloud/bigquery/retry.py
@@ -27,6 +27,7 @@ _UNSTRUCTURED_RETRYABLE_TYPES = (
     exceptions.TooManyRequests,
     exceptions.InternalServerError,
     exceptions.BadGateway,
+    exceptions.ServiceUnavailable,
     requests.exceptions.ChunkedEncodingError,
     requests.exceptions.ConnectionError,
     requests.exceptions.Timeout,

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -79,6 +79,12 @@ class Test_should_retry(unittest.TestCase):
         exc = TooManyRequests("testing")
         self.assertTrue(self._call_fut(exc))
 
+    def test_w_unstructured_service_unavailable(self):
+        from google.api_core.exceptions import ServiceUnavailable
+
+        exc = ServiceUnavailable("testing")
+        self.assertTrue(self._call_fut(exc))
+
     def test_w_internalError(self):
         exc = mock.Mock(errors=[{"reason": "internalError"}], spec=["errors"])
         self.assertTrue(self._call_fut(exc))


### PR DESCRIPTION
Expands retry.  It's possible in the normal lifecycle of an API frontend for the intermediate response to indicate the API service is not ready.

related: internal issue 294103068
