### PR TITLE
fix: add detailed message in job error

### DIFF
--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -83,7 +83,7 @@ def _error_result_to_exception(error_result, errors=None):
         for err in errors:
             for key, value in err.items():
                 string += f"{key}: {value}, "
-        string = string[:-2]
+        string = string[:-2]  # strips off the last unneeded comma and space
 
     error_message = error_result.get("message", "") + string
 

--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -82,7 +82,7 @@ def _error_result_to_exception(error_result, errors=None):
         string = "; "
         for err in errors:
             for key, value in err.items():
-                string += key + ": " + str(value) + ", "
+                string += f"{key}: {value}, "
         string = string[:-2]
 
     error_message = error_result.get("message", "") + string

--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -55,7 +55,7 @@ _ERROR_REASON_TO_EXCEPTION = {
 }
 
 
-def _error_result_to_exception(error_result):
+def _error_result_to_exception(error_result, errors=None):
     """Maps BigQuery error reasons to an exception.
 
     The reasons and their matching HTTP status codes are documented on
@@ -66,6 +66,7 @@ def _error_result_to_exception(error_result):
 
     Args:
         error_result (Mapping[str, str]): The error result from BigQuery.
+        errors (Union[Iterable[str], None]): The detailed error messages.
 
     Returns:
         google.cloud.exceptions.GoogleAPICallError: The mapped exception.
@@ -74,9 +75,20 @@ def _error_result_to_exception(error_result):
     status_code = _ERROR_REASON_TO_EXCEPTION.get(
         reason, http.client.INTERNAL_SERVER_ERROR
     )
-    return exceptions.from_http_status(
-        status_code, error_result.get("message", ""), errors=[error_result]
-    )
+    # Manually create error message to preserve both error_result and errors.
+    # Can be removed once b/310544564 and b/318889899 are resolved.
+    string = ""
+    if errors: 
+        string = "; "
+        for err in errors:
+            for key, value in err.items():
+                string += key + ": " + str(value) + ", "
+        string = string[:-2]
+
+    error_message = error_result.get("message", "") + string
+
+    return exceptions.from_http_status(status_code, error_message, errors=[error_result])
+
 
 
 ReservationUsage = namedtuple("ReservationUsage", "name slot_ms")
@@ -886,7 +898,9 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
                 return
 
             if self.error_result is not None:
-                exception = _error_result_to_exception(self.error_result)
+                exception = _error_result_to_exception(
+                    self.error_result, self.errors or ()
+                )
                 self.set_exception(exception)
             else:
                 self.set_result(self)

--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -78,7 +78,7 @@ def _error_result_to_exception(error_result, errors=None):
     # Manually create error message to preserve both error_result and errors.
     # Can be removed once b/310544564 and b/318889899 are resolved.
     string = ""
-    if errors: 
+    if errors:
         string = "; "
         for err in errors:
             for key, value in err.items():
@@ -87,8 +87,9 @@ def _error_result_to_exception(error_result, errors=None):
 
     error_message = error_result.get("message", "") + string
 
-    return exceptions.from_http_status(status_code, error_message, errors=[error_result])
-
+    return exceptions.from_http_status(
+        status_code, error_message, errors=[error_result]
+    )
 
 
 ReservationUsage = namedtuple("ReservationUsage", "name slot_ms")

--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -77,15 +77,19 @@ def _error_result_to_exception(error_result, errors=None):
     )
     # Manually create error message to preserve both error_result and errors.
     # Can be removed once b/310544564 and b/318889899 are resolved.
-    string = ""
+    concatenated_errors = ""
     if errors:
-        string = "; "
+        concatenated_errors = "; "
         for err in errors:
-            for key, value in err.items():
-                string += f"{key}: {value}, "
-        string = string[:-2]  # strips off the last unneeded comma and space
+            concatenated_errors += ", ".join(
+                [f"{key}: {value}" for key, value in err.items()]
+            )
+            concatenated_errors += "; "
 
-    error_message = error_result.get("message", "") + string
+        # strips off the last unneeded semicolon and space
+        concatenated_errors = concatenated_errors[:-2]
+
+    error_message = error_result.get("message", "") + concatenated_errors
 
     return exceptions.from_http_status(
         status_code, error_message, errors=[error_result]

--- a/samples/snippets/authenticate_service_account.py
+++ b/samples/snippets/authenticate_service_account.py
@@ -24,7 +24,7 @@ def main() -> "bigquery.Client":
 
     # [START bigquery_client_json_credentials]
     from google.cloud import bigquery
-    from google.oauth2 import service_account
+    from google.oauth2 import service_account  # type: ignore
 
     # TODO(developer): Set key_path to the path to the service account key
     #                  file.

--- a/samples/snippets/authenticate_service_account.py
+++ b/samples/snippets/authenticate_service_account.py
@@ -24,7 +24,7 @@ def main() -> "bigquery.Client":
 
     # [START bigquery_client_json_credentials]
     from google.cloud import bigquery
-    from google.oauth2 import service_account  # type: ignore
+    from google.oauth2 import service_account
 
     # TODO(developer): Set key_path to the path to the service account key
     #                  file.

--- a/tests/unit/job/test_base.py
+++ b/tests/unit/job/test_base.py
@@ -47,6 +47,27 @@ class Test__error_result_to_exception(unittest.TestCase):
         exception = self._call_fut(error_result)
         self.assertEqual(exception.code, http.client.INTERNAL_SERVER_ERROR)
 
+    def test_contatenate_errors(self):
+        # Added test for  b/310544564 and b/318889899.
+        # Ensures that error messages from both error_result and errors are
+        # present in the exception raised.
+
+        error_result = {
+            "reason": "invalid1",
+            "message": "error message 1",
+        }
+        errors = [
+            {"reason": "invalid2", "message": "error message 2"},
+            {"reason": "invalid3", "message": "error message 3"},
+        ]
+
+        exception = self._call_fut(error_result, errors)
+        self.assertEqual(
+            exception.message,
+            "error message 1; reason: invalid2, message: error message 2; "
+            "reason: invalid3, message: error message 3",
+        )
+
 
 class Test_JobReference(unittest.TestCase):
     JOB_ID = "job-id"


### PR DESCRIPTION
Temp fix of internal issue b/310544564.

Starting Oct 2023, customers have found that the error message with jobs have lacked exact cause info. This seems to have been caused by detailed errors being moved to a different part of the job message. This PR makes a temp fix by combining both error sources into the exception we raise.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

