### PR TITLE
fix: updates a number of optional dependencies

### DIFF
--- a/google/cloud/bigquery/_tqdm_helpers.py
+++ b/google/cloud/bigquery/_tqdm_helpers.py
@@ -67,7 +67,7 @@ def get_progress_bar(progress_bar_type, description, total, unit):
             )
         elif progress_bar_type == "tqdm_gui":
             return tqdm.tqdm_gui(desc=description, total=total, unit=unit)
-    except (KeyError, TypeError):
+    except (KeyError, TypeError):  # pragma: NO COVER
         # Protect ourselves from any tqdm errors. In case of
         # unexpected tqdm behavior, just fall back to showing
         # no progress bar.

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -593,7 +593,7 @@ class Client(ClientWithProject):
             )
             return None
 
-        if bqstorage_client is None: # pragma: NO COVER
+        if bqstorage_client is None:  # pragma: NO COVER
             bqstorage_client = bigquery_storage.BigQueryReadClient(
                 credentials=self._credentials,
                 client_options=client_options,

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -593,7 +593,7 @@ class Client(ClientWithProject):
             )
             return None
 
-        if bqstorage_client is None:
+        if bqstorage_client is None: # pragma: NO COVER
             bqstorage_client = bigquery_storage.BigQueryReadClient(
                 credentials=self._credentials,
                 client_options=client_options,

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,9 @@ dependencies = [
 ]
 pyarrow_dependency = "pyarrow >= 3.0.0"
 extras = {
-    # Keep the no-op bqstorage extra for backward compatibility.
-    # See: https://github.com/googleapis/python-bigquery/issues/757
+    # bqstorage had a period where it was a required dependency, and has been
+    # moved back to optional due to bloat.  See
+    # https://github.com/googleapis/python-bigquery/issues/1196 for more background.
     "bqstorage": [
         "google-cloud-bigquery-storage >= 2.6.0, <3.0.0dev",
         # Due to an issue in pip's dependency resolver, the `grpc` extra is not

--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -1791,9 +1791,8 @@ class TestBigQuery(unittest.TestCase):
         self.assertEqual(row_tuples, [(5, "foo"), (6, "bar"), (7, "baz")])
 
     def test_dbapi_fetch_w_bqstorage_client_large_result_set(self):
-        pytest.importorskip("google.cloud.bigquery_storage")
+        bigquery_storage = pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pyarrow")
-        from google.cloud import bigquery_storage
 
         bqstorage_client = bigquery_storage.BigQueryReadClient(
             credentials=Config.CLIENT._credentials

--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -1791,7 +1791,7 @@ class TestBigQuery(unittest.TestCase):
         self.assertEqual(row_tuples, [(5, "foo"), (6, "bar"), (7, "baz")])
 
     def test_dbapi_fetch_w_bqstorage_client_large_result_set(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pyarrow")
         from google.cloud import bigquery_storage
 
@@ -1853,7 +1853,7 @@ class TestBigQuery(unittest.TestCase):
         self.assertEqual(list(rows), [])
 
     def test_dbapi_connection_does_not_leak_sockets(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         current_process = psutil.Process()
         conn_count_start = len(current_process.connections())
 
@@ -2399,7 +2399,7 @@ class TestBigQuery(unittest.TestCase):
             self.assertEqual(found[8], decimal.Decimal(expected["FavoriteNumber"]))
 
     def test_nested_table_to_arrow(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         pyarrow = pytest.importorskip("pyarrow")
         pyarrow.types = pytest.importorskip("pyarrow.types")
         from google.cloud import bigquery_storage

--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -55,16 +55,6 @@ from test_utils.system import unique_resource_id
 
 from . import helpers
 
-try:
-    from google.cloud import bigquery_storage
-except ImportError:  # pragma: NO COVER
-    bigquery_storage = None
-
-try:
-    import pyarrow
-    import pyarrow.types
-except ImportError:  # pragma: NO COVER
-    pyarrow = None
 
 JOB_TIMEOUT = 120  # 2 minutes
 DATA_PATH = pathlib.Path(__file__).parent.parent / "data"
@@ -1800,11 +1790,10 @@ class TestBigQuery(unittest.TestCase):
         row_tuples = [r.values() for r in rows]
         self.assertEqual(row_tuples, [(5, "foo"), (6, "bar"), (7, "baz")])
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_dbapi_fetch_w_bqstorage_client_large_result_set(self):
+        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("pyarrow")
+        from google.cloud import bigquery_storage
         bqstorage_client = bigquery_storage.BigQueryReadClient(
             credentials=Config.CLIENT._credentials
         )
@@ -1862,10 +1851,8 @@ class TestBigQuery(unittest.TestCase):
 
         self.assertEqual(list(rows), [])
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_dbapi_connection_does_not_leak_sockets(self):
+        pytest.importorskip("google-cloud-bigquery-storage")
         current_process = psutil.Process()
         conn_count_start = len(current_process.connections())
 
@@ -2410,11 +2397,11 @@ class TestBigQuery(unittest.TestCase):
             self.assertEqual(found[7], e_favtime)
             self.assertEqual(found[8], decimal.Decimal(expected["FavoriteNumber"]))
 
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_nested_table_to_arrow(self):
+        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("pyarrow")
+        pytest.importorskip("pyarrow.types")
+        from google.cloud import bigquery_storage
         from google.cloud.bigquery.job import SourceFormat
         from google.cloud.bigquery.job import WriteDisposition
 

--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -1794,6 +1794,7 @@ class TestBigQuery(unittest.TestCase):
         pytest.importorskip("google-cloud-bigquery-storage")
         pytest.importorskip("pyarrow")
         from google.cloud import bigquery_storage
+
         bqstorage_client = bigquery_storage.BigQueryReadClient(
             credentials=Config.CLIENT._credentials
         )

--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -2400,8 +2400,8 @@ class TestBigQuery(unittest.TestCase):
 
     def test_nested_table_to_arrow(self):
         pytest.importorskip("google-cloud-bigquery-storage")
-        pytest.importorskip("pyarrow")
-        pytest.importorskip("pyarrow.types")
+        pyarrow = pytest.importorskip("pyarrow")
+        pyarrow.types = pytest.importorskip("pyarrow.types")
         from google.cloud import bigquery_storage
         from google.cloud.bigquery.job import SourceFormat
         from google.cloud.bigquery.job import WriteDisposition

--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -2398,10 +2398,9 @@ class TestBigQuery(unittest.TestCase):
             self.assertEqual(found[8], decimal.Decimal(expected["FavoriteNumber"]))
 
     def test_nested_table_to_arrow(self):
-        pytest.importorskip("google.cloud.bigquery_storage")
+        bigquery_storage = pytest.importorskip("google.cloud.bigquery_storage")
         pyarrow = pytest.importorskip("pyarrow")
         pyarrow.types = pytest.importorskip("pyarrow.types")
-        from google.cloud import bigquery_storage
         from google.cloud.bigquery.job import SourceFormat
         from google.cloud.bigquery.job import WriteDisposition
 

--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -1791,7 +1791,7 @@ class TestBigQuery(unittest.TestCase):
         self.assertEqual(row_tuples, [(5, "foo"), (6, "bar"), (7, "baz")])
 
     def test_dbapi_fetch_w_bqstorage_client_large_result_set(self):
-        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery-storage")
         pytest.importorskip("pyarrow")
         from google.cloud import bigquery_storage
 
@@ -1853,7 +1853,7 @@ class TestBigQuery(unittest.TestCase):
         self.assertEqual(list(rows), [])
 
     def test_dbapi_connection_does_not_leak_sockets(self):
-        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery-storage")
         current_process = psutil.Process()
         conn_count_start = len(current_process.connections())
 
@@ -2399,7 +2399,7 @@ class TestBigQuery(unittest.TestCase):
             self.assertEqual(found[8], decimal.Decimal(expected["FavoriteNumber"]))
 
     def test_nested_table_to_arrow(self):
-        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery-storage")
         pyarrow = pytest.importorskip("pyarrow")
         pyarrow.types = pytest.importorskip("pyarrow.types")
         from google.cloud import bigquery_storage

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -40,7 +40,7 @@ def LOCATION():
 
 
 @pytest.fixture
-def PYARROW_MINIMUM_VERSION(): # pragma: NO COVER
+def PYARROW_MINIMUM_VERSION():  # pragma: NO COVER
     return "3.0.0"
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -40,8 +40,6 @@ def LOCATION():
 
 
 @pytest.fixture
-
-
 def noop_add_server_timeout_header(headers, kwargs):
     if headers:
         kwargs["headers"] = headers

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -40,8 +40,6 @@ def LOCATION():
 
 
 @pytest.fixture
-def PYARROW_MINIMUM_VERSION():  # pragma: NO COVER
-    return "3.0.0"
 
 
 def noop_add_server_timeout_header(headers, kwargs):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -40,7 +40,7 @@ def LOCATION():
 
 
 @pytest.fixture
-def PYARROW_MINIMUM_VERSION():
+def PYARROW_MINIMUM_VERSION(): # pragma: NO COVER
     return "3.0.0"
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -39,6 +39,11 @@ def LOCATION():
     yield "us-central"
 
 
+@pytest.fixture
+def PYARROW_MINIMUM_VERSION():
+    return "3.0.0"
+
+
 def noop_add_server_timeout_header(headers, kwargs):
     if headers:
         kwargs["headers"] = headers

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -39,7 +39,6 @@ def LOCATION():
     yield "us-central"
 
 
-@pytest.fixture
 def noop_add_server_timeout_header(headers, kwargs):
     if headers:
         kwargs["headers"] = headers

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -38,11 +38,6 @@ except ImportError:
     import importlib_metadata as metadata
 
 try:
-    import pandas
-except (ImportError, AttributeError):  # pragma: NO COVER
-    pandas = None
-
-try:
     import opentelemetry
 except ImportError:
     opentelemetry = None
@@ -59,11 +54,6 @@ if opentelemetry is not None:
         msg = "Error importing from opentelemetry, is the installed version compatible?"
         raise ImportError(msg) from exc
 
-try:
-    import pyarrow
-except (ImportError, AttributeError):  # pragma: NO COVER
-    pyarrow = None
-
 import google.api_core.exceptions
 from google.api_core import client_info
 import google.cloud._helpers
@@ -75,17 +65,8 @@ from google.cloud.bigquery import ParquetOptions
 from google.cloud.bigquery.retry import DEFAULT_TIMEOUT
 import google.cloud.bigquery.table
 
-try:
-    from google.cloud import bigquery_storage
-except (ImportError, AttributeError):  # pragma: NO COVER
-    bigquery_storage = None
 from test_utils.imports import maybe_fail_import
 from tests.unit.helpers import make_connection
-
-if pandas is not None:
-    PANDAS_INSTALLED_VERSION = metadata.version("pandas")
-else:
-    PANDAS_INSTALLED_VERSION = "0.0.0"
 
 
 def _make_credentials():
@@ -800,10 +781,10 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(dataset.dataset_id, self.DS_ID)
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_ensure_bqstorage_client_creating_new_instance(self):
+        pytest.importorskip("google-cloud-bigquery-storage")
+        from google.cloud import bigquery_storage
+
         mock_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
         mock_client_instance = object()
         mock_client.return_value = mock_client_instance
@@ -849,10 +830,8 @@ class TestClient(unittest.TestCase):
         ]
         assert matching_warnings, "Missing dependency warning not raised."
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_ensure_bqstorage_client_obsolete_dependency(self):
+        pytest.importorskip("google-cloud-bigquery-storage")
         creds = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds)
 
@@ -869,10 +848,8 @@ class TestClient(unittest.TestCase):
         ]
         assert matching_warnings, "Obsolete dependency warning not raised."
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_ensure_bqstorage_client_existing_client_check_passes(self):
+        pytest.importorskip("google-cloud-bigquery-storage")
         creds = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds)
         mock_storage_client = mock.sentinel.mock_storage_client
@@ -883,10 +860,8 @@ class TestClient(unittest.TestCase):
 
         self.assertIs(bqstorage_client, mock_storage_client)
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_ensure_bqstorage_client_existing_client_check_fails(self):
+        pytest.importorskip("google-cloud-bigquery-storage")
         creds = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds)
         mock_storage_client = mock.sentinel.mock_storage_client
@@ -972,8 +947,8 @@ class TestClient(unittest.TestCase):
             timeout=DEFAULT_TIMEOUT,
         )
 
-    @unittest.skipIf(opentelemetry is None, "Requires `opentelemetry`")
     def test_span_status_is_set(self):
+        pytest.importorskip("opentelemetry")
         from google.cloud.bigquery.routine import Routine
 
         tracer_provider = TracerProvider()
@@ -5972,8 +5947,8 @@ class TestClient(unittest.TestCase):
                 timeout=DEFAULT_TIMEOUT,
             )
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_insert_rows_from_dataframe(self):
+        pandas = pytest.importorskip("pandas")
         from google.cloud.bigquery.schema import SchemaField
         from google.cloud.bigquery.table import Table
 
@@ -6059,8 +6034,8 @@ class TestClient(unittest.TestCase):
             )
             assert call == expected_call
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_insert_rows_from_dataframe_nan(self):
+        pandas = pytest.importorskip("pandas")
         from google.cloud.bigquery.schema import SchemaField
         from google.cloud.bigquery.table import Table
 
@@ -6127,8 +6102,8 @@ class TestClient(unittest.TestCase):
             )
             assert call == expected_call
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_insert_rows_from_dataframe_many_columns(self):
+        pandas = pytest.importorskip("pandas")
         from google.cloud.bigquery.schema import SchemaField
         from google.cloud.bigquery.table import Table
 
@@ -6180,8 +6155,8 @@ class TestClient(unittest.TestCase):
         assert len(actual_calls) == 1
         assert actual_calls[0] == expected_call
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_insert_rows_from_dataframe_w_explicit_none_insert_ids(self):
+        pandas = pytest.importorskip("pandas")
         from google.cloud.bigquery.schema import SchemaField
         from google.cloud.bigquery.table import Table
 
@@ -7502,9 +7477,9 @@ class TestClientUpload(object):
             project=self.PROJECT,
         )
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import PolicyTagList, SchemaField
@@ -7598,9 +7573,9 @@ class TestClientUpload(object):
             # (not passed in via job_config)
             assert "description" not in field
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_client_location(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField
@@ -7643,9 +7618,9 @@ class TestClientUpload(object):
         sent_config = load_table_from_file.mock_calls[0][2]["job_config"]
         assert sent_config.source_format == job.SourceFormat.PARQUET
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_custom_job_config_wihtout_source_format(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField
@@ -7698,9 +7673,9 @@ class TestClientUpload(object):
         # the original config object should not have been modified
         assert job_config.to_api_repr() == original_config_copy.to_api_repr()
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_custom_job_config_w_source_format(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField
@@ -7754,9 +7729,9 @@ class TestClientUpload(object):
         # the original config object should not have been modified
         assert job_config.to_api_repr() == original_config_copy.to_api_repr()
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_parquet_options_none(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow") 
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField
@@ -7806,9 +7781,9 @@ class TestClientUpload(object):
         sent_config = load_table_from_file.mock_calls[0][2]["job_config"]
         assert sent_config.parquet_options.enable_list_inference is True
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_list_inference_none(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField
@@ -7866,9 +7841,9 @@ class TestClientUpload(object):
         # the original config object should not have been modified
         assert job_config.to_api_repr() == original_config_copy.to_api_repr()
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_explicit_job_config_override(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField
@@ -7927,9 +7902,9 @@ class TestClientUpload(object):
         # the original config object should not have been modified
         assert job_config.to_api_repr() == original_config_copy.to_api_repr()
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_default_load_config(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField
@@ -7977,9 +7952,9 @@ class TestClientUpload(object):
         assert sent_config.write_disposition == job.WriteDisposition.WRITE_TRUNCATE
         assert sent_config.source_format == job.SourceFormat.PARQUET
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_list_inference_false(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField
@@ -8038,9 +8013,9 @@ class TestClientUpload(object):
         # the original config object should not have been modified
         assert job_config.to_api_repr() == original_config_copy.to_api_repr()
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_custom_job_config_w_wrong_source_format(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery import job
 
         client = self._make_client()
@@ -8058,9 +8033,9 @@ class TestClientUpload(object):
 
         assert "Got unexpected source_format:" in str(exc.value)
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_automatic_schema(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField
@@ -8159,9 +8134,9 @@ class TestClientUpload(object):
             SchemaField("time_col", "TIME"),
         )
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_automatic_schema_detection_fails(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
 
@@ -8219,9 +8194,9 @@ class TestClientUpload(object):
         assert sent_config.source_format == job.SourceFormat.PARQUET
         assert sent_config.schema is None
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_index_and_auto_schema(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField
@@ -8281,9 +8256,9 @@ class TestClientUpload(object):
         ]
         assert sent_schema == expected_sent_schema
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_unknown_table(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
 
         client = self._make_client()
@@ -8317,9 +8292,9 @@ class TestClientUpload(object):
             timeout=DEFAULT_TIMEOUT,
         )
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_nullable_int64_datatype(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField
@@ -8362,9 +8337,8 @@ class TestClientUpload(object):
             SchemaField("x", "INT64", "NULLABLE", None),
         )
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    # @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_nullable_int64_datatype_automatic_schema(self):
+        pandas = pytest.importorskip("pandas")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField
@@ -8407,9 +8381,9 @@ class TestClientUpload(object):
             SchemaField("x", "INT64", "NULLABLE", None),
         )
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_struct_fields(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField
@@ -8467,13 +8441,13 @@ class TestClientUpload(object):
         assert sent_config.source_format == job.SourceFormat.PARQUET
         assert sent_config.schema == schema
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_array_fields(self):
         """Test that a DataFrame with array columns can be uploaded correctly.
 
         See: https://github.com/googleapis/python-bigquery/issues/19
         """
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField
@@ -8532,13 +8506,13 @@ class TestClientUpload(object):
         assert sent_config.source_format == job.SourceFormat.PARQUET
         assert sent_config.schema == schema
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_array_fields_w_auto_schema(self):
         """Test that a DataFrame with array columns can be uploaded correctly.
 
         See: https://github.com/googleapis/python-bigquery/issues/19
         """
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField
@@ -8595,9 +8569,9 @@ class TestClientUpload(object):
         assert sent_config.source_format == job.SourceFormat.PARQUET
         assert sent_config.schema == expected_schema
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_partial_schema(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField
@@ -8679,9 +8653,9 @@ class TestClientUpload(object):
             SchemaField("bytes_col", "BYTES"),
         )
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_partial_schema_extra_types(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField
 
@@ -8716,9 +8690,9 @@ class TestClientUpload(object):
         assert "bq_schema contains fields not present in dataframe" in message
         assert "unknown_col" in message
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_schema_arrow_custom_compression(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField
 
@@ -8749,9 +8723,9 @@ class TestClientUpload(object):
         assert call_args is not None
         assert call_args.get("parquet_compression") == "LZ4"
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_wo_pyarrow_raises_error(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         client = self._make_client()
         records = [{"id": 1, "age": 100}, {"id": 2, "age": 60}]
         dataframe = pandas.DataFrame(records)
@@ -8779,8 +8753,8 @@ class TestClientUpload(object):
                 )
 
     def test_load_table_from_dataframe_w_bad_pyarrow_issues_warning(self):
-        pytest.importorskip("pandas", reason="Requires `pandas`")
-        pytest.importorskip("pyarrow", reason="Requires `pyarrow`")
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
 
         client = self._make_client()
         records = [{"id": 1, "age": 100}, {"id": 2, "age": 60}]
@@ -8807,14 +8781,14 @@ class TestClientUpload(object):
                     location=self.LOCATION,
                 )
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_nulls(self):
         """Test that a DataFrame with null columns can be uploaded if a
         BigQuery schema is specified.
 
         See: https://github.com/googleapis/google-cloud-python/issues/7370
         """
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.schema import SchemaField
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
@@ -8852,8 +8826,8 @@ class TestClientUpload(object):
         assert sent_config.schema == schema
         assert sent_config.source_format == job.SourceFormat.PARQUET
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_load_table_from_dataframe_w_invaild_job_config(self):
+        pandas = pytest.importorskip("pandas") 
         from google.cloud.bigquery import job
 
         client = self._make_client()
@@ -8870,8 +8844,8 @@ class TestClientUpload(object):
         err_msg = str(exc.value)
         assert "Expected an instance of LoadJobConfig" in err_msg
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_load_table_from_dataframe_with_csv_source_format(self):
+        pandas = pytest.importorskip("pandas")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField
@@ -8920,9 +8894,9 @@ class TestClientUpload(object):
         sent_config = load_table_from_file.mock_calls[0][2]["job_config"]
         assert sent_config.source_format == job.SourceFormat.CSV
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_higher_scale_decimal128_datatype(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -778,7 +778,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(dataset.dataset_id, self.DS_ID)
 
     def test_ensure_bqstorage_client_creating_new_instance(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud import bigquery_storage
 
         mock_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
@@ -827,7 +827,7 @@ class TestClient(unittest.TestCase):
         assert matching_warnings, "Missing dependency warning not raised."
 
     def test_ensure_bqstorage_client_obsolete_dependency(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         creds = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds)
 
@@ -845,7 +845,7 @@ class TestClient(unittest.TestCase):
         assert matching_warnings, "Obsolete dependency warning not raised."
 
     def test_ensure_bqstorage_client_existing_client_check_passes(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         creds = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds)
         mock_storage_client = mock.sentinel.mock_storage_client
@@ -872,7 +872,7 @@ class TestClient(unittest.TestCase):
         )
 
     def test_ensure_bqstorage_client_existing_client_check_fails(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         creds = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds)
         mock_storage_client = mock.sentinel.mock_storage_client

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -778,7 +778,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(dataset.dataset_id, self.DS_ID)
 
     def test_ensure_bqstorage_client_creating_new_instance(self):
-        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery-storage")
         from google.cloud import bigquery_storage
 
         mock_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
@@ -827,7 +827,7 @@ class TestClient(unittest.TestCase):
         assert matching_warnings, "Missing dependency warning not raised."
 
     def test_ensure_bqstorage_client_obsolete_dependency(self):
-        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery-storage")
         creds = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds)
 
@@ -845,7 +845,7 @@ class TestClient(unittest.TestCase):
         assert matching_warnings, "Obsolete dependency warning not raised."
 
     def test_ensure_bqstorage_client_existing_client_check_passes(self):
-        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery-storage")
         creds = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds)
         mock_storage_client = mock.sentinel.mock_storage_client
@@ -872,7 +872,7 @@ class TestClient(unittest.TestCase):
         )
 
     def test_ensure_bqstorage_client_existing_client_check_fails(self):
-        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery-storage")
         creds = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds)
         mock_storage_client = mock.sentinel.mock_storage_client

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -778,8 +778,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(dataset.dataset_id, self.DS_ID)
 
     def test_ensure_bqstorage_client_creating_new_instance(self):
-        pytest.importorskip("google.cloud.bigquery_storage")
-        from google.cloud import bigquery_storage
+        bigquery_storage = pytest.importorskip("google.cloud.bigquery_storage")
 
         mock_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
         mock_client_instance = object()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -860,6 +860,20 @@ class TestClient(unittest.TestCase):
 
         self.assertIs(bqstorage_client, mock_storage_client)
 
+    def test_ensure_bqstorage_client_is_none(self):
+        pytest.importorskip("google.cloud.bigquery_storage")
+        creds = _make_credentials()
+        client = self._make_one(project=self.PROJECT, credentials=creds)
+        mock_storage_client = mock.sentinel.mock_storage_client
+
+        bqstorage_client = client._ensure_bqstorage_client(
+            bqstorage_client=None
+        )
+
+        print(bqstorage_client, type(bqstorage_client), dir(bqstorage_client))
+        #self.assertIs(bqstorage_client, mock_storage_client)
+        assert isinstance(bqstorage_client, google.cloud.bigquery_storage_v1.BigQueryReadClient)
+
     def test_ensure_bqstorage_client_existing_client_check_fails(self):
         pytest.importorskip("google-cloud-bigquery-storage")
         creds = _make_credentials()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -866,13 +866,13 @@ class TestClient(unittest.TestCase):
         client = self._make_one(project=self.PROJECT, credentials=creds)
         mock_storage_client = mock.sentinel.mock_storage_client
 
-        bqstorage_client = client._ensure_bqstorage_client(
-            bqstorage_client=None
-        )
+        bqstorage_client = client._ensure_bqstorage_client(bqstorage_client=None)
 
         print(bqstorage_client, type(bqstorage_client), dir(bqstorage_client))
-        #self.assertIs(bqstorage_client, mock_storage_client)
-        assert isinstance(bqstorage_client, google.cloud.bigquery_storage_v1.BigQueryReadClient)
+        # self.assertIs(bqstorage_client, mock_storage_client)
+        assert isinstance(
+            bqstorage_client, google.cloud.bigquery_storage_v1.BigQueryReadClient
+        )
 
     def test_ensure_bqstorage_client_existing_client_check_fails(self):
         pytest.importorskip("google-cloud-bigquery-storage")

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -32,10 +32,6 @@ import requests
 import packaging
 import pytest
 
-try:
-    import importlib.metadata as metadata
-except ImportError:
-    import importlib_metadata as metadata
 
 try:
     import opentelemetry
@@ -864,12 +860,13 @@ class TestClient(unittest.TestCase):
         pytest.importorskip("google.cloud.bigquery_storage")
         creds = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds)
-        mock_storage_client = mock.sentinel.mock_storage_client
+        bqstorage_client = None
 
-        bqstorage_client = client._ensure_bqstorage_client(bqstorage_client=None)
+        assert bqstorage_client is None
+        bqstorage_client = client._ensure_bqstorage_client(
+            bqstorage_client=bqstorage_client,
+        )
 
-        print(bqstorage_client, type(bqstorage_client), dir(bqstorage_client))
-        # self.assertIs(bqstorage_client, mock_storage_client)
         assert isinstance(
             bqstorage_client, google.cloud.bigquery_storage_v1.BigQueryReadClient
         )

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -7731,7 +7731,7 @@ class TestClientUpload(object):
 
     def test_load_table_from_dataframe_w_parquet_options_none(self):
         pandas = pytest.importorskip("pandas")
-        pytest.importorskip("pyarrow") 
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job
         from google.cloud.bigquery.schema import SchemaField
@@ -8827,7 +8827,7 @@ class TestClientUpload(object):
         assert sent_config.source_format == job.SourceFormat.PARQUET
 
     def test_load_table_from_dataframe_w_invaild_job_config(self):
-        pandas = pytest.importorskip("pandas") 
+        pandas = pytest.importorskip("pandas")
         from google.cloud.bigquery import job
 
         client = self._make_client()

--- a/tests/unit/test_dbapi__helpers.py
+++ b/tests/unit/test_dbapi__helpers.py
@@ -21,16 +21,10 @@ import unittest
 
 import pytest
 
-try:
-    import pyarrow
-except ImportError:  # pragma: NO COVER
-    pyarrow = None
-
 import google.cloud._helpers
 from google.cloud.bigquery import query, table
 from google.cloud.bigquery.dbapi import _helpers
 from google.cloud.bigquery.dbapi import exceptions
-from tests.unit.helpers import _to_pyarrow
 
 
 class TestQueryParameters(unittest.TestCase):
@@ -215,8 +209,9 @@ class TestToBqTableRows(unittest.TestCase):
         result = _helpers.to_bq_table_rows(rows_iterable)
         self.assertEqual(list(result), [])
 
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_non_empty_iterable(self):
+        pytest.importorskip("pyarrow")
+        from tests.unit.helpers import _to_pyarrow
         rows_iterable = [
             dict(
                 one=_to_pyarrow(1.1),

--- a/tests/unit/test_dbapi__helpers.py
+++ b/tests/unit/test_dbapi__helpers.py
@@ -212,6 +212,7 @@ class TestToBqTableRows(unittest.TestCase):
     def test_non_empty_iterable(self):
         pytest.importorskip("pyarrow")
         from tests.unit.helpers import _to_pyarrow
+
         rows_iterable = [
             dict(
                 one=_to_pyarrow(1.1),

--- a/tests/unit/test_dbapi_connection.py
+++ b/tests/unit/test_dbapi_connection.py
@@ -56,7 +56,7 @@ class TestConnection(unittest.TestCase):
         self.assertIs(connection._bqstorage_client, None)
 
     def test_ctor_w_bqstorage_client(self):
-        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery-storage")
         from google.cloud.bigquery.dbapi import Connection
 
         mock_client = self._mock_client()
@@ -86,7 +86,7 @@ class TestConnection(unittest.TestCase):
         self.assertIsNotNone(connection._bqstorage_client)
 
     def test_connect_w_client(self):
-        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery-storage")
         from google.cloud.bigquery.dbapi import connect
         from google.cloud.bigquery.dbapi import Connection
 
@@ -102,7 +102,7 @@ class TestConnection(unittest.TestCase):
         self.assertIs(connection._bqstorage_client, mock_bqstorage_client)
 
     def test_connect_w_both_clients(self):
-        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery-storage")
         from google.cloud.bigquery.dbapi import connect
         from google.cloud.bigquery.dbapi import Connection
 
@@ -136,7 +136,7 @@ class TestConnection(unittest.TestCase):
                 getattr(connection, method)()
 
     def test_close_closes_all_created_bigquery_clients(self):
-        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery-storage")
         client = self._mock_client()
         bqstorage_client = self._mock_bqstorage_client()
 
@@ -159,7 +159,7 @@ class TestConnection(unittest.TestCase):
         self.assertTrue(bqstorage_client._transport.grpc_channel.close.called)
 
     def test_close_does_not_close_bigquery_clients_passed_to_it(self):
-        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery-storage")
         client = self._mock_client()
         bqstorage_client = self._mock_bqstorage_client()
         connection = self._make_one(client=client, bqstorage_client=bqstorage_client)

--- a/tests/unit/test_dbapi_connection.py
+++ b/tests/unit/test_dbapi_connection.py
@@ -38,6 +38,7 @@ class TestConnection(unittest.TestCase):
         # Assumption: bigquery_storage exists. It's the test's responisbility to
         # not use this helper or skip itself if bqstorage is not installed.
         from google.cloud import bigquery_storage
+
         mock_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
         mock_client._transport = mock.Mock(spec=["channel"])
         mock_client._transport.grpc_channel = mock.Mock(spec=["close"])

--- a/tests/unit/test_dbapi_connection.py
+++ b/tests/unit/test_dbapi_connection.py
@@ -158,10 +158,8 @@ class TestConnection(unittest.TestCase):
         self.assertTrue(client.close.called)
         self.assertTrue(bqstorage_client._transport.grpc_channel.close.called)
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_close_does_not_close_bigquery_clients_passed_to_it(self):
+        pytest.importorskip("google-cloud-bigquery-storage")
         client = self._mock_client()
         bqstorage_client = self._mock_bqstorage_client()
         connection = self._make_one(client=client, bqstorage_client=bqstorage_client)

--- a/tests/unit/test_dbapi_connection.py
+++ b/tests/unit/test_dbapi_connection.py
@@ -56,7 +56,7 @@ class TestConnection(unittest.TestCase):
         self.assertIs(connection._bqstorage_client, None)
 
     def test_ctor_w_bqstorage_client(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery.dbapi import Connection
 
         mock_client = self._mock_client()
@@ -86,7 +86,7 @@ class TestConnection(unittest.TestCase):
         self.assertIsNotNone(connection._bqstorage_client)
 
     def test_connect_w_client(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery.dbapi import connect
         from google.cloud.bigquery.dbapi import Connection
 
@@ -102,7 +102,7 @@ class TestConnection(unittest.TestCase):
         self.assertIs(connection._bqstorage_client, mock_bqstorage_client)
 
     def test_connect_w_both_clients(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery.dbapi import connect
         from google.cloud.bigquery.dbapi import Connection
 
@@ -136,7 +136,7 @@ class TestConnection(unittest.TestCase):
                 getattr(connection, method)()
 
     def test_close_closes_all_created_bigquery_clients(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         client = self._mock_client()
         bqstorage_client = self._mock_bqstorage_client()
 
@@ -159,7 +159,7 @@ class TestConnection(unittest.TestCase):
         self.assertTrue(bqstorage_client._transport.grpc_channel.close.called)
 
     def test_close_does_not_close_bigquery_clients_passed_to_it(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         client = self._mock_client()
         bqstorage_client = self._mock_bqstorage_client()
         connection = self._make_one(client=client, bqstorage_client=bqstorage_client)

--- a/tests/unit/test_dbapi_connection.py
+++ b/tests/unit/test_dbapi_connection.py
@@ -13,13 +13,9 @@
 #  limitations under the License.
 
 import gc
+import pytest
 import unittest
 from unittest import mock
-
-try:
-    from google.cloud import bigquery_storage
-except ImportError:  # pragma: NO COVER
-    bigquery_storage = None
 
 
 class TestConnection(unittest.TestCase):
@@ -41,6 +37,7 @@ class TestConnection(unittest.TestCase):
     def _mock_bqstorage_client(self):
         # Assumption: bigquery_storage exists. It's the test's responisbility to
         # not use this helper or skip itself if bqstorage is not installed.
+        from google.cloud import bigquery_storage
         mock_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
         mock_client._transport = mock.Mock(spec=["channel"])
         mock_client._transport.grpc_channel = mock.Mock(spec=["close"])
@@ -57,10 +54,8 @@ class TestConnection(unittest.TestCase):
         self.assertIs(connection._client, mock_client)
         self.assertIs(connection._bqstorage_client, None)
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_ctor_w_bqstorage_client(self):
+        pytest.importorskip("google-cloud-bigquery-storage")
         from google.cloud.bigquery.dbapi import Connection
 
         mock_client = self._mock_client()
@@ -89,10 +84,8 @@ class TestConnection(unittest.TestCase):
         self.assertIsNotNone(connection._client)
         self.assertIsNotNone(connection._bqstorage_client)
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_connect_w_client(self):
+        pytest.importorskip("google-cloud-bigquery-storage")
         from google.cloud.bigquery.dbapi import connect
         from google.cloud.bigquery.dbapi import Connection
 
@@ -107,10 +100,8 @@ class TestConnection(unittest.TestCase):
         self.assertIs(connection._client, mock_client)
         self.assertIs(connection._bqstorage_client, mock_bqstorage_client)
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_connect_w_both_clients(self):
+        pytest.importorskip("google-cloud-bigquery-storage")
         from google.cloud.bigquery.dbapi import connect
         from google.cloud.bigquery.dbapi import Connection
 
@@ -143,10 +134,8 @@ class TestConnection(unittest.TestCase):
             ):
                 getattr(connection, method)()
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_close_closes_all_created_bigquery_clients(self):
+        pytest.importorskip("google-cloud-bigquery-storage")
         client = self._mock_client()
         bqstorage_client = self._mock_bqstorage_client()
 

--- a/tests/unit/test_dbapi_cursor.py
+++ b/tests/unit/test_dbapi_cursor.py
@@ -313,7 +313,7 @@ class TestCursor(unittest.TestCase):
         self.assertEqual(rows[0], (1,))
 
     def test_fetchall_w_bqstorage_client_fetch_success(self):
-        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery-storage")
         pytest.importorskip("pyarrow")
         from google.cloud.bigquery import dbapi
 
@@ -371,7 +371,7 @@ class TestCursor(unittest.TestCase):
         self.assertEqual(sorted_row_data, expected_row_data)
 
     def test_fetchall_w_bqstorage_client_fetch_no_rows(self):
-        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery-storage")
         from google.cloud.bigquery import dbapi
 
         mock_client = self._mock_client(
@@ -399,7 +399,7 @@ class TestCursor(unittest.TestCase):
         self.assertEqual(rows, [])
 
     def test_fetchall_w_bqstorage_client_fetch_error_no_fallback(self):
-        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery-storage")
         from google.cloud.bigquery import dbapi
 
         row_data = [bq_table.Row([1.1, 1.2], {"foo": 0, "bar": 1})]
@@ -435,7 +435,7 @@ class TestCursor(unittest.TestCase):
         mock_client.list_rows.assert_not_called()
 
     def test_fetchall_w_bqstorage_client_no_arrow_compression(self):
-        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery-storage")
         pytest.importorskip("pyarrow")
         from google.cloud import bigquery_storage
         from google.cloud.bigquery import dbapi

--- a/tests/unit/test_dbapi_cursor.py
+++ b/tests/unit/test_dbapi_cursor.py
@@ -313,7 +313,7 @@ class TestCursor(unittest.TestCase):
         self.assertEqual(rows[0], (1,))
 
     def test_fetchall_w_bqstorage_client_fetch_success(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pyarrow")
         from google.cloud.bigquery import dbapi
 
@@ -371,7 +371,7 @@ class TestCursor(unittest.TestCase):
         self.assertEqual(sorted_row_data, expected_row_data)
 
     def test_fetchall_w_bqstorage_client_fetch_no_rows(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import dbapi
 
         mock_client = self._mock_client(
@@ -399,7 +399,7 @@ class TestCursor(unittest.TestCase):
         self.assertEqual(rows, [])
 
     def test_fetchall_w_bqstorage_client_fetch_error_no_fallback(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import dbapi
 
         row_data = [bq_table.Row([1.1, 1.2], {"foo": 0, "bar": 1})]
@@ -435,7 +435,7 @@ class TestCursor(unittest.TestCase):
         mock_client.list_rows.assert_not_called()
 
     def test_fetchall_w_bqstorage_client_no_arrow_compression(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pyarrow")
         from google.cloud import bigquery_storage
         from google.cloud.bigquery import dbapi

--- a/tests/unit/test_dbapi_cursor.py
+++ b/tests/unit/test_dbapi_cursor.py
@@ -21,17 +21,7 @@ import pytest
 
 import google.cloud.bigquery.table as bq_table
 
-try:
-    import pyarrow
-except ImportError:  # pragma: NO COVER
-    pyarrow = None
-
 from google.api_core import exceptions
-
-try:
-    from google.cloud import bigquery_storage
-except ImportError:  # pragma: NO COVER
-    bigquery_storage = None
 
 from tests.unit.helpers import _to_pyarrow
 
@@ -97,6 +87,7 @@ class TestCursor(unittest.TestCase):
         return mock_client
 
     def _mock_bqstorage_client(self, rows=None, stream_count=0):
+        from google.cloud import bigquery_storage
         if rows is None:
             rows = []
 
@@ -320,11 +311,9 @@ class TestCursor(unittest.TestCase):
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0], (1,))
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_fetchall_w_bqstorage_client_fetch_success(self):
+        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery import dbapi
 
         # use unordered data to also test any non-determenistic key order in dicts
@@ -380,10 +369,8 @@ class TestCursor(unittest.TestCase):
 
         self.assertEqual(sorted_row_data, expected_row_data)
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_fetchall_w_bqstorage_client_fetch_no_rows(self):
+        pytest.importorskip("google-cloud-bigquery-storage")
         from google.cloud.bigquery import dbapi
 
         mock_client = self._mock_client(
@@ -410,10 +397,8 @@ class TestCursor(unittest.TestCase):
         # check the data returned
         self.assertEqual(rows, [])
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_fetchall_w_bqstorage_client_fetch_error_no_fallback(self):
+        pytest.importorskip("google-cloud-bigquery-storage")
         from google.cloud.bigquery import dbapi
 
         row_data = [bq_table.Row([1.1, 1.2], {"foo": 0, "bar": 1})]
@@ -448,11 +433,10 @@ class TestCursor(unittest.TestCase):
         # the default client was not used
         mock_client.list_rows.assert_not_called()
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_fetchall_w_bqstorage_client_no_arrow_compression(self):
+        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("pyarrow")
+        from google.cloud import bigquery_storage
         from google.cloud.bigquery import dbapi
 
         # Use unordered data to also test any non-determenistic key order in dicts.

--- a/tests/unit/test_dbapi_cursor.py
+++ b/tests/unit/test_dbapi_cursor.py
@@ -88,6 +88,7 @@ class TestCursor(unittest.TestCase):
 
     def _mock_bqstorage_client(self, rows=None, stream_count=0):
         from google.cloud import bigquery_storage
+
         if rows is None:
             rows = []
 

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -2327,7 +2327,7 @@ class TestRowIterator(unittest.TestCase):
         )
 
     def test__should_use_bqstorage_returns_true_if_no_cached_results(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         iterator = self._make_one(first_page_response=None)  # not cached
         result = iterator._should_use_bqstorage(
             bqstorage_client=None, create_bqstorage_client=True
@@ -2371,7 +2371,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertFalse(result)
 
     def test__should_use_bqstorage_returns_false_w_warning_if_obsolete_version(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         iterator = self._make_one(first_page_response=None)  # not cached
 
         patcher = mock.patch(
@@ -2495,7 +2495,7 @@ class TestRowIterator(unittest.TestCase):
 
     def test_to_arrow_iterable_w_bqstorage(self):
         pyarrow = pytest.importorskip("pyarrow")
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud import bigquery_storage
         from google.cloud.bigquery_storage_v1 import reader
         from google.cloud.bigquery_storage_v1.services.big_query_read.transports import (
@@ -2783,7 +2783,7 @@ class TestRowIterator(unittest.TestCase):
 
     def test_to_arrow_max_results_w_explicit_bqstorage_client_warning(self):
         pytest.importorskip("pyarrow")
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -2825,7 +2825,7 @@ class TestRowIterator(unittest.TestCase):
 
     def test_to_arrow_max_results_w_create_bqstorage_client_no_warning(self):
         pytest.importorskip("pyarrow")
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -2863,7 +2863,7 @@ class TestRowIterator(unittest.TestCase):
 
     def test_to_arrow_w_bqstorage(self):
         pyarrow = pytest.importorskip("pyarrow")
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
         from google.cloud import bigquery_storage
@@ -2946,7 +2946,7 @@ class TestRowIterator(unittest.TestCase):
 
     def test_to_arrow_w_bqstorage_creates_client(self):
         pytest.importorskip("pyarrow")
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
         from google.cloud import bigquery_storage
@@ -3012,7 +3012,7 @@ class TestRowIterator(unittest.TestCase):
 
     def test_to_arrow_w_bqstorage_no_streams(self):
         pyarrow = pytest.importorskip("pyarrow")
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
         from google.cloud import bigquery_storage
@@ -3185,7 +3185,7 @@ class TestRowIterator(unittest.TestCase):
     def test_to_dataframe_iterable_w_bqstorage(self):
         pandas = pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
         from google.cloud import bigquery_storage
@@ -3258,7 +3258,7 @@ class TestRowIterator(unittest.TestCase):
 
     def test_to_dataframe_iterable_w_bqstorage_max_results_warning(self):
         pandas = pytest.importorskip("pandas")
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
         from google.cloud import bigquery_storage
@@ -4145,7 +4145,7 @@ class TestRowIterator(unittest.TestCase):
 
     def test_to_dataframe_w_bqstorage_creates_client(self):
         pytest.importorskip("pandas")
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
         from google.cloud import bigquery_storage
@@ -4178,7 +4178,7 @@ class TestRowIterator(unittest.TestCase):
 
     def test_to_dataframe_w_bqstorage_no_streams(self):
         pytest.importorskip("pandas")
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
         from google.cloud import bigquery_storage
@@ -4205,7 +4205,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertTrue(got.empty)
 
     def test_to_dataframe_w_bqstorage_logs_session(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         pytest.importorskip("pyarrow")
         from google.cloud.bigquery.table import Table
@@ -4229,7 +4229,7 @@ class TestRowIterator(unittest.TestCase):
         )
 
     def test_to_dataframe_w_bqstorage_empty_streams(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
         from google.cloud import bigquery_storage
@@ -4365,7 +4365,7 @@ class TestRowIterator(unittest.TestCase):
         bqstorage_client._transport.grpc_channel.close.assert_not_called()
 
     def test_to_dataframe_w_bqstorage_multiple_streams_return_unique_index(self):
-        bigquery_storage = pytest.importorskip("google.cloud.bigquery-storage")
+        bigquery_storage = pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
         from google.cloud.bigquery import schema
@@ -4417,7 +4417,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertTrue(got.index.is_unique)
 
     def test_to_dataframe_w_bqstorage_updates_progress_bar(self):
-        bigquery_storage = pytest.importorskip("google.cloud.bigquery-storage")
+        bigquery_storage = pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
         pytest.importorskip("tqdm")
@@ -4494,7 +4494,7 @@ class TestRowIterator(unittest.TestCase):
             tqdm_mock().close.assert_called_once()
 
     def test_to_dataframe_w_bqstorage_exits_on_keyboardinterrupt(self):
-        bigquery_storage = pytest.importorskip("google.cloud.bigquery-storage")
+        bigquery_storage = pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
         from google.cloud.bigquery import schema
@@ -4612,7 +4612,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertTrue(df.index.is_unique)
 
     def test_to_dataframe_w_bqstorage_raises_auth_error(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         from google.cloud import bigquery_storage
         from google.cloud.bigquery import table as mut
@@ -4633,7 +4633,7 @@ class TestRowIterator(unittest.TestCase):
             row_iterator.to_dataframe(bqstorage_client=bqstorage_client)
 
     def test_to_dataframe_w_bqstorage_partition(self):
-        bigquery_storage = pytest.importorskip("google.cloud.bigquery-storage")
+        bigquery_storage = pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
 
@@ -4651,7 +4651,7 @@ class TestRowIterator(unittest.TestCase):
             row_iterator.to_dataframe(bqstorage_client)
 
     def test_to_dataframe_w_bqstorage_snapshot(self):
-        bigquery_storage = pytest.importorskip("google.cloud.bigquery-storage")
+        bigquery_storage = pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
 
@@ -4669,7 +4669,7 @@ class TestRowIterator(unittest.TestCase):
             row_iterator.to_dataframe(bqstorage_client)
 
     def test_to_dataframe_concat_categorical_dtype_w_pyarrow(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         pandas = pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
         from google.cloud import bigquery_storage
@@ -5654,7 +5654,7 @@ class TestTableConstraint(unittest.TestCase):
     ),
 )
 def test_table_reference_to_bqstorage_v1_stable(table_path):
-    pytest.importorskip("google.cloud.bigquery-storage")
+    pytest.importorskip("google.cloud.bigquery_storage")
     from google.cloud.bigquery import table as mut
 
     expected = "projects/my-project/datasets/my_dataset/tables/my_table"

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -3540,7 +3540,7 @@ class TestRowIterator(unittest.TestCase):
 
             # Warn that a progress bar was requested, but creating the tqdm
             # progress bar failed.
-            for warning in warned:
+            for warning in warned:  # pragma: NO COVER
                 self.assertIn(
                     warning.category,
                     [UserWarning, DeprecationWarning],

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -3802,7 +3802,9 @@ class TestRowIterator(unittest.TestCase):
 
     def test_to_dataframe_w_none_dtypes_mapper(self):
         pandas = pytest.importorskip("pandas")
-        pytest.mark.skipif(pandas.__version__[0:2] not in ["0.", "1."], reason="")
+        pandas_major_version = pandas.__version__[0:2]
+        if pandas_major_version not in ["0.", "1."]:
+            pytest.skip(reason="Requires a version of pandas less than 2.0")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -3912,10 +3914,12 @@ class TestRowIterator(unittest.TestCase):
                 create_bqstorage_client=False,
                 timestamp_dtype=numpy.dtype("datetime64[us]"),
             )
-
+    
     def test_to_dataframe_column_dtypes(self):
         pandas = pytest.importorskip("pandas")
-        pytest.mark.skipif(pandas.__version__[0:2] not in ["0.", "1."], reason="")
+        pandas_major_version = pandas.__version__[0:2]
+        if pandas_major_version not in ["0.", "1."]:
+            pytest.skip("Requires a version of pandas less than 2.0")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -3928,9 +3932,9 @@ class TestRowIterator(unittest.TestCase):
             SchemaField("date", "DATE"),
         ]
         row_data = [
-            ["1433836800000000", "420", "1.1", "1.77", "Cash", "true", "1999-12-01"],
+            ["1433836800000", "420", "1.1", "1.77", "Cash", "true", "1999-12-01"],
             [
-                "1387811700000000",
+                "1387811700000",
                 "2580",
                 "17.7",
                 "28.5",
@@ -3938,7 +3942,7 @@ class TestRowIterator(unittest.TestCase):
                 "false",
                 "1953-06-14",
             ],
-            ["1385565300000000", "2280", "4.4", "7.1", "Credit", "true", "1981-11-04"],
+            ["1385565300000", "2280", "4.4", "7.1", "Credit", "true", "1981-11-04"],
         ]
         rows = [{"f": [{"v": field} for field in row]} for row in row_data]
         path = "/foo"

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -3914,7 +3914,7 @@ class TestRowIterator(unittest.TestCase):
                 create_bqstorage_client=False,
                 timestamp_dtype=numpy.dtype("datetime64[us]"),
             )
-    
+
     def test_to_dataframe_column_dtypes(self):
         pandas = pytest.importorskip("pandas")
         pandas_major_version = pandas.__version__[0:2]

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -4279,7 +4279,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertTrue(got.empty)
 
     def test_to_dataframe_w_bqstorage_nonempty(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
         from google.cloud.bigquery import schema

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -3049,7 +3049,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(actual_table.schema[1].name, "colC")
         self.assertEqual(actual_table.schema[2].name, "colB")
 
-    def test_to_arrow_progress_bar(self, tqdm_mock, tqdm_notebook_mock, tqdm_gui_mock):
+    def test_to_arrow_progress_bar(self):
         pytest.importorskip("pyarrow")
         pytest.importorskip("tqdm")
         pytest.importorskip("tqdm.notebook")
@@ -3406,9 +3406,7 @@ class TestRowIterator(unittest.TestCase):
             [datetime.datetime(4567, 1, 1), datetime.datetime(9999, 12, 31)],
         )
 
-    def test_to_dataframe_progress_bar(
-        self, tqdm_mock, tqdm_notebook_mock, tqdm_gui_mock
-    ):
+    def test_to_dataframe_progress_bar(self)
         pytest.importorskip("pandas")
         pytest.importorskip("tqdm")
 
@@ -4414,7 +4412,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(len(got.index), total_rows)
         self.assertTrue(got.index.is_unique)
 
-    def test_to_dataframe_w_bqstorage_updates_progress_bar(self, tqdm_mock):
+    def test_to_dataframe_w_bqstorage_updates_progress_bar(self):
         bigquery_storage = pytest.importorskip("google.cloud.bigquery-storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -3406,7 +3406,7 @@ class TestRowIterator(unittest.TestCase):
             [datetime.datetime(4567, 1, 1), datetime.datetime(9999, 12, 31)],
         )
 
-    def test_to_dataframe_progress_bar(self)
+    def test_to_dataframe_progress_bar(self):
         pytest.importorskip("pandas")
         pytest.importorskip("tqdm")
 

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -24,11 +24,6 @@ import warnings
 
 import pytest
 
-try:
-    import importlib.metadata as metadata
-except ImportError:
-    import importlib_metadata as metadata
-
 import google.api_core.exceptions
 from test_utils.imports import maybe_fail_import
 
@@ -1965,7 +1960,7 @@ class Test_EmptyRowIterator(unittest.TestCase):
             row_iterator.to_dataframe_iterable()
 
     def test_to_dataframe_iterable(self):
-        pandas = pytest.importorskip("pandas") 
+        pandas = pytest.importorskip("pandas")
         row_iterator = self._make_one()
         df_iter = row_iterator.to_dataframe_iterable()
 
@@ -1990,7 +1985,7 @@ class Test_EmptyRowIterator(unittest.TestCase):
             row_iterator.to_geodataframe(create_bqstorage_client=False)
 
     def test_to_geodataframe(self):
-        geopandas = pytest.importorskip("geopandas")        
+        geopandas = pytest.importorskip("geopandas")
         row_iterator = self._make_one()
         df = row_iterator.to_geodataframe(create_bqstorage_client=False)
         self.assertIsInstance(df, geopandas.GeoDataFrame)
@@ -2581,7 +2576,9 @@ class TestRowIterator(unittest.TestCase):
         bqstorage_client._transport.grpc_channel.close.assert_not_called()
 
     def test_to_arrow(self):
-        pyarrow = pytest.importorskip("pyarrow", minversion=self.PYARROW_MINIMUM_VERSION)
+        pyarrow = pytest.importorskip(
+            "pyarrow", minversion=self.PYARROW_MINIMUM_VERSION
+        )
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -2873,7 +2870,7 @@ class TestRowIterator(unittest.TestCase):
         from google.cloud.bigquery_storage_v1 import reader
         from google.cloud.bigquery_storage_v1.services.big_query_read.transports import (
             grpc as big_query_read_grpc_transport,
-        )        
+        )
 
         bqstorage_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
         bqstorage_client._transport = mock.create_autospec(
@@ -3019,7 +3016,7 @@ class TestRowIterator(unittest.TestCase):
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
         from google.cloud import bigquery_storage
-        
+
         bqstorage_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
         session = bigquery_storage.types.ReadSession()
         arrow_schema = pyarrow.schema(
@@ -3054,7 +3051,7 @@ class TestRowIterator(unittest.TestCase):
 
     def test_to_arrow_progress_bar(self, tqdm_mock, tqdm_notebook_mock, tqdm_gui_mock):
         pytest.importorskip("pyarrow")
-        tqdm = pytest.importorskip("tqdm")
+        pytest.importorskip("tqdm")
         pytest.importorskip("tqdm.notebook")
         from google.cloud.bigquery.schema import SchemaField
 
@@ -3410,10 +3407,11 @@ class TestRowIterator(unittest.TestCase):
         )
 
     def test_to_dataframe_progress_bar(
-        pandas = pytest.importorskip("pandas")
-        tqdm = pytest.importorskip("tqdm")
         self, tqdm_mock, tqdm_notebook_mock, tqdm_gui_mock
     ):
+        pytest.importorskip("pandas")
+        pytest.importorskip("tqdm")
+
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -3450,7 +3448,7 @@ class TestRowIterator(unittest.TestCase):
 
     @mock.patch("google.cloud.bigquery._tqdm_helpers.tqdm", new=None)
     def test_to_dataframe_no_tqdm_no_progress_bar(self):
-        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pandas")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -3478,7 +3476,7 @@ class TestRowIterator(unittest.TestCase):
 
     @mock.patch("google.cloud.bigquery._tqdm_helpers.tqdm", new=None)
     def test_to_dataframe_no_tqdm(self):
-        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pandas")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -3511,8 +3509,8 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(len(df), 4)
 
     def test_to_dataframe_tqdm_error(self):
-        pandas = pytest.importorskip("pandas")
-        tqdm = pytest.importorskip("tqdm")
+        pytest.importorskip("pandas")
+        pytest.importorskip("tqdm")
         mock.patch("tqdm.tqdm_gui", new=None)
         mock.patch("tqdm.notebook.tqdm", new=None)
         mock.patch("tqdm.tqdm", new=None)
@@ -3610,6 +3608,7 @@ class TestRowIterator(unittest.TestCase):
 
     def test_to_dataframe_w_dtypes_mapper(self):
         pandas = pytest.importorskip("pandas")
+        pyarrow = pytest.importorskip("pyarrow")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -4016,7 +4015,7 @@ class TestRowIterator(unittest.TestCase):
 
     @mock.patch("google.cloud.bigquery.table.shapely", new=None)
     def test_to_dataframe_error_if_shapely_is_none(self):
-        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pandas")
 
         with self.assertRaisesRegex(
             ValueError,
@@ -4282,7 +4281,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertTrue(got.empty)
 
     def test_to_dataframe_w_bqstorage_nonempty(self):
-        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("google.cloud.bigquery-storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
         from google.cloud.bigquery import schema
@@ -4364,7 +4363,7 @@ class TestRowIterator(unittest.TestCase):
         bqstorage_client._transport.grpc_channel.close.assert_not_called()
 
     def test_to_dataframe_w_bqstorage_multiple_streams_return_unique_index(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        bigquery_storage = pytest.importorskip("google.cloud.bigquery-storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
         from google.cloud.bigquery import schema
@@ -4416,7 +4415,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertTrue(got.index.is_unique)
 
     def test_to_dataframe_w_bqstorage_updates_progress_bar(self, tqdm_mock):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        bigquery_storage = pytest.importorskip("google.cloud.bigquery-storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
         pytest.importorskip("tqdm")
@@ -4493,7 +4492,7 @@ class TestRowIterator(unittest.TestCase):
             tqdm_mock().close.assert_called_once()
 
     def test_to_dataframe_w_bqstorage_exits_on_keyboardinterrupt(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        bigquery_storage = pytest.importorskip("google.cloud.bigquery-storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
         from google.cloud.bigquery import schema
@@ -4632,7 +4631,7 @@ class TestRowIterator(unittest.TestCase):
             row_iterator.to_dataframe(bqstorage_client=bqstorage_client)
 
     def test_to_dataframe_w_bqstorage_partition(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        bigquery_storage = pytest.importorskip("google.cloud.bigquery-storage")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
 
@@ -4650,7 +4649,7 @@ class TestRowIterator(unittest.TestCase):
             row_iterator.to_dataframe(bqstorage_client)
 
     def test_to_dataframe_w_bqstorage_snapshot(self):
-        pytest.importorskip("google.cloud.bigquery-storage")
+        bigquery_storage = pytest.importorskip("google.cloud.bigquery-storage")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
 
@@ -4669,12 +4668,11 @@ class TestRowIterator(unittest.TestCase):
 
     def test_to_dataframe_concat_categorical_dtype_w_pyarrow(self):
         pytest.importorskip("google.cloud.bigquery-storage")
-        pytest.importorskip("pandas")
+        pandas = pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
         from google.cloud import bigquery_storage
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
-        from google.cloud import bigquery_storage
         from google.cloud.bigquery_storage_v1 import reader
         from google.cloud.bigquery_storage_v1.services.big_query_read.transports import (
             grpc as big_query_read_grpc_transport,
@@ -4785,7 +4783,7 @@ class TestRowIterator(unittest.TestCase):
 
     def test_to_dataframe_geography_as_object(self):
         pandas = pytest.importorskip("pandas")
-        pytest.importorskip("geopandas") 
+        pytest.importorskip("geopandas")
         row_iterator = self._make_one_from_data(
             (("name", "STRING"), ("geog", "GEOGRAPHY")),
             (
@@ -4895,7 +4893,8 @@ class TestRowIterator(unittest.TestCase):
             row_iterator.to_geodataframe(create_bqstorage_client=False)
 
     def test_to_geodataframe_w_geography_column(self):
-        pytest.importorskip("geopandas")
+        geopandas = pytest.importorskip("geopandas")
+        pandas = pytest.importorskip("pandas")
         row_iterator = self._make_one_from_data(
             (("name", "STRING"), ("geog", "GEOGRAPHY"), ("geog2", "GEOGRAPHY")),
             (
@@ -5643,9 +5642,6 @@ class TestTableConstraint(unittest.TestCase):
         self.assertIsNotNone(instance.foreign_keys)
 
 
-@pytest.mark.skipif(
-    bigquery_storage is None, reason="Requires `google-cloud-bigquery-storage`"
-)
 @pytest.mark.parametrize(
     "table_path",
     (
@@ -5656,6 +5652,7 @@ class TestTableConstraint(unittest.TestCase):
     ),
 )
 def test_table_reference_to_bqstorage_v1_stable(table_path):
+    pytest.importorskip("google.cloud.bigquery-storage")
     from google.cloud.bigquery import table as mut
 
     expected = "projects/my-project/datasets/my_dataset/tables/my_table"

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -37,48 +37,6 @@ from google.cloud.bigquery import exceptions
 from google.cloud.bigquery.table import TableReference
 from google.cloud.bigquery.dataset import DatasetReference
 
-try:
-    from google.cloud import bigquery_storage
-    from google.cloud.bigquery_storage_v1.services.big_query_read.transports import (
-        grpc as big_query_read_grpc_transport,
-    )
-except ImportError:  # pragma: NO COVER
-    bigquery_storage = None
-    big_query_read_grpc_transport = None
-
-
-pyarrow = _versions_helpers.PYARROW_VERSIONS.try_import()
-
-if pyarrow:  # pragma: NO COVER
-    import pyarrow.types
-
-try:
-    import pandas
-except (ImportError, AttributeError):  # pragma: NO COVER
-    pandas = None
-
-try:
-    import db_dtypes  # type: ignore
-except ImportError:  # pragma: NO COVER
-    db_dtypes = None
-
-try:
-    import geopandas
-except (ImportError, AttributeError):  # pragma: NO COVER
-    geopandas = None
-
-try:
-    import tqdm
-    from tqdm.std import TqdmDeprecationWarning
-
-except (ImportError, AttributeError):  # pragma: NO COVER
-    tqdm = None
-
-if pandas is not None:
-    PANDAS_INSTALLED_VERSION = metadata.version("pandas")
-else:
-    PANDAS_INSTALLED_VERSION = "0.0.0"
-
 
 def _mock_client():
     from google.cloud.bigquery import client
@@ -1948,6 +1906,8 @@ class TestRow(unittest.TestCase):
 
 
 class Test_EmptyRowIterator(unittest.TestCase):
+    PYARROW_MINIMUM_VERSION = str(_versions_helpers._MIN_PYARROW_VERSION)
+
     def _make_one(self):
         from google.cloud.bigquery.table import _EmptyRowIterator
 
@@ -1963,15 +1923,17 @@ class Test_EmptyRowIterator(unittest.TestCase):
         with self.assertRaises(ValueError):
             row_iterator.to_arrow()
 
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_arrow(self):
+        pyarrow = pytest.importorskip("pyarrow")
         row_iterator = self._make_one()
         tbl = row_iterator.to_arrow()
         self.assertIsInstance(tbl, pyarrow.Table)
         self.assertEqual(tbl.num_rows, 0)
 
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_arrow_iterable(self):
+        pyarrow = pytest.importorskip(
+            "pyarrow", minversion=self.PYARROW_MINIMUM_VERSION
+        )
         row_iterator = self._make_one()
         arrow_iter = row_iterator.to_arrow_iterable()
 
@@ -1989,8 +1951,8 @@ class Test_EmptyRowIterator(unittest.TestCase):
         with self.assertRaises(ValueError):
             row_iterator.to_dataframe()
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe(self):
+        pandas = pytest.importorskip("pandas")
         row_iterator = self._make_one()
         df = row_iterator.to_dataframe(create_bqstorage_client=False)
         self.assertIsInstance(df, pandas.DataFrame)
@@ -2002,8 +1964,8 @@ class Test_EmptyRowIterator(unittest.TestCase):
         with self.assertRaises(ValueError):
             row_iterator.to_dataframe_iterable()
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_iterable(self):
+        pandas = pytest.importorskip("pandas") 
         row_iterator = self._make_one()
         df_iter = row_iterator.to_dataframe_iterable()
 
@@ -2027,8 +1989,8 @@ class Test_EmptyRowIterator(unittest.TestCase):
         ):
             row_iterator.to_geodataframe(create_bqstorage_client=False)
 
-    @unittest.skipIf(geopandas is None, "Requires `geopandas`")
     def test_to_geodataframe(self):
+        geopandas = pytest.importorskip("geopandas")        
         row_iterator = self._make_one()
         df = row_iterator.to_geodataframe(create_bqstorage_client=False)
         self.assertIsInstance(df, geopandas.GeoDataFrame)
@@ -2040,6 +2002,8 @@ class Test_EmptyRowIterator(unittest.TestCase):
 
 
 class TestRowIterator(unittest.TestCase):
+    PYARROW_MINIMUM_VERSION = str(_versions_helpers._MIN_PYARROW_VERSION)
+
     def _class_under_test(self):
         from google.cloud.bigquery.table import RowIterator
 
@@ -2367,10 +2331,8 @@ class TestRowIterator(unittest.TestCase):
             )
         )
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test__should_use_bqstorage_returns_true_if_no_cached_results(self):
+        pytest.importorskip("google.cloud.bigquery-storage")
         iterator = self._make_one(first_page_response=None)  # not cached
         result = iterator._should_use_bqstorage(
             bqstorage_client=None, create_bqstorage_client=True
@@ -2413,10 +2375,8 @@ class TestRowIterator(unittest.TestCase):
 
         self.assertFalse(result)
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test__should_use_bqstorage_returns_false_w_warning_if_obsolete_version(self):
+        pytest.importorskip("google.cloud.bigquery-storage")
         iterator = self._make_one(first_page_response=None)  # not cached
 
         patcher = mock.patch(
@@ -2435,8 +2395,10 @@ class TestRowIterator(unittest.TestCase):
         ]
         assert matching_warnings, "Obsolete dependency warning not raised."
 
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_arrow_iterable(self):
+        pyarrow = pytest.importorskip(
+            "pyarrow", minversion=self.PYARROW_MINIMUM_VERSION
+        )
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -2536,14 +2498,17 @@ class TestRowIterator(unittest.TestCase):
             [[{"name": "Bepples Phlyntstone", "age": 0}, {"name": "Dino", "age": 4}]],
         )
 
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_to_arrow_iterable_w_bqstorage(self):
+        pyarrow = pytest.importorskip("pyarrow")
+        pytest.importorskip("google.cloud.bigquery-storage")
+        from google.cloud import bigquery_storage
+        from google.cloud.bigquery_storage_v1 import reader
+        from google.cloud.bigquery_storage_v1.services.big_query_read.transports import (
+            grpc as big_query_read_grpc_transport,
+        )
+
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
-        from google.cloud.bigquery_storage_v1 import reader
 
         bqstorage_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
         bqstorage_client._transport = mock.create_autospec(
@@ -2615,8 +2580,8 @@ class TestRowIterator(unittest.TestCase):
         # Don't close the client if it was passed in.
         bqstorage_client._transport.grpc_channel.close.assert_not_called()
 
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_arrow(self):
+        pyarrow = pytest.importorskip("pyarrow", minversion=self.PYARROW_MINIMUM_VERSION)
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -2697,8 +2662,11 @@ class TestRowIterator(unittest.TestCase):
             ],
         )
 
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_arrow_w_nulls(self):
+        pyarrow = pytest.importorskip(
+            "pyarrow", minversion=self.PYARROW_MINIMUM_VERSION
+        )
+        import pyarrow.types
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [SchemaField("name", "STRING"), SchemaField("age", "INTEGER")]
@@ -2730,8 +2698,10 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(names, ["Donkey", "Diddy", "Dixie", None])
         self.assertEqual(ages, [32, 29, None, 111])
 
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_arrow_w_unknown_type(self):
+        pyarrow = pytest.importorskip(
+            "pyarrow", minversion=self.PYARROW_MINIMUM_VERSION
+        )
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -2773,8 +2743,10 @@ class TestRowIterator(unittest.TestCase):
         warning = warned[0]
         self.assertTrue("sport" in str(warning))
 
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_arrow_w_empty_table(self):
+        pyarrow = pytest.importorskip(
+            "pyarrow", minversion=self.PYARROW_MINIMUM_VERSION
+        )
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -2812,11 +2784,9 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(child_field.type.value_type[0].name, "name")
         self.assertEqual(child_field.type.value_type[1].name, "age")
 
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_to_arrow_max_results_w_explicit_bqstorage_client_warning(self):
+        pytest.importorskip("pyarrow")
+        pytest.importorskip("google.cloud.bigquery-storage")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -2856,11 +2826,9 @@ class TestRowIterator(unittest.TestCase):
         )
         mock_client._ensure_bqstorage_client.assert_not_called()
 
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_to_arrow_max_results_w_create_bqstorage_client_no_warning(self):
+        pytest.importorskip("pyarrow")
+        pytest.importorskip("google.cloud.bigquery-storage")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -2896,14 +2864,16 @@ class TestRowIterator(unittest.TestCase):
         self.assertFalse(matches)
         mock_client._ensure_bqstorage_client.assert_not_called()
 
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_to_arrow_w_bqstorage(self):
+        pyarrow = pytest.importorskip("pyarrow")
+        pytest.importorskip("google.cloud.bigquery-storage")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
+        from google.cloud import bigquery_storage
         from google.cloud.bigquery_storage_v1 import reader
+        from google.cloud.bigquery_storage_v1.services.big_query_read.transports import (
+            grpc as big_query_read_grpc_transport,
+        )        
 
         bqstorage_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
         bqstorage_client._transport = mock.create_autospec(
@@ -2977,13 +2947,15 @@ class TestRowIterator(unittest.TestCase):
         # Don't close the client if it was passed in.
         bqstorage_client._transport.grpc_channel.close.assert_not_called()
 
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_to_arrow_w_bqstorage_creates_client(self):
+        pytest.importorskip("pyarrow")
+        pytest.importorskip("google.cloud.bigquery-storage")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
+        from google.cloud import bigquery_storage
+        from google.cloud.bigquery_storage_v1.services.big_query_read.transports import (
+            grpc as big_query_read_grpc_transport,
+        )
 
         mock_client = _mock_client()
         bqstorage_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
@@ -3008,8 +2980,10 @@ class TestRowIterator(unittest.TestCase):
         mock_client._ensure_bqstorage_client.assert_called_once()
         bqstorage_client._transport.grpc_channel.close.assert_called_once()
 
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_arrow_ensure_bqstorage_client_wo_bqstorage(self):
+        pyarrow = pytest.importorskip(
+            "pyarrow", minversion=self.PYARROW_MINIMUM_VERSION
+        )
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -3039,14 +3013,13 @@ class TestRowIterator(unittest.TestCase):
         self.assertIsInstance(tbl, pyarrow.Table)
         self.assertEqual(tbl.num_rows, 2)
 
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_to_arrow_w_bqstorage_no_streams(self):
+        pyarrow = pytest.importorskip("pyarrow")
+        pytest.importorskip("google.cloud.bigquery-storage")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
-
+        from google.cloud import bigquery_storage
+        
         bqstorage_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
         session = bigquery_storage.types.ReadSession()
         arrow_schema = pyarrow.schema(
@@ -3079,12 +3052,10 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(actual_table.schema[1].name, "colC")
         self.assertEqual(actual_table.schema[2].name, "colB")
 
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
-    @unittest.skipIf(tqdm is None, "Requires `tqdm`")
-    @mock.patch("tqdm.tqdm_gui")
-    @mock.patch("tqdm.notebook.tqdm")
-    @mock.patch("tqdm.tqdm")
     def test_to_arrow_progress_bar(self, tqdm_mock, tqdm_notebook_mock, tqdm_gui_mock):
+        pytest.importorskip("pyarrow")
+        tqdm = pytest.importorskip("tqdm")
+        pytest.importorskip("tqdm.notebook")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -3101,12 +3072,13 @@ class TestRowIterator(unittest.TestCase):
         api_request = mock.Mock(return_value={"rows": rows})
 
         progress_bars = (
-            ("tqdm", tqdm_mock),
-            ("tqdm_notebook", tqdm_notebook_mock),
-            ("tqdm_gui", tqdm_gui_mock),
+            ("tqdm", mock.patch("tqdm.tqdm")),
+            ("tqdm_notebook", mock.patch("tqdm.notebook.tqdm")),
+            ("tqdm_gui", mock.patch("tqdm.tqdm_gui")),
         )
 
-        for progress_bar_type, progress_bar_mock in progress_bars:
+        for progress_bar_type, bar_patch in progress_bars:
+            progress_bar_mock = bar_patch.start()
             row_iterator = self._make_one(_mock_client(), api_request, path, schema)
             tbl = row_iterator.to_arrow(
                 progress_bar_type=progress_bar_type,
@@ -3129,8 +3101,8 @@ class TestRowIterator(unittest.TestCase):
         with self.assertRaises(ValueError):
             row_iterator.to_arrow()
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_iterable(self):
+        pandas = pytest.importorskip("pandas")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -3171,8 +3143,8 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(df_2["name"][0], "Sven")
         self.assertEqual(df_2["age"][0], 33)
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_iterable_with_dtypes(self):
+        pandas = pytest.importorskip("pandas")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -3213,15 +3185,17 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(df_2["name"][0], "Sven")
         self.assertEqual(df_2["age"][0], 33)
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_dataframe_iterable_w_bqstorage(self):
+        pandas = pytest.importorskip("pandas")
+        pyarrow = pytest.importorskip("pyarrow")
+        pytest.importorskip("google.cloud.bigquery-storage")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
+        from google.cloud import bigquery_storage
         from google.cloud.bigquery_storage_v1 import reader
+        from google.cloud.bigquery_storage_v1.services.big_query_read.transports import (
+            grpc as big_query_read_grpc_transport,
+        )
 
         arrow_fields = [
             pyarrow.field("colA", pyarrow.int64()),
@@ -3285,13 +3259,12 @@ class TestRowIterator(unittest.TestCase):
         # Don't close the client if it was passed in.
         bqstorage_client._transport.grpc_channel.close.assert_not_called()
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_iterable_w_bqstorage_max_results_warning(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("google.cloud.bigquery-storage")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
+        from google.cloud import bigquery_storage
 
         bqstorage_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
 
@@ -3358,8 +3331,8 @@ class TestRowIterator(unittest.TestCase):
         with pytest.raises(ValueError, match="pandas"):
             row_iterator.to_dataframe_iterable()
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe(self):
+        pandas = pytest.importorskip("pandas")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -3384,9 +3357,9 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(df.name.dtype.name, "object")
         self.assertEqual(df.age.dtype.name, "Int64")
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_dataframe_timestamp_out_of_pyarrow_bounds(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [SchemaField("some_timestamp", "TIMESTAMP")]
@@ -3412,9 +3385,9 @@ class TestRowIterator(unittest.TestCase):
             ],
         )
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_dataframe_datetime_out_of_pyarrow_bounds(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [SchemaField("some_datetime", "DATETIME")]
@@ -3436,12 +3409,9 @@ class TestRowIterator(unittest.TestCase):
             [datetime.datetime(4567, 1, 1), datetime.datetime(9999, 12, 31)],
         )
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(tqdm is None, "Requires `tqdm`")
-    @mock.patch("tqdm.tqdm_gui")
-    @mock.patch("tqdm.notebook.tqdm")
-    @mock.patch("tqdm.tqdm")
     def test_to_dataframe_progress_bar(
+        pandas = pytest.importorskip("pandas")
+        tqdm = pytest.importorskip("tqdm")
         self, tqdm_mock, tqdm_notebook_mock, tqdm_gui_mock
     ):
         from google.cloud.bigquery.schema import SchemaField
@@ -3460,12 +3430,13 @@ class TestRowIterator(unittest.TestCase):
         api_request = mock.Mock(return_value={"rows": rows})
 
         progress_bars = (
-            ("tqdm", tqdm_mock),
-            ("tqdm_notebook", tqdm_notebook_mock),
-            ("tqdm_gui", tqdm_gui_mock),
+            ("tqdm", mock.patch("tqdm.tqdm")),
+            ("tqdm_notebook", mock.patch("tqdm.notebook.tqdm")),
+            ("tqdm_gui", mock.patch("tqdm.tqdm_gui")),
         )
 
-        for progress_bar_type, progress_bar_mock in progress_bars:
+        for progress_bar_type, bar_patch in progress_bars:
+            progress_bar_mock = bar_patch.start()
             row_iterator = self._make_one(_mock_client(), api_request, path, schema)
             df = row_iterator.to_dataframe(
                 progress_bar_type=progress_bar_type,
@@ -3477,9 +3448,9 @@ class TestRowIterator(unittest.TestCase):
             progress_bar_mock().close.assert_called_once()
             self.assertEqual(len(df), 4)
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     @mock.patch("google.cloud.bigquery._tqdm_helpers.tqdm", new=None)
     def test_to_dataframe_no_tqdm_no_progress_bar(self):
+        pandas = pytest.importorskip("pandas")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -3505,9 +3476,9 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(len(user_warnings), 0)
         self.assertEqual(len(df), 4)
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     @mock.patch("google.cloud.bigquery._tqdm_helpers.tqdm", new=None)
     def test_to_dataframe_no_tqdm(self):
+        pandas = pytest.importorskip("pandas")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -3539,12 +3510,12 @@ class TestRowIterator(unittest.TestCase):
         # should still work.
         self.assertEqual(len(df), 4)
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(tqdm is None, "Requires `tqdm`")
-    @mock.patch("tqdm.tqdm_gui", new=None)  # will raise TypeError on call
-    @mock.patch("tqdm.notebook.tqdm", new=None)  # will raise TypeError on call
-    @mock.patch("tqdm.tqdm", new=None)  # will raise TypeError on call
     def test_to_dataframe_tqdm_error(self):
+        pandas = pytest.importorskip("pandas")
+        tqdm = pytest.importorskip("tqdm")
+        mock.patch("tqdm.tqdm_gui", new=None)
+        mock.patch("tqdm.notebook.tqdm", new=None)
+        mock.patch("tqdm.tqdm", new=None)
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -3576,11 +3547,11 @@ class TestRowIterator(unittest.TestCase):
             for warning in warned:
                 self.assertIn(
                     warning.category,
-                    [UserWarning, DeprecationWarning, TqdmDeprecationWarning],
+                    [UserWarning, DeprecationWarning],
                 )
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_w_empty_results(self):
+        pandas = pytest.importorskip("pandas")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -3596,8 +3567,8 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(len(df), 0)  # verify the number of rows
         self.assertEqual(list(df), ["name", "age"])  # verify the column names
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_w_various_types_nullable(self):
+        pandas = pytest.importorskip("pandas")
         import datetime
         from google.cloud.bigquery.schema import SchemaField
 
@@ -3637,8 +3608,8 @@ class TestRowIterator(unittest.TestCase):
                 self.assertIsInstance(row.complete, bool)
                 self.assertIsInstance(row.date, datetime.date)
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_w_dtypes_mapper(self):
+        pandas = pytest.importorskip("pandas")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -3832,9 +3803,9 @@ class TestRowIterator(unittest.TestCase):
             )
             self.assertEqual(df.timestamp.dtype.name, "object")
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @pytest.mark.skipif(PANDAS_INSTALLED_VERSION[0:2] not in ["0.", "1."], reason="")
     def test_to_dataframe_w_none_dtypes_mapper(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.mark.skipif(pandas.__version__[0:2] not in ["0.", "1."], reason="")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -3888,8 +3859,8 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(df.time.dtype.name, "object")
         self.assertEqual(df.timestamp.dtype.name, "datetime64[ns, UTC]")
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_w_unsupported_dtypes_mapper(self):
+        pytest.importorskip("pandas")
         import numpy
         from google.cloud.bigquery.schema import SchemaField
 
@@ -3945,9 +3916,9 @@ class TestRowIterator(unittest.TestCase):
                 timestamp_dtype=numpy.dtype("datetime64[us]"),
             )
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @pytest.mark.skipif(PANDAS_INSTALLED_VERSION[0:2] not in ["0.", "1."], reason="")
     def test_to_dataframe_column_dtypes(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.mark.skipif(pandas.__version__[0:2] not in ["0.", "1."], reason="")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -3995,13 +3966,12 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(df.complete.dtype.name, "boolean")
         self.assertEqual(df.date.dtype.name, "dbdate")
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_datetime_objects(self):
         # When converting date or timestamp values to nanosecond
         # precision, the result can be out of pyarrow bounds. To avoid
         # the error when converting to Pandas, we use object type if
         # necessary.
-
+        pandas = pytest.importorskip("pandas")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -4044,9 +4014,10 @@ class TestRowIterator(unittest.TestCase):
         with self.assertRaises(ValueError):
             row_iterator.to_dataframe()
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     @mock.patch("google.cloud.bigquery.table.shapely", new=None)
     def test_to_dataframe_error_if_shapely_is_none(self):
+        pandas = pytest.importorskip("pandas")
+
         with self.assertRaisesRegex(
             ValueError,
             re.escape(
@@ -4056,8 +4027,9 @@ class TestRowIterator(unittest.TestCase):
         ):
             self._make_one_from_data().to_dataframe(geography_as_object=True)
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_max_results_w_bqstorage_warning(self):
+        pytest.importorskip("pandas")
+
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -4092,8 +4064,8 @@ class TestRowIterator(unittest.TestCase):
         ]
         self.assertEqual(len(matches), 1, msg="User warning was not emitted.")
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_max_results_w_explicit_bqstorage_client_warning(self):
+        pytest.importorskip("pandas")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -4133,8 +4105,8 @@ class TestRowIterator(unittest.TestCase):
         )
         mock_client._ensure_bqstorage_client.assert_not_called()
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_max_results_w_create_bqstorage_client_no_warning(self):
+        pytest.importorskip("pandas")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -4170,13 +4142,15 @@ class TestRowIterator(unittest.TestCase):
         self.assertFalse(matches)
         mock_client._ensure_bqstorage_client.assert_not_called()
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_to_dataframe_w_bqstorage_creates_client(self):
+        pytest.importorskip("pandas")
+        pytest.importorskip("google.cloud.bigquery-storage")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
+        from google.cloud import bigquery_storage
+        from google.cloud.bigquery_storage_v1.services.big_query_read.transports import (
+            grpc as big_query_read_grpc_transport,
+        )
 
         mock_client = _mock_client()
         bqstorage_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
@@ -4201,13 +4175,12 @@ class TestRowIterator(unittest.TestCase):
         mock_client._ensure_bqstorage_client.assert_called_once()
         bqstorage_client._transport.grpc_channel.close.assert_called_once()
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_to_dataframe_w_bqstorage_no_streams(self):
+        pytest.importorskip("pandas")
+        pytest.importorskip("google.cloud.bigquery-storage")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
+        from google.cloud import bigquery_storage
 
         bqstorage_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
         session = bigquery_storage.types.ReadSession()
@@ -4230,13 +4203,12 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(list(got), column_names)
         self.assertTrue(got.empty)
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_dataframe_w_bqstorage_logs_session(self):
+        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
         from google.cloud.bigquery.table import Table
+        from google.cloud import bigquery_storage
 
         bqstorage_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
         session = bigquery_storage.types.ReadSession()
@@ -4255,12 +4227,11 @@ class TestRowIterator(unittest.TestCase):
             "with BQ Storage API session 'projects/test-proj/locations/us/sessions/SOMESESSION'."
         )
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_dataframe_w_bqstorage_empty_streams(self):
+        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("pandas")
+        pyarrow = pytest.importorskip("pyarrow")
+        from google.cloud import bigquery_storage
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
         from google.cloud.bigquery_storage_v1 import reader
@@ -4310,15 +4281,17 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(list(got), column_names)
         self.assertTrue(got.empty)
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_dataframe_w_bqstorage_nonempty(self):
+        pytest.importorskip("google-cloud-bigquery-storage")
+        pytest.importorskip("pandas")
+        pyarrow = pytest.importorskip("pyarrow")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
+        from google.cloud import bigquery_storage
         from google.cloud.bigquery_storage_v1 import reader
+        from google.cloud.bigquery_storage_v1.services.big_query_read.transports import (
+            grpc as big_query_read_grpc_transport,
+        )
 
         arrow_fields = [
             pyarrow.field("colA", pyarrow.int64()),
@@ -4390,12 +4363,10 @@ class TestRowIterator(unittest.TestCase):
         # Don't close the client if it was passed in.
         bqstorage_client._transport.grpc_channel.close.assert_not_called()
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_dataframe_w_bqstorage_multiple_streams_return_unique_index(self):
+        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("pandas")
+        pyarrow = pytest.importorskip("pyarrow")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
         from google.cloud.bigquery_storage_v1 import reader
@@ -4444,14 +4415,11 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(len(got.index), total_rows)
         self.assertTrue(got.index.is_unique)
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
-    @unittest.skipIf(tqdm is None, "Requires `tqdm`")
-    @mock.patch("tqdm.tqdm")
     def test_to_dataframe_w_bqstorage_updates_progress_bar(self, tqdm_mock):
+        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("pandas")
+        pyarrow = pytest.importorskip("pyarrow")
+        pytest.importorskip("tqdm")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
         from google.cloud.bigquery_storage_v1 import reader
@@ -4507,28 +4475,27 @@ class TestRowIterator(unittest.TestCase):
             selected_fields=schema,
         )
 
-        row_iterator.to_dataframe(
-            bqstorage_client=bqstorage_client, progress_bar_type="tqdm"
-        )
+        with mock.patch("tqdm.tqdm") as tqdm_mock:
+            row_iterator.to_dataframe(
+                bqstorage_client=bqstorage_client, progress_bar_type="tqdm"
+            )
 
-        # Make sure that this test updated the progress bar once per page from
-        # each stream.
-        total_pages = len(streams) * len(mock_pages)
-        expected_total_rows = total_pages * len(page_items)
-        progress_updates = [
-            args[0] for args, kwargs in tqdm_mock().update.call_args_list
-        ]
-        # Should have sent >1 update due to delay in blocking_to_arrow.
-        self.assertGreater(len(progress_updates), 1)
-        self.assertEqual(sum(progress_updates), expected_total_rows)
-        tqdm_mock().close.assert_called_once()
+            # Make sure that this test updated the progress bar once per page from
+            # each stream.
+            total_pages = len(streams) * len(mock_pages)
+            expected_total_rows = total_pages * len(page_items)
+            progress_updates = [
+                args[0] for args, kwargs in tqdm_mock().update.call_args_list
+            ]
+            # Should have sent >1 update due to delay in blocking_to_arrow.
+            self.assertGreater(len(progress_updates), 1)
+            self.assertEqual(sum(progress_updates), expected_total_rows)
+            tqdm_mock().close.assert_called_once()
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_dataframe_w_bqstorage_exits_on_keyboardinterrupt(self):
+        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("pandas")
+        pyarrow = pytest.importorskip("pyarrow")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
         from google.cloud.bigquery_storage_v1 import reader
@@ -4611,8 +4578,8 @@ class TestRowIterator(unittest.TestCase):
         # should have been set.
         self.assertLessEqual(mock_page.to_dataframe.call_count, 2)
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_tabledata_list_w_multiple_pages_return_unique_index(self):
+        pandas = pytest.importorskip("pandas")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
 
@@ -4643,11 +4610,10 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(df.name.dtype.name, "object")
         self.assertTrue(df.index.is_unique)
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_to_dataframe_w_bqstorage_raises_auth_error(self):
+        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("pandas")
+        from google.cloud import bigquery_storage
         from google.cloud.bigquery import table as mut
 
         bqstorage_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
@@ -4665,10 +4631,8 @@ class TestRowIterator(unittest.TestCase):
         with pytest.raises(google.api_core.exceptions.Forbidden):
             row_iterator.to_dataframe(bqstorage_client=bqstorage_client)
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_to_dataframe_w_bqstorage_partition(self):
+        pytest.importorskip("google.cloud.bigquery-storage")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
 
@@ -4685,10 +4649,8 @@ class TestRowIterator(unittest.TestCase):
         with pytest.raises(ValueError):
             row_iterator.to_dataframe(bqstorage_client)
 
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
     def test_to_dataframe_w_bqstorage_snapshot(self):
+        pytest.importorskip("google.cloud.bigquery-storage")
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
 
@@ -4705,15 +4667,18 @@ class TestRowIterator(unittest.TestCase):
         with pytest.raises(ValueError):
             row_iterator.to_dataframe(bqstorage_client)
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(
-        bigquery_storage is None, "Requires `google-cloud-bigquery-storage`"
-    )
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_dataframe_concat_categorical_dtype_w_pyarrow(self):
+        pytest.importorskip("google.cloud.bigquery-storage")
+        pytest.importorskip("pandas")
+        pyarrow = pytest.importorskip("pyarrow")
+        from google.cloud import bigquery_storage
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
+        from google.cloud import bigquery_storage
         from google.cloud.bigquery_storage_v1 import reader
+        from google.cloud.bigquery_storage_v1.services.big_query_read.transports import (
+            grpc as big_query_read_grpc_transport,
+        )
 
         arrow_fields = [
             # Not alphabetical to test column order.
@@ -4818,8 +4783,9 @@ class TestRowIterator(unittest.TestCase):
         # Don't close the client if it was passed in.
         bqstorage_client._transport.grpc_channel.close.assert_not_called()
 
-    @unittest.skipIf(geopandas is None, "Requires `geopandas`")
     def test_to_dataframe_geography_as_object(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("geopandas") 
         row_iterator = self._make_one_from_data(
             (("name", "STRING"), ("geog", "GEOGRAPHY")),
             (
@@ -4853,8 +4819,8 @@ class TestRowIterator(unittest.TestCase):
         ):
             self._make_one_from_data().to_geodataframe()
 
-    @unittest.skipIf(geopandas is None, "Requires `geopandas`")
     def test_to_geodataframe(self):
+        geopandas = pytest.importorskip("geopandas")
         row_iterator = self._make_one_from_data(
             (("name", "STRING"), ("geog", "GEOGRAPHY")),
             (
@@ -4883,8 +4849,8 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(df.geog.crs.srs, "EPSG:4326")
         self.assertEqual(df.geog.crs.name, "WGS 84")
 
-    @unittest.skipIf(geopandas is None, "Requires `geopandas`")
     def test_to_geodataframe_ambiguous_geog(self):
+        pytest.importorskip("geopandas")
         row_iterator = self._make_one_from_data(
             (("name", "STRING"), ("geog", "GEOGRAPHY"), ("geog2", "GEOGRAPHY")), ()
         )
@@ -4898,8 +4864,8 @@ class TestRowIterator(unittest.TestCase):
         ):
             row_iterator.to_geodataframe(create_bqstorage_client=False)
 
-    @unittest.skipIf(geopandas is None, "Requires `geopandas`")
     def test_to_geodataframe_bad_geography_column(self):
+        pytest.importorskip("geopandas")
         row_iterator = self._make_one_from_data(
             (("name", "STRING"), ("geog", "GEOGRAPHY"), ("geog2", "GEOGRAPHY")), ()
         )
@@ -4914,8 +4880,8 @@ class TestRowIterator(unittest.TestCase):
                 create_bqstorage_client=False, geography_column="xxx"
             )
 
-    @unittest.skipIf(geopandas is None, "Requires `geopandas`")
     def test_to_geodataframe_no_geog(self):
+        pytest.importorskip("geopandas")
         row_iterator = self._make_one_from_data(
             (("name", "STRING"), ("geog", "STRING")), ()
         )
@@ -4928,8 +4894,8 @@ class TestRowIterator(unittest.TestCase):
         ):
             row_iterator.to_geodataframe(create_bqstorage_client=False)
 
-    @unittest.skipIf(geopandas is None, "Requires `geopandas`")
     def test_to_geodataframe_w_geography_column(self):
+        pytest.importorskip("geopandas")
         row_iterator = self._make_one_from_data(
             (("name", "STRING"), ("geog", "GEOGRAPHY"), ("geog2", "GEOGRAPHY")),
             (
@@ -4974,7 +4940,6 @@ class TestRowIterator(unittest.TestCase):
                 ["0.0", "0.0", "0.0"],
             )
 
-    @unittest.skipIf(geopandas is None, "Requires `geopandas`")
     @mock.patch("google.cloud.bigquery.table.RowIterator.to_dataframe")
     def test_rowiterator_to_geodataframe_delegation(self, to_dataframe):
         """
@@ -4983,6 +4948,8 @@ class TestRowIterator(unittest.TestCase):
         This test just demonstrates that. We don't need to test all the
         variations, which are tested for to_dataframe.
         """
+        pandas = pytest.importorskip("pandas")
+        geopandas = pytest.importorskip("geopandas")
         import numpy
         from shapely import wkt
 


### PR DESCRIPTION
This fix updates a number of optional dependencies.
We use a different module import process (pytest.importorskip versus unittest.skipif).

This first major commit gets the ball rolling, there are gonna be a few additional commits to cover other files.

Fixes #<issue_number_goes_here> 🦕
