### PR TITLE
testing: unhook prerelease-deps-3.12 from presubmit

### DIFF
--- a/.kokoro/presubmit/prerelease-deps-3.12.cfg
+++ b/.kokoro/presubmit/prerelease-deps-3.12.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Only run this nox session.
-env_vars: {
-    key: "NOX_SESSION"
-    value: "prerelease_deps-3.12"
-}


### PR DESCRIPTION
Testing for prerelease-deps is done within continuous.
