### PR TITLE
Add ZSTD to compression types

### DIFF
--- a/google/cloud/bigquery/enums.py
+++ b/google/cloud/bigquery/enums.py
@@ -39,6 +39,9 @@ class Compression(object):
     SNAPPY = "SNAPPY"
     """Specifies SNAPPY format."""
 
+    ZSTD = "ZSTD"
+    """Specifies ZSTD format."""
+
     NONE = "NONE"
     """Specifies no compression."""
 


### PR DESCRIPTION
One of BigQuery's neat features is how it supports ZSTD compression for exports.

See: https://cloud.google.com/bigquery/docs/exporting-data#parquet_export_details

This commit simply adds ZSTD to the list of enums allowed for the compression type.