### PR TITLE
fix: correct type checking

### DIFF
--- a/google/cloud/bigquery/job/query.py
+++ b/google/cloud/bigquery/job/query.py
@@ -1411,7 +1411,7 @@ class QueryJob(_AsyncJob):
         # Our system does not natively handle that and instead expects
         # either none or a numeric value. If passed a Python object, convert to
         # None.
-        if isinstance(self._done_timeout, object):  # pragma: NO COVER
+        if type(self._done_timeout) is object:  # pragma: NO COVER
             self._done_timeout = None
 
         if self._done_timeout is not None:  # pragma: NO COVER

--- a/google/cloud/bigquery/job/query.py
+++ b/google/cloud/bigquery/job/query.py
@@ -1409,7 +1409,7 @@ class QueryJob(_AsyncJob):
         # Python_API_core, as part of a major rewrite of the deadline, timeout,
         # retry process sets the timeout value as a Python object().
         # Our system does not natively handle that and instead expects
-        # either none or a numeric value. If passed a Python object, convert to
+        # either None or a numeric value. If passed a Python object, convert to
         # None.
         if type(self._done_timeout) is object:  # pragma: NO COVER
             self._done_timeout = None


### PR DESCRIPTION
Correct the way we check whether `self._done_timeout` is an instance of `object` class or not.

Fixes #1838 🦕
