### PR TITLE
fix: keep `RowIterator.total_rows` populated after iteration

### DIFF
--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -2997,7 +2997,7 @@ def _rows_page_start(iterator, page, response):
     page._columns = _row_iterator_page_columns(iterator._schema, response)
 
     total_rows = response.get("totalRows")
-    # Don't reset total_rows is it's not present in the next API response.
+    # Don't reset total_rows if it's not present in the next API response.
     if total_rows is not None:
         iterator._total_rows = int(total_rows)
 

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -2997,9 +2997,9 @@ def _rows_page_start(iterator, page, response):
     page._columns = _row_iterator_page_columns(iterator._schema, response)
 
     total_rows = response.get("totalRows")
+    # Don't reset total_rows is it's not present in the next API response.
     if total_rows is not None:
-        total_rows = int(total_rows)
-    iterator._total_rows = total_rows
+        iterator._total_rows = int(total_rows)
 
 
 # pylint: enable=unused-argument

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -2201,9 +2201,18 @@ class TestRowIterator(unittest.TestCase):
         path = "/foo"
         api_request = mock.Mock(return_value={"rows": rows})
         row_iterator = self._make_one(
-            _mock_client(), api_request, path, schema, first_page_response=first_page
+            _mock_client(),
+            api_request,
+            path,
+            schema,
+            first_page_response=first_page,
+            total_rows=4,
         )
+        self.assertEqual(row_iterator.total_rows, 4)
         rows = list(row_iterator)
+        # Total rows should be maintained, even though subsequent API calls
+        # don't include it.
+        self.assertEqual(row_iterator.total_rows, 4)
         self.assertEqual(len(rows), 4)
         self.assertEqual(rows[0].age, 27)
         self.assertEqual(rows[1].age, 28)


### PR DESCRIPTION
Split out of https://github.com/googleapis/python-bigquery/pull/1722

This was being reset in some cases when the rows were all available in the first page of results.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #589  🦕
