### PR TITLE
ci: updates types-protobuf version for mypy-samples nox session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -219,7 +219,7 @@ def mypy_samples(session):
     session.install(
         "types-mock",
         "types-pytz",
-        "types-protobuf",
+        "types-protobuf!=4.24.0.20240106",  # This version causes an error: 'Module "google.oauth2" has no attribute "service_account"'
         "types-python-dateutil",
         "types-requests",
         "types-setuptools",


### PR DESCRIPTION
A specific version of `types-protobuf==4.24.0.4` causes the following error:

`Module "google.oauth2" has no attribute "service_account"`

This ensures that the problematic version of `types-protobuf` does not get installed and includes a note explaining why the limitation is present.

Fixes #1763 🦕
