### PR TITLE
feat: support interval data type (read only)

### DIFF
--- a/google/cloud/bigquery/_pandas_helpers.py
+++ b/google/cloud/bigquery/_pandas_helpers.py
@@ -108,6 +108,7 @@ _PANDAS_DTYPE_TO_BQ = {
     "uint16": "INTEGER",
     "uint32": "INTEGER",
     "geometry": "GEOGRAPHY",
+    "interval": "INTERVAL",
     date_dtype_name: "DATE",
     time_dtype_name: "TIME",
 }
@@ -223,6 +224,7 @@ def default_types_mapper(
     datetime_dtype: Union[Any, None] = None,
     time_dtype: Union[Any, None] = None,
     timestamp_dtype: Union[Any, None] = None,
+    month_day_nano_interval_dtype: Union[Any, None] = None,
 ):
     """Create a mapping from pyarrow types to pandas types.
 
@@ -276,6 +278,9 @@ def default_types_mapper(
 
         elif time_dtype is not None and pyarrow.types.is_time(arrow_data_type):
             return time_dtype
+        
+        elif month_day_nano_interval_dtype is not None and pyarrow.types.is_month_day_nano_interval(arrow_data_type):
+            return month_day_nano_interval_dtype
 
     return types_mapper
 

--- a/google/cloud/bigquery/_pyarrow_helpers.py
+++ b/google/cloud/bigquery/_pyarrow_helpers.py
@@ -64,6 +64,7 @@ if pyarrow:
         "GEOGRAPHY": pyarrow.string,
         "INT64": pyarrow.int64,
         "INTEGER": pyarrow.int64,
+        "INTERVAL": pyarrow.month_day_nano_interval,
         "NUMERIC": pyarrow_numeric,
         "STRING": pyarrow.string,
         "TIME": pyarrow_time,
@@ -92,6 +93,7 @@ if pyarrow:
         pyarrow.binary().id: "BYTES",
         pyarrow.string().id: "STRING",  # also alias for pyarrow.utf8()
         pyarrow.large_string().id: "STRING",
+        pyarrow.month_day_nano_interval().id: "INTERVAL",
         # The exact scale and precision don't matter, see below.
         pyarrow.decimal128(38, scale=9).id: "NUMERIC",
     }


### PR DESCRIPTION
This PR:
- Adds support for interval datatype by converting BQ storage API data to pyarrow.month_day_nano_interval datatype
- Wraps that pyarrow datatype in a pandas.ArrowDType for library use
- Adds tests for interval functionality

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #826 or #836 ? 🦕

This PR is a work in progress.
