### PR TITLE
fix: add pyarrow version check for range support

### DIFF
--- a/google/cloud/bigquery/_versions_helpers.py
+++ b/google/cloud/bigquery/_versions_helpers.py
@@ -238,6 +238,10 @@ class PandasVersions:
 
 PANDAS_VERSIONS = PandasVersions()
 
+# Since RANGE support in pandas requires specific versions
+# of both pyarrow and pandas, we make this a separate
+# constant instead of as a property of PANDAS_VERSIONS
+# or PYARROW_VERSIONS.
 SUPPORTS_RANGE_PYARROW = (
     PANDAS_VERSIONS.try_import() is not None
     and PANDAS_VERSIONS.installed_version >= _MIN_PANDAS_VERSION_RANGE

--- a/google/cloud/bigquery/_versions_helpers.py
+++ b/google/cloud/bigquery/_versions_helpers.py
@@ -26,6 +26,9 @@ _MIN_BQ_STORAGE_VERSION = packaging.version.Version("2.0.0")
 _BQ_STORAGE_OPTIONAL_READ_SESSION_VERSION = packaging.version.Version("2.6.0")
 _MIN_PANDAS_VERSION = packaging.version.Version("1.1.0")
 
+_MIN_PANDAS_VERSION_RANGE = packaging.version.Version("1.5.0")
+_MIN_PYARROW_VERSION_RANGE = packaging.version.Version("10.0.1")
+
 
 class PyarrowVersions:
     """Version comparisons for pyarrow package."""
@@ -234,3 +237,10 @@ class PandasVersions:
 
 
 PANDAS_VERSIONS = PandasVersions()
+
+SUPPORTS_RANGE_PYARROW = (
+    PANDAS_VERSIONS.try_import() is not None
+    and PANDAS_VERSIONS.installed_version >= _MIN_PANDAS_VERSION_RANGE
+    and PYARROW_VERSIONS.try_import() is not None
+    and PYARROW_VERSIONS.installed_version >= _MIN_PYARROW_VERSION_RANGE
+)


### PR DESCRIPTION
* adds a version check for pyarrow
* consolidates warning messages
* use a constant in _versions_helper.py for checking range support in both pandas and pyarrow

TODO: add nox test session for the case when a newer pandas is installed, but pyarrow is very old.

Fixes #1912 🦕
