### PR TITLE
fix: no longer set autodetect=True with empty schema in load_table_from_json()

### DIFF
--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -2833,9 +2833,6 @@ class Client(ClientWithProject):
 
         new_job_config.source_format = job.SourceFormat.NEWLINE_DELIMITED_JSON
 
-        if new_job_config.schema is None:
-            new_job_config.autodetect = True
-
         if project is None:
             project = self.project
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -8986,7 +8986,7 @@ class TestClientUpload(object):
         sent_config = load_table_from_file.mock_calls[0][2]["job_config"]
         assert sent_config.source_format == job.SourceFormat.NEWLINE_DELIMITED_JSON
         assert sent_config.schema is None
-        assert sent_config.autodetect
+        assert sent_config.autodetect is None
 
     def test_load_table_from_json_non_default_args(self):
         from google.cloud.bigquery import job


### PR DESCRIPTION
In the past, if we don't set `autodetect=True` when schema is empty, the backend will throw an error. This has changed now, backend will autodetect even if we don't send autodetect value. This has caused some issues with users, when the detected schema doesn't match that of the existing table. (#1228, #1563) 

For more discussions, see #1228.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #1228 🦕
