### PR TITLE
docs(samples): updates to urllib3 constraint for Python 3.7

### DIFF
--- a/samples/geography/requirements.txt
+++ b/samples/geography/requirements.txt
@@ -45,5 +45,5 @@ Shapely==2.0.2
 six==1.16.0
 typing-extensions==4.7.1
 typing-inspect==0.9.0
-urllib3==1.24; python_version == '3.7'
-urllib3==1.26.18; python_version >= '3.8'
+urllib3===1.26.18; python_version == '3.7'
+urllib3==2.2.1; python_version >= '3.8'

--- a/samples/geography/requirements.txt
+++ b/samples/geography/requirements.txt
@@ -46,4 +46,4 @@ six==1.16.0
 typing-extensions==4.7.1
 typing-inspect==0.9.0
 urllib3==1.24; python_version == '3.7'
-urllib3==2.1.0; python_version >= '3.8'
+urllib3==2.0; python_version >= '3.8'

--- a/samples/geography/requirements.txt
+++ b/samples/geography/requirements.txt
@@ -46,4 +46,4 @@ six==1.16.0
 typing-extensions==4.7.1
 typing-inspect==0.9.0
 urllib3==1.24; python_version == '3.7'
-urllib3==2.0; python_version >= '3.8'
+urllib3==1.26.18; python_version >= '3.8'

--- a/samples/geography/requirements.txt
+++ b/samples/geography/requirements.txt
@@ -13,7 +13,7 @@ geopandas===0.10.2; python_version == '3.7'
 geopandas==0.13.2; python_version == '3.8'
 geopandas==0.14.1; python_version >= '3.9'
 google-api-core==2.11.1
-google-auth==2.22.0
+google-auth==2.25.2
 google-cloud-bigquery==3.11.4
 google-cloud-bigquery-storage==2.22.0
 google-cloud-core==2.3.3

--- a/samples/geography/requirements.txt
+++ b/samples/geography/requirements.txt
@@ -45,4 +45,5 @@ Shapely==2.0.2
 six==1.16.0
 typing-extensions==4.7.1
 typing-inspect==0.9.0
-urllib3==1.26.18
+urllib3==1.24; python_version == '3.7'
+urllib3==2.1.0; python_version >= '3.8'

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -28,3 +28,4 @@ requests==2.21.0
 Shapely==1.8.4
 six==1.13.0
 tqdm==4.7.4
+urllib3==2.0.7

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -28,4 +28,4 @@ requests==2.21.0
 Shapely==1.8.4
 six==1.13.0
 tqdm==4.7.4
-urllib3==2.0.7
+urllib3==1.24

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -28,4 +28,3 @@ requests==2.21.0
 Shapely==1.8.4
 six==1.13.0
 tqdm==4.7.4
-urllib3==1.24


### PR DESCRIPTION
There are some dependency issues when trying to run with Python 3.7 in the geography samples folder. In particular the following Error is raised during testing:

```
ERROR: Could not find a version that satisfies the requirement urllib3==2.1.0 (from versions: 0.3, 1.0, 1.0.1, 1.0.2, 1.1, 1.2, 1.2.1,
1.2.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.7.1, 1.8, 1.8.2, 1.8.3, 1.9, 1.9.1, 
1.10, 1.10.1, 1.10.2, 1.10.3, 1.10.4, 1.11, 1.12, 1.13, 1.13.1, 1.14, 
1.15, 1.15.1, 1.16, 1.17, 1.18, 1.18.1, 1.19, 1.19.1, 1.20, 1.21, 1.21.1, 
1.22, 1.23, 1.24, 1.24.1, 1.24.2, 1.24.3, 1.25.2, 1.25.3, 1.25.4, 1.25.5, 
1.25.6, 1.25.7, 1.25.8, 1.25.9, 1.25.10, 1.25.11, 1.26.0, 1.26.1, 1.26.2, 
1.26.3, 1.26.4, 1.26.5, 1.26.6, 1.26.7, 1.26.8, 1.26.9, 1.26.10, 1.26.11, 
1.26.12, 1.26.13, 1.26.14, 1.26.15, 1.26.16, 1.26.17, 1.26.18, 2.0.0a1, 
2.0.0a2, 2.0.0a3, 2.0.0a4, 2.0.2, 2.0.3, 2.0.4, 2.0.5, 2.0.6, 2.0.7)
ERROR: No matching distribution found for urllib3==2.1.0
```

Version `2.1.0` is not compatible with Python 3.7.

When running under Python 3.7, setting a constraint for `urllib3` to a version that was compatible with 3.7 (ie `<1.25`) enables the test suite to pass.

Similarly, setting the requirement for 3.8+ versions of Python ensures that all the tests across the test suite pass.