### PR TITLE
chore: cleanup resources at startup

### DIFF
--- a/samples/snippets/authorized_view_tutorial_test.py
+++ b/samples/snippets/authorized_view_tutorial_test.py
@@ -39,12 +39,8 @@ def test_authorized_view_tutorial(
     client: bigquery.Client, datasets_to_delete: List[str]
 ) -> None:
     override_values = {
-        "source_dataset_id": f"{prefixer.create_prefix()}_authorized_view_tutorial".format(
-            str(uuid.uuid4()).replace("-", "_")
-        ),
-        "shared_dataset_id": "shared_views_{}".format(
-            str(uuid.uuid4()).replace("-", "_")
-        ),
+        "source_dataset_id": f"{prefixer.create_prefix()}_authorized_view_tutorial",
+        "shared_dataset_id": f"{prefixer.create_prefix()}_authorized_view_tutorial_shared_views",
     }
     source_dataset_ref = "{}.{}".format(
         client.project, override_values["source_dataset_id"]

--- a/samples/snippets/authorized_view_tutorial_test.py
+++ b/samples/snippets/authorized_view_tutorial_test.py
@@ -22,16 +22,6 @@ import authorized_view_tutorial  # type: ignore
 from conftest import prefixer  # type: ignore
 
 
-@pytest.fixture
-def table_id(
-    bigquery_client: bigquery.Client, project_id: str, dataset_id: str
-) -> Iterator[str]:
-    table_id = f"{prefixer.create_prefix()}_authorized_view_tutorial"
-    yield table_id
-    full_table_id = f"{project_id}.{dataset_id}.{table_id}"
-    bigquery_client.delete_table(full_table_id, not_found_ok=True)
-
-
 @pytest.fixture(scope="module")
 def client() -> bigquery.Client:
     return bigquery.Client()
@@ -49,7 +39,7 @@ def test_authorized_view_tutorial(
     client: bigquery.Client, datasets_to_delete: List[str]
 ) -> None:
     override_values = {
-        "source_dataset_id": "github_source_data_{}".format(
+        "source_dataset_id": f"{prefixer.create_prefix()}_authorized_view_tutorial".format(
             str(uuid.uuid4()).replace("-", "_")
         ),
         "shared_dataset_id": "shared_views_{}".format(

--- a/samples/snippets/authorized_view_tutorial_test.py
+++ b/samples/snippets/authorized_view_tutorial_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from typing import Iterator, List
-import uuid
 
 from google.cloud import bigquery
 import pytest

--- a/samples/snippets/authorized_view_tutorial_test.py
+++ b/samples/snippets/authorized_view_tutorial_test.py
@@ -19,6 +19,17 @@ from google.cloud import bigquery
 import pytest
 
 import authorized_view_tutorial  # type: ignore
+from conftest import prefixer  # type: ignore
+
+
+@pytest.fixture
+def table_id(
+    bigquery_client: bigquery.Client, project_id: str, dataset_id: str
+) -> Iterator[str]:
+    table_id = f"{prefixer.create_prefix()}_authorized_view_tutorial"
+    yield table_id
+    full_table_id = f"{project_id}.{dataset_id}.{table_id}"
+    bigquery_client.delete_table(full_table_id, not_found_ok=True)
 
 
 @pytest.fixture(scope="module")

--- a/samples/snippets/dataset_access_test.py
+++ b/samples/snippets/dataset_access_test.py
@@ -22,6 +22,7 @@ if typing.TYPE_CHECKING:
     import pytest
 
 
+# is it possible to cleanup these datasets if they are passed in?
 def test_dataset_access_permissions(
     capsys: "pytest.CaptureFixture[str]",
     dataset_id: str,

--- a/samples/snippets/dataset_access_test.py
+++ b/samples/snippets/dataset_access_test.py
@@ -22,7 +22,6 @@ if typing.TYPE_CHECKING:
     import pytest
 
 
-# is it possible to cleanup these datasets if they are passed in?
 def test_dataset_access_permissions(
     capsys: "pytest.CaptureFixture[str]",
     dataset_id: str,

--- a/samples/snippets/materialized_view_test.py
+++ b/samples/snippets/materialized_view_test.py
@@ -21,6 +21,7 @@ from google.cloud import bigquery
 import pytest
 
 import materialized_view  # type: ignore
+from conftest import prefixer  # type: ignore
 
 
 def temp_suffix() -> str:
@@ -37,7 +38,7 @@ def bigquery_client_patch(
 
 @pytest.fixture(scope="module")
 def dataset_id(bigquery_client: bigquery.Client) -> Iterator[str]:
-    dataset_id = f"mvdataset_{temp_suffix()}"
+    dataset_id = f"{prefixer.create_prefix()}_materialized_view"
     bigquery_client.create_dataset(dataset_id)
     yield dataset_id
     bigquery_client.delete_dataset(dataset_id, delete_contents=True)

--- a/samples/snippets/natality_tutorial_test.py
+++ b/samples/snippets/natality_tutorial_test.py
@@ -38,11 +38,7 @@ def datasets_to_delete(client: bigquery.Client) -> Iterator[List[str]]:
 def test_natality_tutorial(
     client: bigquery.Client, datasets_to_delete: List[str]
 ) -> None:
-    override_values = {
-        "dataset_id": f"{prefixer.create_prefix()}_natality_tutorial".format(
-            str(uuid.uuid4()).replace("-", "_")
-        ),
-    }
+    override_values = {"dataset_id": f"{prefixer.create_prefix()}_natality_tutorial"}
     datasets_to_delete.append(override_values["dataset_id"])
 
     natality_tutorial.run_natality_tutorial(override_values)

--- a/samples/snippets/natality_tutorial_test.py
+++ b/samples/snippets/natality_tutorial_test.py
@@ -19,6 +19,7 @@ from google.cloud import bigquery
 import pytest
 
 import natality_tutorial  # type: ignore
+from conftest import prefixer  # type: ignore
 
 
 @pytest.fixture(scope="module")
@@ -38,7 +39,7 @@ def test_natality_tutorial(
     client: bigquery.Client, datasets_to_delete: List[str]
 ) -> None:
     override_values = {
-        "dataset_id": "natality_regression_{}".format(
+        "dataset_id": f"{prefixer.create_prefix()}_natality_tutorial".format(
             str(uuid.uuid4()).replace("-", "_")
         ),
     }

--- a/samples/snippets/natality_tutorial_test.py
+++ b/samples/snippets/natality_tutorial_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from typing import Iterator, List
-import uuid
 
 from google.cloud import bigquery
 import pytest

--- a/samples/snippets/quickstart_test.py
+++ b/samples/snippets/quickstart_test.py
@@ -44,11 +44,7 @@ def test_quickstart(
     client: bigquery.Client,
     datasets_to_delete: List[str],
 ) -> None:
-    override_values = {
-        "dataset_id": f"{prefixer.create_prefix()}_quickstart".format(
-            str(uuid.uuid4()).replace("-", "_")
-        ),
-    }
+    override_values = {"dataset_id": f"{prefixer.create_prefix()}_quickstart"}
     datasets_to_delete.append(override_values["dataset_id"])
 
     quickstart.run_quickstart(override_values)

--- a/samples/snippets/quickstart_test.py
+++ b/samples/snippets/quickstart_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from typing import Iterator, List
-import uuid
 
 from google.cloud import bigquery
 import pytest

--- a/samples/snippets/quickstart_test.py
+++ b/samples/snippets/quickstart_test.py
@@ -19,6 +19,7 @@ from google.cloud import bigquery
 import pytest
 
 import quickstart  # type: ignore
+from conftest import prefixer  # type: ignore
 
 # Must match the dataset listed in quickstart.py (there's no easy way to
 # extract this).
@@ -44,7 +45,9 @@ def test_quickstart(
     datasets_to_delete: List[str],
 ) -> None:
     override_values = {
-        "dataset_id": "my_new_dataset_{}".format(str(uuid.uuid4()).replace("-", "_")),
+        "dataset_id": f"{prefixer.create_prefix()}_quickstart".format(
+            str(uuid.uuid4()).replace("-", "_")
+        ),
     }
     datasets_to_delete.append(override_values["dataset_id"])
 

--- a/samples/snippets/view_test.py
+++ b/samples/snippets/view_test.py
@@ -20,6 +20,17 @@ from google.cloud import bigquery
 import pytest
 
 import view  # type: ignore
+from conftest import prefixer  # type: ignore
+
+
+@pytest.fixture
+def table_id(
+    bigquery_client: bigquery.Client, project_id: str, dataset_id: str
+) -> Iterator[str]:
+    table_id = f"{prefixer.create_prefix()}_view_tet"
+    yield table_id
+    full_table_id = f"{project_id}.{dataset_id}.{table_id}"
+    bigquery_client.delete_table(full_table_id, not_found_ok=True)  
 
 
 def temp_suffix() -> str:

--- a/samples/snippets/view_test.py
+++ b/samples/snippets/view_test.py
@@ -30,7 +30,7 @@ def table_id(
     table_id = f"{prefixer.create_prefix()}_view_tet"
     yield table_id
     full_table_id = f"{project_id}.{dataset_id}.{table_id}"
-    bigquery_client.delete_table(full_table_id, not_found_ok=True)  
+    bigquery_client.delete_table(full_table_id, not_found_ok=True)
 
 
 def temp_suffix() -> str:

--- a/samples/snippets/view_test.py
+++ b/samples/snippets/view_test.py
@@ -23,16 +23,6 @@ import view  # type: ignore
 from conftest import prefixer  # type: ignore
 
 
-@pytest.fixture
-def table_id(
-    bigquery_client: bigquery.Client, project_id: str, dataset_id: str
-) -> Iterator[str]:
-    table_id = f"{prefixer.create_prefix()}_view_tet"
-    yield table_id
-    full_table_id = f"{project_id}.{dataset_id}.{table_id}"
-    bigquery_client.delete_table(full_table_id, not_found_ok=True)
-
-
 def temp_suffix() -> str:
     now = datetime.datetime.now()
     return f"{now.strftime('%Y%m%d%H%M%S')}_{uuid.uuid4().hex[:8]}"
@@ -64,7 +54,7 @@ def view_id(bigquery_client: bigquery.Client, view_dataset_id: str) -> Iterator[
 def source_dataset_id(
     bigquery_client: bigquery.Client, project_id: str
 ) -> Iterator[str]:
-    dataset_id = f"{project_id}.view_{temp_suffix()}"
+    dataset_id = f"{prefixer.create_prefix()}_view"
     bigquery_client.create_dataset(dataset_id)
     yield dataset_id
     bigquery_client.delete_dataset(dataset_id, delete_contents=True)


### PR DESCRIPTION
This PR:
- Uses prefixer function in conftest from python-test-utils to assign IDs to datasets in samples/snippets
- If dataset IDs already exist with the same name, those get deleted at start time
- Primarily, this ensures that any tests that are stopped or crash do not leave dataset resources behind

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #590  🦕
