### PR TITLE
fix: relax timeout expectations

### DIFF
--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -1895,7 +1895,10 @@ class Client(ClientWithProject):
         extra_params: Dict[str, Any] = {"maxResults": 0}
 
         if timeout is not None:
-            timeout = max(timeout, _MIN_GET_QUERY_RESULTS_TIMEOUT)
+            if type(timeout) == object:
+                timeout = _MIN_GET_QUERY_RESULTS_TIMEOUT
+            else:
+                timeout = max(timeout, _MIN_GET_QUERY_RESULTS_TIMEOUT)
 
         if project is None:
             project = self.project
@@ -3924,7 +3927,10 @@ class Client(ClientWithProject):
         }
 
         if timeout is not None:
-            timeout = max(timeout, _MIN_GET_QUERY_RESULTS_TIMEOUT)
+            if type(timeout) == object:
+                timeout = _MIN_GET_QUERY_RESULTS_TIMEOUT
+            else:
+                timeout = max(timeout, _MIN_GET_QUERY_RESULTS_TIMEOUT)
 
         if start_index is not None:
             params["startIndex"] = start_index

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -395,6 +395,31 @@ class TestClient(unittest.TestCase):
             timeout=google.cloud.bigquery.client._MIN_GET_QUERY_RESULTS_TIMEOUT,
         )
 
+    def test__get_query_results_miss_w_default_timeout(self):
+        import google.cloud.bigquery.client
+        from google.cloud.exceptions import NotFound
+
+        creds = _make_credentials()
+        client = self._make_one(self.PROJECT, creds)
+        conn = client._connection = make_connection()
+        path = "/projects/other-project/queries/nothere"
+        with self.assertRaises(NotFound):
+            client._get_query_results(
+                "nothere",
+                None,
+                project="other-project",
+                location=self.LOCATION,
+                timeout_ms=500,
+                timeout=object(),  # the api core default timeout
+            )
+
+        conn.api_request.assert_called_once_with(
+            method="GET",
+            path=path,
+            query_params={"maxResults": 0, "timeoutMs": 500, "location": self.LOCATION},
+            timeout=google.cloud.bigquery.client._MIN_GET_QUERY_RESULTS_TIMEOUT,
+        )
+
     def test__get_query_results_miss_w_client_location(self):
         from google.cloud.exceptions import NotFound
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -484,18 +484,19 @@ class TestClient(unittest.TestCase):
         )
 
         # trigger the iterator to request data
-        with self.assertRaises(google.api_core.exceptions.NotFound):
+        with self.assertRaises(NotFound):
             iterator._get_next_page_response()
 
         conn.api_request.assert_called_once_with(
             method="GET",
             path=path,
-            query_params={'fields': 'jobReference,totalRows,pageToken,rows', 'location': None, 'formatOptions.useInt64Timestamp': True},
+            query_params={
+                "fields": "jobReference,totalRows,pageToken,rows",
+                "location": None,
+                "formatOptions.useInt64Timestamp": True,
+            },
             timeout=None,
         )
-
-
-
 
     def test__list_rows_from_query_results_w_default_timeout(self):
         import google.cloud.bigquery.client
@@ -518,13 +519,17 @@ class TestClient(unittest.TestCase):
         )
 
         # trigger the iterator to request data
-        with self.assertRaises(google.api_core.exceptions.NotFound):
+        with self.assertRaises(NotFound):
             iterator._get_next_page_response()
 
         conn.api_request.assert_called_once_with(
             method="GET",
             path=path,
-            query_params={'fields': 'jobReference,totalRows,pageToken,rows', 'location': None, 'formatOptions.useInt64Timestamp': True},
+            query_params={
+                "fields": "jobReference,totalRows,pageToken,rows",
+                "location": None,
+                "formatOptions.useInt64Timestamp": True,
+            },
             timeout=google.cloud.bigquery.client._MIN_GET_QUERY_RESULTS_TIMEOUT,
         )
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -464,7 +464,6 @@ class TestClient(unittest.TestCase):
         self.assertTrue(query_results.complete)
 
     def test__list_rows_from_query_results_w_none_timeout(self):
-        import google.cloud.bigquery.client
         from google.cloud.exceptions import NotFound
         from google.cloud.bigquery.schema import SchemaField
 


### PR DESCRIPTION
Changes to python-api-core can in certain cases cause timeout to be represented as a literal python base object type.  This CL adjusts logic that selects from multiple timeout values to better handle this case, which previously assumed either a None or scalar value being present.

Fixes: https://github.com/googleapis/python-bigquery/issues/1612