### PR TITLE
fix: avoid "Unable to determine type" warning with JSON columns in `to_dataframe`

### DIFF
--- a/google/cloud/bigquery/_helpers.py
+++ b/google/cloud/bigquery/_helpers.py
@@ -387,6 +387,21 @@ class CellDataParser:
 CELL_DATA_PARSER = CellDataParser()
 
 
+class DataFrameCellDataParser(CellDataParser):
+    """Override of CellDataParser to handle differences in expection of values in DataFrame-like outputs.
+
+    This is used to turn the output of the REST API into a pyarrow Table,
+    emulating the serialized arrow from the BigQuery Storage Read API.
+    """
+
+    def json_to_py(self, value, _):
+        """No-op because DataFrame expects string for JSON output."""
+        return value
+
+
+DATA_FRAME_CELL_DATA_PARSER = DataFrameCellDataParser()
+
+
 class ScalarQueryParamParser(CellDataParser):
     """Override of CellDataParser to handle the differences in the response from query params.
 

--- a/google/cloud/bigquery/_pandas_helpers.py
+++ b/google/cloud/bigquery/_pandas_helpers.py
@@ -158,6 +158,7 @@ BQ_FIELD_TYPE_TO_ARROW_FIELD_METADATA = {
         b"ARROW:extension:metadata": b'{"encoding": "WKT"}',
     },
     "DATETIME": {b"ARROW:extension:name": b"google:sqlType:datetime"},
+    "JSON": {b"ARROW:extension:name": b"google:sqlType:json"},
 }
 
 

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -3533,7 +3533,9 @@ def _row_iterator_page_columns(schema, response):
 
     def get_column_data(field_index, field):
         for row in rows:
-            yield _helpers.CELL_DATA_PARSER.to_py(row["f"][field_index]["v"], field)
+            yield _helpers.DATA_FRAME_CELL_DATA_PARSER.to_py(
+                row["f"][field_index]["v"], field
+            )
 
     for field_index, field in enumerate(schema):
         columns.append(get_column_data(field_index, field))

--- a/tests/system/test_pandas.py
+++ b/tests/system/test_pandas.py
@@ -1304,6 +1304,32 @@ def test_upload_time_and_datetime_56(bigquery_client, dataset_id):
     ]
 
 
+def test_to_dataframe_query_with_empty_results(bigquery_client):
+    """
+    JSON regression test for https://github.com/googleapis/python-bigquery/issues/1580.
+    """
+    job = bigquery_client.query(
+        """
+        select
+        123 as int_col,
+        '' as string_col,
+        to_json('{}') as json_col,
+        struct(to_json('[]') as json_field, -1 as int_field) as struct_col,
+        [to_json('null')] as json_array_col,
+        from unnest([])
+        """
+    )
+    df = job.to_dataframe()
+    assert list(df.columns) == [
+        "int_col",
+        "string_col",
+        "json_col",
+        "struct_col",
+        "json_array_col",
+    ]
+    assert len(df.index) == 0
+
+
 def test_to_dataframe_geography_as_objects(bigquery_client, dataset_id):
     wkt = pytest.importorskip("shapely.wkt")
     bigquery_client.query(

--- a/tests/unit/_helpers/test_data_frame_cell_data_parser.py
+++ b/tests/unit/_helpers/test_data_frame_cell_data_parser.py
@@ -1,0 +1,71 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import google.cloud.bigquery.schema
+
+
+def create_field(mode="NULLABLE", type_="IGNORED", name="test_field", **kwargs):
+    return google.cloud.bigquery.schema.SchemaField(name, type_, mode=mode, **kwargs)
+
+
+@pytest.fixture
+def mut():
+    from google.cloud.bigquery import _helpers
+
+    return _helpers
+
+
+@pytest.fixture
+def object_under_test(mut):
+    return mut.DATA_FRAME_CELL_DATA_PARSER
+
+
+def test_json_to_py_doesnt_parse_json(object_under_test):
+    coerced = object_under_test.json_to_py('{"key":"value"}', create_field())
+    assert coerced == '{"key":"value"}'
+
+
+def test_json_to_py_repeated_doesnt_parse_json(object_under_test):
+    coerced = object_under_test.json_to_py('{"key":"value"}', create_field("REPEATED"))
+    assert coerced == '{"key":"value"}'
+
+
+def test_record_to_py_doesnt_parse_json(object_under_test):
+    subfield = create_field(type_="JSON", name="json")
+    field = create_field(fields=[subfield])
+    value = {"f": [{"v": '{"key":"value"}'}]}
+    coerced = object_under_test.record_to_py(value, field)
+    assert coerced == {"json": '{"key":"value"}'}
+
+
+def test_record_to_py_doesnt_parse_repeated_json(object_under_test):
+    subfield = create_field("REPEATED", "JSON", name="json")
+    field = create_field("REQUIRED", fields=[subfield])
+    value = {
+        "f": [
+            {
+                "v": [
+                    {"v": '{"key":"value0"}'},
+                    {"v": '{"key":"value1"}'},
+                    {"v": '{"key":"value2"}'},
+                ]
+            }
+        ]
+    }
+    coerced = object_under_test.record_to_py(value, field)
+    assert coerced == {
+        "json": ['{"key":"value0"}', '{"key":"value1"}', '{"key":"value2"}']
+    }

--- a/tests/unit/test__pyarrow_helpers.py
+++ b/tests/unit/test__pyarrow_helpers.py
@@ -27,8 +27,16 @@ def module_under_test():
 
 def test_bq_to_arrow_scalars(module_under_test):
     assert (
-        module_under_test.bq_to_arrow_scalars("BIGNUMERIC")
-        == module_under_test.pyarrow_bignumeric
+        module_under_test.bq_to_arrow_scalars("BIGNUMERIC")()
+        == module_under_test.pyarrow_bignumeric()
+    )
+    assert (
+        # Normally, we'd prefer JSON type built-in to pyarrow (added in 19.0.0),
+        # but we'd like this to map as closely to the BQ Storage API as
+        # possible, which uses the string() dtype, as JSON support in Arrow
+        # predates JSON support in BigQuery by several years.
+        module_under_test.bq_to_arrow_scalars("JSON")()
+        == pyarrow.string()
     )
     assert module_under_test.bq_to_arrow_scalars("UNKNOWN_TYPE") is None
 

--- a/tests/unit/test_table_arrow.py
+++ b/tests/unit/test_table_arrow.py
@@ -28,6 +28,7 @@ def test_to_arrow_with_jobs_query_response():
             "fields": [
                 {"name": "name", "type": "STRING", "mode": "NULLABLE"},
                 {"name": "number", "type": "INTEGER", "mode": "NULLABLE"},
+                {"name": "json", "type": "JSON", "mode": "NULLABLE"},
             ]
         },
         "jobReference": {
@@ -37,15 +38,21 @@ def test_to_arrow_with_jobs_query_response():
         },
         "totalRows": "9",
         "rows": [
-            {"f": [{"v": "Tiarra"}, {"v": "6"}]},
-            {"f": [{"v": "Timothy"}, {"v": "325"}]},
-            {"f": [{"v": "Tina"}, {"v": "26"}]},
-            {"f": [{"v": "Tierra"}, {"v": "10"}]},
-            {"f": [{"v": "Tia"}, {"v": "17"}]},
-            {"f": [{"v": "Tiara"}, {"v": "22"}]},
-            {"f": [{"v": "Tiana"}, {"v": "6"}]},
-            {"f": [{"v": "Tiffany"}, {"v": "229"}]},
-            {"f": [{"v": "Tiffani"}, {"v": "8"}]},
+            {"f": [{"v": "Tiarra"}, {"v": "6"}, {"v": "123"}]},
+            {"f": [{"v": "Timothy"}, {"v": "325"}, {"v": '{"key":"value"}'}]},
+            {"f": [{"v": "Tina"}, {"v": "26"}, {"v": "[1,2,3]"}]},
+            {
+                "f": [
+                    {"v": "Tierra"},
+                    {"v": "10"},
+                    {"v": '{"aKey": {"bKey": {"cKey": -123}}}'},
+                ]
+            },
+            {"f": [{"v": "Tia"}, {"v": "17"}, {"v": None}]},
+            {"f": [{"v": "Tiara"}, {"v": "22"}, {"v": '"some-json-string"'}]},
+            {"f": [{"v": "Tiana"}, {"v": "6"}, {"v": '{"nullKey":null}'}]},
+            {"f": [{"v": "Tiffany"}, {"v": "229"}, {"v": '""'}]},
+            {"f": [{"v": "Tiffani"}, {"v": "8"}, {"v": "[]"}]},
         ],
         "totalBytesProcessed": "154775150",
         "jobComplete": True,
@@ -65,7 +72,7 @@ def test_to_arrow_with_jobs_query_response():
     )
     records = rows.to_arrow()
 
-    assert records.column_names == ["name", "number"]
+    assert records.column_names == ["name", "number", "json"]
     assert records["name"].to_pylist() == [
         "Tiarra",
         "Timothy",
@@ -78,6 +85,17 @@ def test_to_arrow_with_jobs_query_response():
         "Tiffani",
     ]
     assert records["number"].to_pylist() == [6, 325, 26, 10, 17, 22, 6, 229, 8]
+    assert records["json"].to_pylist() == [
+        "123",
+        '{"key":"value"}',
+        "[1,2,3]",
+        '{"aKey": {"bKey": {"cKey": -123}}}',
+        None,
+        '"some-json-string"',
+        '{"nullKey":null}',
+        '""',
+        "[]",
+    ]
 
 
 def test_to_arrow_with_jobs_query_response_and_max_results():
@@ -87,6 +105,7 @@ def test_to_arrow_with_jobs_query_response_and_max_results():
             "fields": [
                 {"name": "name", "type": "STRING", "mode": "NULLABLE"},
                 {"name": "number", "type": "INTEGER", "mode": "NULLABLE"},
+                {"name": "json", "type": "JSON", "mode": "NULLABLE"},
             ]
         },
         "jobReference": {
@@ -96,15 +115,21 @@ def test_to_arrow_with_jobs_query_response_and_max_results():
         },
         "totalRows": "9",
         "rows": [
-            {"f": [{"v": "Tiarra"}, {"v": "6"}]},
-            {"f": [{"v": "Timothy"}, {"v": "325"}]},
-            {"f": [{"v": "Tina"}, {"v": "26"}]},
-            {"f": [{"v": "Tierra"}, {"v": "10"}]},
-            {"f": [{"v": "Tia"}, {"v": "17"}]},
-            {"f": [{"v": "Tiara"}, {"v": "22"}]},
-            {"f": [{"v": "Tiana"}, {"v": "6"}]},
-            {"f": [{"v": "Tiffany"}, {"v": "229"}]},
-            {"f": [{"v": "Tiffani"}, {"v": "8"}]},
+            {"f": [{"v": "Tiarra"}, {"v": "6"}, {"v": "123"}]},
+            {"f": [{"v": "Timothy"}, {"v": "325"}, {"v": '{"key":"value"}'}]},
+            {"f": [{"v": "Tina"}, {"v": "26"}, {"v": "[1,2,3]"}]},
+            {
+                "f": [
+                    {"v": "Tierra"},
+                    {"v": "10"},
+                    {"v": '{"aKey": {"bKey": {"cKey": -123}}}'},
+                ]
+            },
+            {"f": [{"v": "Tia"}, {"v": "17"}, {"v": None}]},
+            {"f": [{"v": "Tiara"}, {"v": "22"}, {"v": '"some-json-string"'}]},
+            {"f": [{"v": "Tiana"}, {"v": "6"}, {"v": '{"nullKey":null}'}]},
+            {"f": [{"v": "Tiffany"}, {"v": "229"}, {"v": '""'}]},
+            {"f": [{"v": "Tiffani"}, {"v": "8"}, {"v": "[]"}]},
         ],
         "totalBytesProcessed": "154775150",
         "jobComplete": True,
@@ -125,10 +150,11 @@ def test_to_arrow_with_jobs_query_response_and_max_results():
     )
     records = rows.to_arrow()
 
-    assert records.column_names == ["name", "number"]
+    assert records.column_names == ["name", "number", "json"]
     assert records["name"].to_pylist() == [
         "Tiarra",
         "Timothy",
         "Tina",
     ]
     assert records["number"].to_pylist() == [6, 325, 26]
+    assert records["json"].to_pylist() == ["123", '{"key":"value"}', "[1,2,3]"]

--- a/tests/unit/test_table_pandas.py
+++ b/tests/unit/test_table_pandas.py
@@ -59,6 +59,7 @@ def test_to_dataframe_nullable_scalars(
             pyarrow.field(
                 "timestamp_col", pyarrow.timestamp("us", tz=datetime.timezone.utc)
             ),
+            pyarrow.field("json_col", pyarrow.string()),
         ]
     )
     arrow_table = pyarrow.Table.from_pydict(
@@ -78,6 +79,7 @@ def test_to_dataframe_nullable_scalars(
                     2021, 8, 9, 13, 30, 44, 123456, tzinfo=datetime.timezone.utc
                 )
             ],
+            "json_col": ["{}"],
         },
         schema=arrow_schema,
     )
@@ -94,6 +96,7 @@ def test_to_dataframe_nullable_scalars(
         bigquery.SchemaField("string_col", "STRING"),
         bigquery.SchemaField("time_col", "TIME"),
         bigquery.SchemaField("timestamp_col", "TIMESTAMP"),
+        bigquery.SchemaField("json_col", "JSON"),
     ]
     mock_client = mock.create_autospec(bigquery.Client)
     mock_client.project = "test-proj"
@@ -117,6 +120,7 @@ def test_to_dataframe_nullable_scalars(
     assert df.dtypes["string_col"].name == "object"
     assert df.dtypes["time_col"].name == "dbtime"
     assert df.dtypes["timestamp_col"].name == "datetime64[ns, UTC]"
+    assert df.dtypes["json_col"].name == "object"
 
     # Check for expected values.
     assert df["bignumeric_col"][0] == decimal.Decimal("123.456789101112131415")


### PR DESCRIPTION
Based on https://github.com/googleapis/python-bigquery/pull/2144, which should merge first.

TODO:

- [x] tests
- [x] maybe we don't want string columns for JSON? Update: keeping string because that's consistent with (1) current behavior and (2) the BQ Storage Read API.


Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes https://github.com/googleapis/python-bigquery/issues/1580
🦕
