### PR TITLE
fix: creates linting-typing.cfg in presubmit

### DIFF
--- a/.kokoro/presubmit/linting-typing.cfg
+++ b/.kokoro/presubmit/linting-typing.cfg
@@ -7,5 +7,5 @@ env_vars: {
 }
 env_vars: {
     key: "RUN_LINTING_TYPING_TESTS"
-    value: "true"
+    value: "false"
 }

--- a/.kokoro/presubmit/linting-typing.cfg
+++ b/.kokoro/presubmit/linting-typing.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Only run these nox sessions.
+env_vars: {
+    key: "NOX_SESSION"
+    value: "lint lint_setup_py blacken mypy mypy_samples pytype"
+}

--- a/.kokoro/presubmit/linting-typing.cfg
+++ b/.kokoro/presubmit/linting-typing.cfg
@@ -5,7 +5,3 @@ env_vars: {
     key: "NOX_SESSION"
     value: "lint lint_setup_py blacken mypy mypy_samples pytype"
 }
-env_vars: {
-    key: "RUN_LINTING_TYPING_TESTS"
-    value: "false"
-}

--- a/.kokoro/presubmit/linting-typing.cfg
+++ b/.kokoro/presubmit/linting-typing.cfg
@@ -5,3 +5,7 @@ env_vars: {
     key: "NOX_SESSION"
     value: "lint lint_setup_py blacken mypy mypy_samples pytype"
 }
+env_vars: {
+    key: "RUN_LINTING_TYPING_TESTS"
+    value: "true"
+}

--- a/.kokoro/presubmit/presubmit.cfg
+++ b/.kokoro/presubmit/presubmit.cfg
@@ -9,3 +9,12 @@ env_vars: {
     key: "RUN_SNIPPETS_TESTS"
     value: "false"
 }
+env_vars: {
+    key: "RUN_TYPING_TESTS"
+    value: "false"
+}
+env_vars: {
+    key: "RUN_LINTING_TESTS"
+    value: "false"
+}
+

--- a/.kokoro/presubmit/presubmit.cfg
+++ b/.kokoro/presubmit/presubmit.cfg
@@ -11,5 +11,5 @@ env_vars: {
 }
 env_vars: {
     key: "RUN_LINTING_TYPING_TESTS"
-    value: "false"
+    value: "test_false"
 }

--- a/.kokoro/presubmit/presubmit.cfg
+++ b/.kokoro/presubmit/presubmit.cfg
@@ -10,10 +10,6 @@ env_vars: {
     value: "false"
 }
 env_vars: {
-    key: "RUN_TYPING_TESTS"
-    value: "false"
-}
-env_vars: {
-    key: "RUN_LINTING_TESTS"
+    key: "RUN_LINTING_TYPING_TESTS"
     value: "false"
 }

--- a/.kokoro/presubmit/presubmit.cfg
+++ b/.kokoro/presubmit/presubmit.cfg
@@ -11,5 +11,5 @@ env_vars: {
 }
 env_vars: {
     key: "RUN_LINTING_TYPING_TESTS"
-    value: "test_false"
+    value: "false"
 }

--- a/.kokoro/presubmit/presubmit.cfg
+++ b/.kokoro/presubmit/presubmit.cfg
@@ -17,4 +17,3 @@ env_vars: {
     key: "RUN_LINTING_TESTS"
     value: "false"
 }
-

--- a/noxfile.py
+++ b/noxfile.py
@@ -225,7 +225,6 @@ def mypy_samples(session):
     if os.environ.get("RUN_TYPING_TESTS", "true") == "false":
         session.skip("RUN_TYPING_TESTS is set to false, skipping")
 
-
     session.install("pytest")
     for requirements_path in CURRENT_DIRECTORY.glob("samples/*/requirements.txt"):
         session.install("-r", str(requirements_path))

--- a/noxfile.py
+++ b/noxfile.py
@@ -132,6 +132,10 @@ def unit_noextras(session):
 def mypy(session):
     """Run type checks with mypy."""
 
+    # Check the value of `RUN_TYPING_TESTS` env var. It defaults to true.
+    if os.environ.get("RUN_TYPING_TESTS", "true") == "false":
+        session.skip("RUN_TYPING_TESTS is set to false, skipping")
+
     session.install("-e", ".[all]")
     session.install(MYPY_VERSION)
 
@@ -152,6 +156,10 @@ def pytype(session):
     # An indirect dependecy attrs==21.1.0 breaks the check, and installing a less
     # recent version avoids the error until a possibly better fix is found.
     # https://github.com/googleapis/python-bigquery/issues/655
+
+    # Check the value of `RUN_TYPING_TESTS` env var. It defaults to true.
+    if os.environ.get("RUN_TYPING_TESTS", "true") == "false":
+        session.skip("RUN_TYPING_TESTS is set to false, skipping")
 
     session.install("attrs==20.3.0")
     session.install("-e", ".[all]")
@@ -212,6 +220,11 @@ def system(session):
 @nox.session(python=DEFAULT_PYTHON_VERSION)
 def mypy_samples(session):
     """Run type checks with mypy."""
+
+    # Check the value of `RUN_TYPING_TESTS` env var. It defaults to true.
+    if os.environ.get("RUN_TYPING_TESTS", "true") == "false":
+        session.skip("RUN_TYPING_TESTS is set to false, skipping")
+
 
     session.install("pytest")
     for requirements_path in CURRENT_DIRECTORY.glob("samples/*/requirements.txt"):
@@ -394,6 +407,10 @@ def lint(session):
     serious code quality issues.
     """
 
+    # Check the value of `RUN_LINTING_TESTS` env var. It defaults to true.
+    if os.environ.get("RUN_LINTING_TESTS", "true") == "false":
+        session.skip("RUN_LINTING_TESTS is set to false, skipping")
+
     session.install("flake8", BLACK_VERSION)
     session.install("-e", ".")
     session.run("flake8", os.path.join("google", "cloud", "bigquery"))
@@ -408,6 +425,10 @@ def lint(session):
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
 
+    # Check the value of `RUN_LINTING_TESTS` env var. It defaults to true.
+    if os.environ.get("RUN_LINTING_TESTS", "true") == "false":
+        session.skip("RUN_LINTING_TESTS is set to false, skipping")
+
     session.install("docutils", "Pygments")
     session.run("python", "setup.py", "check", "--restructuredtext", "--strict")
 
@@ -417,6 +438,10 @@ def blacken(session):
     """Run black.
     Format code to uniform standard.
     """
+
+    # Check the value of `RUN_LINTING_TESTS` env var. It defaults to true.
+    if os.environ.get("RUN_LINTING_TESTS", "true") == "false":
+        session.skip("RUN_LINTING_TESTS is set to false, skipping")
 
     session.install(BLACK_VERSION)
     session.run("black", *BLACK_PATHS)

--- a/noxfile.py
+++ b/noxfile.py
@@ -406,7 +406,7 @@ def lint(session):
     serious code quality issues.
     """
 
-    # Check the value of `RUN_LINTING_TESTS` env var. It defaults to true.
+    # Check the value of `RUN_LINTING_TYPING_TESTS` env var. It defaults to true.
     if os.environ.get("RUN_LINTING_TYPING_TESTS", "true") == "false":
         session.skip("RUN_LINTING_TYPING_TESTS is set to false, skipping")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -132,7 +132,7 @@ def unit_noextras(session):
 def mypy(session):
     """Run type checks with mypy."""
 
-    # Check the value of `RUN_TYPING_TESTS` env var. It defaults to true.
+    # Check the value of `RUN_LINTING_TYPING_TESTS` env var. It defaults to true.
     if os.environ.get("RUN_LINTING_TYPING_TESTS", "true") == "false":
         session.skip("RUN_LINTING_TYPING_TESTS is set to false, skipping")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -438,7 +438,7 @@ def blacken(session):
     Format code to uniform standard.
     """
 
-    # Check the value of `RUN_LINTING_TESTS` env var. It defaults to true.
+    # Check the value of `RUN_LINTING_TYPING_TESTS` env var. It defaults to true.
     if os.environ.get("RUN_LINTING_TYPING_TESTS", "true") == "false":
         session.skip("RUN_LINTING_TYPING_TESTS is set to false, skipping")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -221,7 +221,7 @@ def system(session):
 def mypy_samples(session):
     """Run type checks with mypy."""
 
-    # Check the value of `RUN_TYPING_TESTS` env var. It defaults to true.
+    # Check the value of `RUN_LINTING_TYPING_TESTS` env var. It defaults to true.
     if os.environ.get("RUN_LINTING_TYPING_TESTS", "true") == "false":
         session.skip("RUN_LINTING_TYPING_TESTS is set to false, skipping")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -133,8 +133,8 @@ def mypy(session):
     """Run type checks with mypy."""
 
     # Check the value of `RUN_TYPING_TESTS` env var. It defaults to true.
-    if os.environ.get("RUN_TYPING_TESTS", "true") == "false":
-        session.skip("RUN_TYPING_TESTS is set to false, skipping")
+    if os.environ.get("RUN_LINTING_TYPING_TESTS", "true") == "false":
+        session.skip("RUN_LINTING_TYPING_TESTS is set to false, skipping")
 
     session.install("-e", ".[all]")
     session.install(MYPY_VERSION)
@@ -158,8 +158,8 @@ def pytype(session):
     # https://github.com/googleapis/python-bigquery/issues/655
 
     # Check the value of `RUN_TYPING_TESTS` env var. It defaults to true.
-    if os.environ.get("RUN_TYPING_TESTS", "true") == "false":
-        session.skip("RUN_TYPING_TESTS is set to false, skipping")
+    if os.environ.get("RUN_LINTING_TYPING_TESTS", "true") == "false":
+        session.skip("RUN_LINTING_TYPING_TESTS is set to false, skipping")
 
     session.install("attrs==20.3.0")
     session.install("-e", ".[all]")
@@ -222,8 +222,8 @@ def mypy_samples(session):
     """Run type checks with mypy."""
 
     # Check the value of `RUN_TYPING_TESTS` env var. It defaults to true.
-    if os.environ.get("RUN_TYPING_TESTS", "true") == "false":
-        session.skip("RUN_TYPING_TESTS is set to false, skipping")
+    if os.environ.get("RUN_LINTING_TYPING_TESTS", "true") == "false":
+        session.skip("RUN_LINTING_TYPING_TESTS is set to false, skipping")
 
     session.install("pytest")
     for requirements_path in CURRENT_DIRECTORY.glob("samples/*/requirements.txt"):
@@ -407,8 +407,8 @@ def lint(session):
     """
 
     # Check the value of `RUN_LINTING_TESTS` env var. It defaults to true.
-    if os.environ.get("RUN_LINTING_TESTS", "true") == "false":
-        session.skip("RUN_LINTING_TESTS is set to false, skipping")
+    if os.environ.get("RUN_LINTING_TYPING_TESTS", "true") == "false":
+        session.skip("RUN_LINTING_TYPING_TESTS is set to false, skipping")
 
     session.install("flake8", BLACK_VERSION)
     session.install("-e", ".")
@@ -425,8 +425,8 @@ def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
 
     # Check the value of `RUN_LINTING_TESTS` env var. It defaults to true.
-    if os.environ.get("RUN_LINTING_TESTS", "true") == "false":
-        session.skip("RUN_LINTING_TESTS is set to false, skipping")
+    if os.environ.get("RUN_LINTING_TYPING_TESTS", "true") == "false":
+        session.skip("RUN_LINTING_TYPING_TESTS is set to false, skipping")
 
     session.install("docutils", "Pygments")
     session.run("python", "setup.py", "check", "--restructuredtext", "--strict")
@@ -439,8 +439,8 @@ def blacken(session):
     """
 
     # Check the value of `RUN_LINTING_TESTS` env var. It defaults to true.
-    if os.environ.get("RUN_LINTING_TESTS", "true") == "false":
-        session.skip("RUN_LINTING_TESTS is set to false, skipping")
+    if os.environ.get("RUN_LINTING_TYPING_TESTS", "true") == "false":
+        session.skip("RUN_LINTING_TYPING_TESTS is set to false, skipping")
 
     session.install(BLACK_VERSION)
     session.run("black", *BLACK_PATHS)

--- a/noxfile.py
+++ b/noxfile.py
@@ -424,7 +424,7 @@ def lint(session):
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
 
-    # Check the value of `RUN_LINTING_TESTS` env var. It defaults to true.
+    # Check the value of `RUN_LINTING_TYPING_TESTS` env var. It defaults to true.
     if os.environ.get("RUN_LINTING_TYPING_TESTS", "true") == "false":
         session.skip("RUN_LINTING_TYPING_TESTS is set to false, skipping")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -157,7 +157,7 @@ def pytype(session):
     # recent version avoids the error until a possibly better fix is found.
     # https://github.com/googleapis/python-bigquery/issues/655
 
-    # Check the value of `RUN_TYPING_TESTS` env var. It defaults to true.
+    # Check the value of `RUN_LINTING_TYPING_TESTS` env var. It defaults to true.
     if os.environ.get("RUN_LINTING_TYPING_TESTS", "true") == "false":
         session.skip("RUN_LINTING_TYPING_TESTS is set to false, skipping")
 


### PR DESCRIPTION
This PR creates a new configuration file in the `.kokoro/presubmit` folder.
The intent is to eventually move multiple checks out of the baseline `Kokoro` check and put them into their own `Kokoro linting-typing`:

The checks we are moving out include:

#### Typing:
* mypy
* mypy_samples
* pytype
#### Linting/formatting:
* lint
* lint_setup_py
* blacken


