### PR TITLE
fix: use isinstance() per E721, unpin flake8

### DIFF
--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -1895,7 +1895,7 @@ class Client(ClientWithProject):
         extra_params: Dict[str, Any] = {"maxResults": 0}
 
         if timeout is not None:
-            if type(timeout) == object:
+            if isinstance(timeout, object):
                 timeout = _MIN_GET_QUERY_RESULTS_TIMEOUT
             else:
                 timeout = max(timeout, _MIN_GET_QUERY_RESULTS_TIMEOUT)
@@ -3927,7 +3927,7 @@ class Client(ClientWithProject):
         }
 
         if timeout is not None:
-            if type(timeout) == object:
+            if isinstance(timeout, object):
                 timeout = _MIN_GET_QUERY_RESULTS_TIMEOUT
             else:
                 timeout = max(timeout, _MIN_GET_QUERY_RESULTS_TIMEOUT)

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -1895,7 +1895,7 @@ class Client(ClientWithProject):
         extra_params: Dict[str, Any] = {"maxResults": 0}
 
         if timeout is not None:
-            if isinstance(timeout, object):
+            if not isinstance(timeout, (int, float)):
                 timeout = _MIN_GET_QUERY_RESULTS_TIMEOUT
             else:
                 timeout = max(timeout, _MIN_GET_QUERY_RESULTS_TIMEOUT)
@@ -3927,7 +3927,7 @@ class Client(ClientWithProject):
         }
 
         if timeout is not None:
-            if isinstance(timeout, object):
+            if not isinstance(timeout, (int, float)):
                 timeout = _MIN_GET_QUERY_RESULTS_TIMEOUT
             else:
                 timeout = max(timeout, _MIN_GET_QUERY_RESULTS_TIMEOUT)

--- a/noxfile.py
+++ b/noxfile.py
@@ -375,9 +375,7 @@ def lint(session):
     serious code quality issues.
     """
 
-    # Pin flake8 to 6.0.0
-    # See https://github.com/googleapis/python-bigquery/issues/1635
-    session.install("flake8==6.0.0", BLACK_VERSION)
+    session.install("flake8", BLACK_VERSION)
     session.install("-e", ".")
     session.run("flake8", os.path.join("google", "cloud", "bigquery"))
     session.run("flake8", "tests")


### PR DESCRIPTION
* Fixes lint error following [E721](https://www.flake8rules.com/rules/E721.html)
* Unpins `flake8==6.0.0` because error is resolved

Fixes #1635 🦕
