### PR TITLE
bug: add type checking to prevent object issues

### DIFF
--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -1894,6 +1894,14 @@ class Client(ClientWithProject):
 
         extra_params: Dict[str, Any] = {"maxResults": 0}
 
+        # Python_API_core, as part of a major rewrite of the deadline, timeout,
+        # and retry process sets the timeout value as a Python object().
+        # Our system does not natively handle that and instead expects
+        # either none or a numeric value. If passed a Python object, convert to
+        # None.
+        if type(timeout) == object:  # pragma: NO COVER
+            timeout = None
+
         if timeout is not None:
             timeout = max(timeout, _MIN_GET_QUERY_RESULTS_TIMEOUT)
 


### PR DESCRIPTION
This fix attempts to overcome a backwards incompatible fix related to how python-api-core handles default timeout values and how bigquery handles default timeout values.

Namely:

the default timeout value in python-api-core is a Python object()
python-bigquery expects a value of None or a numeric value
This fix checks to see if the value being passed in is an object(), and if so, converts it to a NoneType value of None.

A similar fix can be found in PR: https://github.com/googleapis/python-bigquery/pull/1541

Fixes #1612 🦕
