### PR TITLE
testing: update CI configurations

### DIFF
--- a/.kokoro/continuous/prerelease-deps-3.12.cfg
+++ b/.kokoro/continuous/prerelease-deps-3.12.cfg
@@ -3,5 +3,5 @@
 # Only run this nox session.
 env_vars: {
     key: "NOX_SESSION"
-    value: "prerelease_deps-3.11"
+    value: "prerelease_deps-3.12"
 }

--- a/.kokoro/continuous/prerelease-deps-3.8.cfg
+++ b/.kokoro/continuous/prerelease-deps-3.8.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Only run this nox session.
-env_vars: {
-    key: "NOX_SESSION"
-    value: "prerelease_deps-3.8"
-}

--- a/.kokoro/continuous/prerelease-deps.cfg
+++ b/.kokoro/continuous/prerelease-deps.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Only run this nox session.
-env_vars: {
-    key: "NOX_SESSION"
-    value: "prerelease_deps"
-}

--- a/.kokoro/presubmit/prerelease-deps-3.8.cfg
+++ b/.kokoro/presubmit/prerelease-deps-3.8.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Only run this nox session.
-env_vars: {
-    key: "NOX_SESSION"
-    value: "prerelease_deps-3.8"
-}

--- a/.kokoro/presubmit/prerelease-deps.cfg
+++ b/.kokoro/presubmit/prerelease-deps.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Only run this nox session.
-env_vars: {
-    key: "NOX_SESSION"
-    value: "prerelease_deps"
-}


### PR DESCRIPTION
This PR does two things:
* remove unneeded prerelease-deps configs for removed and nonexisting CI targets
* fixes the continuous prerelease-deps-3.12 config
