### PR TITLE
feat: add support for map target type in Parquet options

### DIFF
--- a/google/cloud/bigquery/format_options.py
+++ b/google/cloud/bigquery/format_options.py
@@ -105,6 +105,21 @@ class ParquetOptions:
     def enable_list_inference(self, value: bool) -> None:
         self._properties["enableListInference"] = value
 
+    @property
+    def map_target_type(self) -> str:
+        """Indicates whether to simplify the representation of parquet maps to only show keys and values."""
+
+        return self._properties.get("mapTargetType")
+
+    @map_target_type.setter
+    def map_target_type(self, value: str) -> None:
+        """Sets the map target type.
+
+        Args:
+          value: The map target type (eg ARRAY_OF_STRUCT).
+        """
+        self._properties["mapTargetType"] = value
+
     @classmethod
     def from_api_repr(cls, resource: Dict[str, bool]) -> "ParquetOptions":
         """Factory: construct an instance from a resource dict.

--- a/tests/unit/test_format_options.py
+++ b/tests/unit/test_format_options.py
@@ -63,4 +63,8 @@ class TestParquetOptions:
         config.map_target_type = "ARRAY_OF_STRUCT"
 
         result = config.to_api_repr()
-        assert result == {"enumAsString": True, "enableListInference": False, "mapTargetType": "ARRAY_OF_STRUCT"}
+        assert result == {
+            "enumAsString": True,
+            "enableListInference": False,
+            "mapTargetType": "ARRAY_OF_STRUCT",
+        }

--- a/tests/unit/test_format_options.py
+++ b/tests/unit/test_format_options.py
@@ -54,6 +54,7 @@ class TestParquetOptions:
         )
         assert not config.enum_as_string
         assert config.enable_list_inference
+        assert config.map_target_type is None
 
     def test_to_api_repr(self):
         config = self._get_target_class()()

--- a/tests/unit/test_format_options.py
+++ b/tests/unit/test_format_options.py
@@ -59,6 +59,7 @@ class TestParquetOptions:
         config = self._get_target_class()()
         config.enum_as_string = True
         config.enable_list_inference = False
+        config.map_target_type = "ARRAY_OF_STRUCT"
 
         result = config.to_api_repr()
-        assert result == {"enumAsString": True, "enableListInference": False}
+        assert result == {"enumAsString": True, "enableListInference": False, "mapTargetType": "ARRAY_OF_STRUCT"}


### PR DESCRIPTION
The map target type creates a schema without the added key_value repeated field.

