### PR TITLE
fix: supplementary fix to env-based universe resolution

### DIFF
--- a/google/cloud/bigquery/_helpers.py
+++ b/google/cloud/bigquery/_helpers.py
@@ -81,9 +81,8 @@ def _get_client_universe(
     if isinstance(client_options, dict):
         client_options = client_options_lib.from_dict(client_options)
     universe = _DEFAULT_UNIVERSE
-    if hasattr(client_options, "universe_domain"):
-        options_universe = getattr(client_options, "universe_domain")
-        if options_universe is not None and len(options_universe) > 0:
+    options_universe = getattr(client_options, "universe_domain", None)
+    if options_universe and isinstance(options_universe, str) and len(options_universe) > 0:
             universe = options_universe
     else:
         env_universe = os.getenv(_UNIVERSE_DOMAIN_ENV)

--- a/google/cloud/bigquery/_helpers.py
+++ b/google/cloud/bigquery/_helpers.py
@@ -82,8 +82,12 @@ def _get_client_universe(
         client_options = client_options_lib.from_dict(client_options)
     universe = _DEFAULT_UNIVERSE
     options_universe = getattr(client_options, "universe_domain", None)
-    if options_universe and isinstance(options_universe, str) and len(options_universe) > 0:
-            universe = options_universe
+    if (
+        options_universe
+        and isinstance(options_universe, str)
+        and len(options_universe) > 0
+    ):
+        universe = options_universe
     else:
         env_universe = os.getenv(_UNIVERSE_DOMAIN_ENV)
         if isinstance(env_universe, str) and len(env_universe) > 0:

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -60,10 +60,22 @@ class Test_get_client_universe(unittest.TestCase):
 
         self.assertEqual("foo.com", _get_client_universe(None))
 
+    @mock.patch.dict(os.environ, {"GOOGLE_CLOUD_UNIVERSE_DOMAIN": "foo.com"})
+    def test_with_environ_and_dict(self):
+        from google.cloud.bigquery._helpers import _get_client_universe
+        options = {"credentials_file": "file.json"},
+        self.assertEqual("foo.com", _get_client_universe(options))
+
+    @mock.patch.dict(os.environ, {"GOOGLE_CLOUD_UNIVERSE_DOMAIN": "foo.com"})
+    def test_with_environ_and_empty_options(self):
+        from google.cloud.bigquery._helpers import _get_client_universe
+        from google.api_core import client_options
+        options = client_options.from_dict({})
+        self.assertEqual("foo.com", _get_client_universe(options))
+
     @mock.patch.dict(os.environ, {"GOOGLE_CLOUD_UNIVERSE_DOMAIN": ""})
     def test_with_environ_empty(self):
         from google.cloud.bigquery._helpers import _get_client_universe
-
         self.assertEqual("googleapis.com", _get_client_universe(None))
 
 

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -63,19 +63,22 @@ class Test_get_client_universe(unittest.TestCase):
     @mock.patch.dict(os.environ, {"GOOGLE_CLOUD_UNIVERSE_DOMAIN": "foo.com"})
     def test_with_environ_and_dict(self):
         from google.cloud.bigquery._helpers import _get_client_universe
-        options = {"credentials_file": "file.json"},
+
+        options = ({"credentials_file": "file.json"},)
         self.assertEqual("foo.com", _get_client_universe(options))
 
     @mock.patch.dict(os.environ, {"GOOGLE_CLOUD_UNIVERSE_DOMAIN": "foo.com"})
     def test_with_environ_and_empty_options(self):
         from google.cloud.bigquery._helpers import _get_client_universe
         from google.api_core import client_options
+
         options = client_options.from_dict({})
         self.assertEqual("foo.com", _get_client_universe(options))
 
     @mock.patch.dict(os.environ, {"GOOGLE_CLOUD_UNIVERSE_DOMAIN": ""})
     def test_with_environ_empty(self):
         from google.cloud.bigquery._helpers import _get_client_universe
+
         self.assertEqual("googleapis.com", _get_client_universe(None))
 
 


### PR DESCRIPTION
There's a corner case where conversion from dict to a ClientOptions will return a universe_domain value as None that wasn't covered by initial testing.  This updates the resolution code and adds tests to exercise the new path.
