### PR TITLE
fix: AccessEntry API representation parsing

### DIFF
--- a/google/cloud/bigquery/dataset.py
+++ b/google/cloud/bigquery/dataset.py
@@ -501,9 +501,7 @@ class AccessEntry(object):
         if len(entry) != 0:
             raise ValueError("Entry has unexpected keys remaining.", entry)
 
-        config = cls(role, entity_type, entity_id)
-        config._properties = copy.deepcopy(resource)
-        return config
+        return cls(role, entity_type, entity_id)
 
 
 class Dataset(object):

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -152,6 +152,22 @@ class TestAccessEntry(unittest.TestCase):
         exp_resource = entry.to_api_repr()
         self.assertEqual(resource, exp_resource)
 
+    def test_from_api_repr_wo_role(self):
+        resource = {
+            "view": {
+                'projectId': 'my-project',
+                'datasetId': 'my_dataset',
+                'tableId': 'my_table',
+            }
+        }
+        entry = self._get_target_class().from_api_repr(resource)
+        exp_entry = self._make_one(
+            role=None,
+            entity_type="view",
+            entity_id=resource["view"],
+        )
+        self.assertEqual(entry, exp_entry)
+
     def test_to_api_repr_w_extra_properties(self):
         resource = {
             "role": "READER",

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -155,9 +155,9 @@ class TestAccessEntry(unittest.TestCase):
     def test_from_api_repr_wo_role(self):
         resource = {
             "view": {
-                'projectId': 'my-project',
-                'datasetId': 'my_dataset',
-                'tableId': 'my_table',
+                "projectId": "my-project",
+                "datasetId": "my_dataset",
+                "tableId": "my_table",
             }
         }
         entry = self._get_target_class().from_api_repr(resource)


### PR DESCRIPTION
Overriding the `AccessEntry#_properties` with a deep copy of the API resource overwrites the `role` property set in `AccessEntry.__init__` which isn't present in the resource if the `role` is set to `None`. This causes `AccessEntry`s generated from API representations to no longer evaluate to equal with equivalent `AccessEntry` resources instantiated through `AccessEntry.__init__`. The added unit test fails without the change and passes with the change.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #1681 🦕
