### PR TITLE
fix: Due to upstream change in dataset, updates expected results

### DIFF
--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -1805,7 +1805,6 @@ class TestBigQuery(unittest.TestCase):
             ],
         ]
 
-
         self.assertEqual(fetched_data, expected_data)
 
     def test_dbapi_dry_run_query(self):

--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -1781,7 +1781,6 @@ class TestBigQuery(unittest.TestCase):
         )
 
         result_rows = [cursor.fetchone(), cursor.fetchone(), cursor.fetchone()]
-
         field_name = operator.itemgetter(0)
         fetched_data = [sorted(row.items(), key=field_name) for row in result_rows]
         # Since DB API is not thread safe, only a single result stream should be
@@ -1789,11 +1788,6 @@ class TestBigQuery(unittest.TestCase):
         # in the sorted order.
 
         expected_data = [
-            [
-                ("by", "pg"),
-                ("id", 1),
-                ("timestamp", datetime.datetime(2006, 10, 9, 18, 21, 51, tzinfo=UTC)),
-            ],
             [
                 ("by", "phyllis"),
                 ("id", 2),
@@ -1804,7 +1798,13 @@ class TestBigQuery(unittest.TestCase):
                 ("id", 3),
                 ("timestamp", datetime.datetime(2006, 10, 9, 18, 40, 33, tzinfo=UTC)),
             ],
+            [
+                ("by", "onebeerdave"),
+                ("id", 4),
+                ("timestamp", datetime.datetime(2006, 10, 9, 18, 47, 42, tzinfo=UTC)),
+            ],
         ]
+
 
         self.assertEqual(fetched_data, expected_data)
 


### PR DESCRIPTION
A system test was failing because an upstream Google Public Dataset had changed slightly, which thus created a disparity between the expected results in the test and the actual results. 
This PR corrects that error.


