### PR TITLE
feat: Support jsonExtension in LoadJobConfig

### DIFF
--- a/google/cloud/bigquery/job/load.py
+++ b/google/cloud/bigquery/job/load.py
@@ -328,6 +328,23 @@ class LoadJobConfig(_JobConfig):
         self._set_sub_prop("ignoreUnknownValues", value)
 
     @property
+    def json_extension(self):
+        """Optional[str]: The extension to use for writing JSON data to BigQuery.
+
+        For example, if you set `jsonExtension` to "nested", BigQuery
+        writes the loaded data as nested rows, one row per top-level
+        JSON object.
+
+        See: https://cloud.google.com/bigquery/docs/reference/rest/v2/JobConfigurationLoad.FIELDS.json_extension
+
+        """
+        return self._get_sub_prop("jsonExtension")
+
+    @json_extension.setter
+    def json_extension(self, value):
+        self._set_sub_prop("jsonExtension", value)
+    
+    @property
     def max_bad_records(self):
         """Optional[int]: Number of invalid rows to ignore.
 

--- a/google/cloud/bigquery/job/load.py
+++ b/google/cloud/bigquery/job/load.py
@@ -343,7 +343,7 @@ class LoadJobConfig(_JobConfig):
     @json_extension.setter
     def json_extension(self, value):
         self._set_sub_prop("jsonExtension", value)
-    
+
     @property
     def max_bad_records(self):
         """Optional[int]: Number of invalid rows to ignore.

--- a/google/cloud/bigquery/job/load.py
+++ b/google/cloud/bigquery/job/load.py
@@ -329,13 +329,9 @@ class LoadJobConfig(_JobConfig):
 
     @property
     def json_extension(self):
-        """Optional[str]: The extension to use for writing JSON data to BigQuery.
+        """Optional[str]: The extension to use for writing JSON data to BigQuery. Only supports GeoJSON currently.
 
-        For example, if you set `jsonExtension` to "nested", BigQuery
-        writes the loaded data as nested rows, one row per top-level
-        JSON object.
-
-        See: https://cloud.google.com/bigquery/docs/reference/rest/v2/JobConfigurationLoad.FIELDS.json_extension
+        See: https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#JobConfigurationLoad.FIELDS.json_extension
 
         """
         return self._get_sub_prop("jsonExtension")

--- a/tests/unit/job/test_load_config.py
+++ b/tests/unit/job/test_load_config.py
@@ -412,7 +412,7 @@ class TestLoadJobConfig(_Base):
         config = self._get_target_class()()
         config.ignore_unknown_values = True
         self.assertTrue(config._properties["load"]["ignoreUnknownValues"])
-    
+
     def test_json_extension_missing(self):
         config = self._get_target_class()()
         self.assertIsNone(config.json_extension)
@@ -426,7 +426,7 @@ class TestLoadJobConfig(_Base):
         config = self._get_target_class()()
         config.json_extension = "GEOJSON"
         self.assertEqual(config._properties["load"]["jsonExtension"], "GEOJSON")
-    
+
     # def test_source_format_autodetect_with_json_extension(self):
     #     config = self._get_target_class()()
     #     config._properties["load"]["sourceFormat"] = "AUTODETECT"

--- a/tests/unit/job/test_load_config.py
+++ b/tests/unit/job/test_load_config.py
@@ -412,6 +412,45 @@ class TestLoadJobConfig(_Base):
         config = self._get_target_class()()
         config.ignore_unknown_values = True
         self.assertTrue(config._properties["load"]["ignoreUnknownValues"])
+    
+    def test_json_extension_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.json_extension)
+
+    def test_json_extension_hit(self):
+        config = self._get_target_class()()
+        config._properties["load"]["jsonExtension"] = "jsonl"
+        self.assertEqual(config.json_extension, "jsonl")
+
+    def test_json_extension_setter(self):
+        config = self._get_target_class()()
+        config.json_extension = "GEOJSON"
+        self.assertEqual(config._properties["load"]["jsonExtension"], "GEOJSON")
+    
+    # def test_source_format_autodetect_with_json_extension(self):
+    #     config = self._get_target_class()()
+    #     config._properties["load"]["sourceFormat"] = "AUTODETECT"
+    #     config._properties["load"]["jsonExtension"] = "NEWLINE_DELIMITED_JSON"
+
+    #     # Assert JSON-based format is prioritized
+    #     self.assertEqual(config.source_format, "NEWLINE_DELIMITED_JSON")
+
+    # def test_source_format_explicit_overrides_json_extension(self):
+    #     config = self._get_target_class()()
+    #     config._properties["load"]["sourceFormat"] = "PARQUET"
+    #     config._properties["load"]["jsonExtension"] = "jsonl"
+
+    #     # Assert explicitly set format takes precedence
+    #     self.assertEqual(config.source_format, "PARQUET")
+
+    # def test_to_api_repr_includes_json_extension(self):
+    #     config = self._get_target_class()()
+    #     config._properties["load"]["jsonExtension"] = "GEOJSON"
+    #     api_repr = config.to_api_repr()
+
+    #     # Assert "jsonExtension" key is present and value is encoded
+    #     self.assertIn("jsonExtension", api_repr)
+    #     self.assertEqual(api_repr["jsonExtension"], "GEOJSON")
 
     def test_max_bad_records_missing(self):
         config = self._get_target_class()()

--- a/tests/unit/job/test_load_config.py
+++ b/tests/unit/job/test_load_config.py
@@ -419,38 +419,20 @@ class TestLoadJobConfig(_Base):
 
     def test_json_extension_hit(self):
         config = self._get_target_class()()
-        config._properties["load"]["jsonExtension"] = "jsonl"
-        self.assertEqual(config.json_extension, "jsonl")
+        config._properties["load"]["jsonExtension"] = "GEOJSON"
+        self.assertEqual(config.json_extension, "GEOJSON")
 
     def test_json_extension_setter(self):
         config = self._get_target_class()()
         config.json_extension = "GEOJSON"
         self.assertEqual(config._properties["load"]["jsonExtension"], "GEOJSON")
 
-    # def test_source_format_autodetect_with_json_extension(self):
-    #     config = self._get_target_class()()
-    #     config._properties["load"]["sourceFormat"] = "AUTODETECT"
-    #     config._properties["load"]["jsonExtension"] = "NEWLINE_DELIMITED_JSON"
-
-    #     # Assert JSON-based format is prioritized
-    #     self.assertEqual(config.source_format, "NEWLINE_DELIMITED_JSON")
-
-    # def test_source_format_explicit_overrides_json_extension(self):
-    #     config = self._get_target_class()()
-    #     config._properties["load"]["sourceFormat"] = "PARQUET"
-    #     config._properties["load"]["jsonExtension"] = "jsonl"
-
-    #     # Assert explicitly set format takes precedence
-    #     self.assertEqual(config.source_format, "PARQUET")
-
-    # def test_to_api_repr_includes_json_extension(self):
-    #     config = self._get_target_class()()
-    #     config._properties["load"]["jsonExtension"] = "GEOJSON"
-    #     api_repr = config.to_api_repr()
-
-    #     # Assert "jsonExtension" key is present and value is encoded
-    #     self.assertIn("jsonExtension", api_repr)
-    #     self.assertEqual(api_repr["jsonExtension"], "GEOJSON")
+    def test_to_api_repr_includes_json_extension(self):
+        config = self._get_target_class()()
+        config._properties["load"]["jsonExtension"] = "GEOJSON"
+        api_repr = config.to_api_repr()
+        self.assertIn("jsonExtension", api_repr["load"])
+        self.assertEqual(api_repr["load"]["jsonExtension"], "GEOJSON")
 
     def test_max_bad_records_missing(self):
         config = self._get_target_class()()

--- a/tests/unit/job/test_load_config.py
+++ b/tests/unit/job/test_load_config.py
@@ -424,7 +424,9 @@ class TestLoadJobConfig(_Base):
 
     def test_json_extension_setter(self):
         config = self._get_target_class()()
+        self.assertFalse(config.json_extension)
         config.json_extension = "GEOJSON"
+        self.assertTrue(config.json_extension)
         self.assertEqual(config._properties["load"]["jsonExtension"], "GEOJSON")
 
     def test_to_api_repr_includes_json_extension(self):


### PR DESCRIPTION
This PR:
- Adds jsonExtension as a parameter to LoadJobConfig when loading data from a specified file format
- It enable users to directly specify the extension within the job configuration and store that information in metadata
- It allows BQ to Interpret the source format correctly (?)

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [] Appropriate docs were updated (if necessary) (should autogenerate?)

Fixes #1581 🦕
