### PR TITLE
Expose jobTimeoutMs in JobConfig

### DIFF
--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -172,7 +172,7 @@ class _JobConfig(object):
         super(_JobConfig, self).__setattr__(name, value)
 
     @property
-    def jobtimeout(self):
+    def job_timeout_ms(self):
         """ Optional parameter. Job timeout in milliseconds. If this time limit is exceeded, BigQuery might attempt to stop the job.
 
         https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#JobConfiguration.FIELDS.job_timeout_ms

--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -192,8 +192,8 @@ class _JobConfig(object):
             return self._properties["jobTimeoutMs"]
         return None
 
-    @jobtimeout.setter
-    def jobtimeout(self, value):
+    @job_timeout_ms.setter
+    def job_timeout_ms(self, value):
         if not isinstance(value, int):
             raise ValueError("Pass an int for jobTimeoutMs, e.g. 5000")
         

--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -179,7 +179,6 @@ class _JobConfig(object):
 
         e.g.
             job_config = bigquery.QueryJobConfig( jobtimeout = 5000 )
-            job_config = bigquery.QueryJobConfig()
             
                 or
 
@@ -188,7 +187,7 @@ class _JobConfig(object):
             ValueError: If ``value`` type is invalid.
         """
         
-        # None as this does is an optional parameter.
+        # None as this is an optional parameter.
         return None
 
     @jobtimeout.setter

--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -172,6 +172,34 @@ class _JobConfig(object):
         super(_JobConfig, self).__setattr__(name, value)
 
     @property
+    def jobtimeout(self):
+        """ Optional parameter. Job timeout in milliseconds. If this time limit is exceeded, BigQuery might attempt to stop the job.
+
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#JobConfiguration.FIELDS.job_timeout_ms
+
+        e.g.
+            job_config = bigquery.QueryJobConfig( jobtimeout = 5000 )
+            job_config = bigquery.QueryJobConfig()
+            
+                or
+
+            job_config.jobtimeout = 5000
+        Raises:
+            ValueError: If ``value`` type is invalid.
+        """
+        
+        # None as this does is an optional parameter.
+        return None
+
+    @jobtimeout.setter
+    def jobtimeout(self, value):
+        if not isinstance(value, int):
+            raise ValueError("Pass an int for jobTimeoutMs, e.g. 5000")
+        
+        """ Docs indicate a string is expected by the API """
+        self._properties["jobTimeoutMs"] = str(value)
+
+    @property
     def labels(self):
         """Dict[str, str]: Labels for the job.
 

--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -188,6 +188,8 @@ class _JobConfig(object):
         """
         
         # None as this is an optional parameter.
+        if self._properties.get("jobTimeoutMs"):
+            return self._properties["jobTimeoutMs"]
         return None
 
     @jobtimeout.setter


### PR DESCRIPTION
Fixes #1421

Exposes job timeout setting in Python job timeout config.
        https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#JobConfiguration.FIELDS.job_timeout_ms

```
# python3 test.py 5000
Client creating using default project: demo-project-xyz
Job config: {'query': {}, 'jobTimeoutMs': '5000'}
Trying to execute long (30s) running query: call `demo-project-xyz`.`dbt_lbondkennedy`.`sleep_seconds_approximate`(30);
An exception of type GoogleAPICallError occurred. Arguments:
('Job execution was cancelled: Job timed out after 5 sec',)
```

![image](https://github.com/googleapis/python-bigquery/assets/79948589/1960cdfe-067b-4744-b32a-3d13865628ed)

---
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)