### PR TITLE
feat: add default timeout for Client.get_job()

### DIFF
--- a/google/cloud/bigquery/_helpers.py
+++ b/google/cloud/bigquery/_helpers.py
@@ -33,6 +33,8 @@ from google.cloud._helpers import _to_bytes
 from google.auth import credentials as ga_credentials  # type: ignore
 from google.api_core import client_options as client_options_lib
 
+TimeoutType = Union[float, None]
+
 _RFC3339_MICROS_NO_ZULU = "%Y-%m-%dT%H:%M:%S.%f"
 _TIMEONLY_WO_MICROS = "%H:%M:%S"
 _TIMEONLY_W_MICROS = "%H:%M:%S.%f"

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -2163,7 +2163,7 @@ class Client(ClientWithProject):
                 object.
             retry (Optional[google.api_core.retry.Retry]):
                 How to retry the RPC.
-            timeout (Optinal[float]):
+            timeout (Optional[float]):
                 The number of seconds to wait for the underlying HTTP transport
                 before using ``retry``.
 

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -2140,7 +2140,7 @@ class Client(ClientWithProject):
         project: Optional[str] = None,
         location: Optional[str] = None,
         retry: retries.Retry = DEFAULT_RETRY,
-        timeout: Optional[Union[TimeoutType, object]] = DEFAULT_GET_JOB_TIMEOUT,
+        timeout: Optional[TimeoutType] = DEFAULT_GET_JOB_TIMEOUT,
     ) -> Union[job.LoadJob, job.CopyJob, job.ExtractJob, job.QueryJob, job.UnknownJob]:
         """Fetch a job for the project associated with this client.
 
@@ -2163,9 +2163,7 @@ class Client(ClientWithProject):
                 object.
             retry (Optional[google.api_core.retry.Retry]):
                 How to retry the RPC.
-            timeout (Optinal[Union[float, \
-                google.api_core.future.polling.PollingFuture._DEFAULT_VALUE, \
-            ]]):
+            timeout (Optinal[TimeoutType]):
                 The number of seconds to wait for the underlying HTTP transport
                 before using ``retry``.
 

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -82,6 +82,7 @@ from google.cloud.bigquery._helpers import _DEFAULT_HOST_TEMPLATE
 from google.cloud.bigquery._helpers import _DEFAULT_UNIVERSE
 from google.cloud.bigquery._helpers import _validate_universe
 from google.cloud.bigquery._helpers import _get_client_universe
+from google.cloud.bigquery._helpers import TimeoutType
 from google.cloud.bigquery._job_helpers import make_job_id as _make_job_id
 from google.cloud.bigquery.dataset import Dataset
 from google.cloud.bigquery.dataset import DatasetListItem
@@ -124,7 +125,6 @@ pandas = (
     _versions_helpers.PANDAS_VERSIONS.try_import()
 )  # mypy check fails because pandas import is outside module, there are type: ignore comments related to this
 
-TimeoutType = Union[float, None]
 ResumableTimeoutType = Union[
     None, float, Tuple[float, float]
 ]  # for resumable media methods

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -53,7 +53,6 @@ import google.api_core.exceptions as core_exceptions
 from google.api_core.iam import Policy
 from google.api_core import page_iterator
 from google.api_core import retry as retries
-from google.api_core.future.polling import PollingFuture
 import google.cloud._helpers  # type: ignore
 from google.cloud import exceptions  # pytype: disable=import-error
 from google.cloud.client import ClientWithProject  # type: ignore  # pytype: disable=import-error
@@ -2141,7 +2140,7 @@ class Client(ClientWithProject):
         project: Optional[str] = None,
         location: Optional[str] = None,
         retry: retries.Retry = DEFAULT_RETRY,
-        timeout: Union[TimeoutType, object] = DEFAULT_GET_JOB_TIMEOUT,
+        timeout: Optional[Union[TimeoutType, object]] = DEFAULT_GET_JOB_TIMEOUT,
     ) -> Union[job.LoadJob, job.CopyJob, job.ExtractJob, job.QueryJob, job.UnknownJob]:
         """Fetch a job for the project associated with this client.
 

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -2140,7 +2140,7 @@ class Client(ClientWithProject):
         project: Optional[str] = None,
         location: Optional[str] = None,
         retry: retries.Retry = DEFAULT_RETRY,
-        timeout: Optional[TimeoutType] = DEFAULT_GET_JOB_TIMEOUT,
+        timeout: TimeoutType = DEFAULT_GET_JOB_TIMEOUT,
     ) -> Union[job.LoadJob, job.CopyJob, job.ExtractJob, job.QueryJob, job.UnknownJob]:
         """Fetch a job for the project associated with this client.
 
@@ -2163,7 +2163,7 @@ class Client(ClientWithProject):
                 object.
             retry (Optional[google.api_core.retry.Retry]):
                 How to retry the RPC.
-            timeout (Optinal[TimeoutType]):
+            timeout (Optinal[float]):
                 The number of seconds to wait for the underlying HTTP transport
                 before using ``retry``.
 

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -53,6 +53,7 @@ import google.api_core.exceptions as core_exceptions
 from google.api_core.iam import Policy
 from google.api_core import page_iterator
 from google.api_core import retry as retries
+from google.api_core.future.polling import PollingFuture
 import google.cloud._helpers  # type: ignore
 from google.cloud import exceptions  # pytype: disable=import-error
 from google.cloud.client import ClientWithProject  # type: ignore  # pytype: disable=import-error
@@ -107,6 +108,7 @@ from google.cloud.bigquery.retry import (
     DEFAULT_JOB_RETRY,
     DEFAULT_RETRY,
     DEFAULT_TIMEOUT,
+    DEFAULT_GET_JOB_TIMEOUT,
 )
 from google.cloud.bigquery.routine import Routine
 from google.cloud.bigquery.routine import RoutineReference
@@ -2139,7 +2141,7 @@ class Client(ClientWithProject):
         project: Optional[str] = None,
         location: Optional[str] = None,
         retry: retries.Retry = DEFAULT_RETRY,
-        timeout: TimeoutType = DEFAULT_TIMEOUT,
+        timeout: Union[TimeoutType, object] = DEFAULT_GET_JOB_TIMEOUT,
     ) -> Union[job.LoadJob, job.CopyJob, job.ExtractJob, job.QueryJob, job.UnknownJob]:
         """Fetch a job for the project associated with this client.
 
@@ -2162,7 +2164,9 @@ class Client(ClientWithProject):
                 object.
             retry (Optional[google.api_core.retry.Retry]):
                 How to retry the RPC.
-            timeout (Optional[float]):
+            timeout (Optinal[Union[float, \
+                google.api_core.future.polling.PollingFuture._DEFAULT_VALUE, \
+            ]]):
                 The number of seconds to wait for the underlying HTTP transport
                 before using ``retry``.
 

--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -831,9 +831,11 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
         elif isinstance(timeout, (int, float)):
             kwargs["timeout"] = timeout
         else:
-            raise ValueError(f"Unsupported timeout type {type(timeout)}. "
-                             "Must be float, int, None, or "
-                             "google.api_core.future.polling.PollingFuture._DEFAULT_VALUE.")
+            raise ValueError(
+                f"Unsupported timeout type {type(timeout)}. "
+                "Must be float, int, None, or "
+                "google.api_core.future.polling.PollingFuture._DEFAULT_VALUE."
+            )
 
         got_job = client.get_job(
             self,

--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -24,10 +24,9 @@ from typing import Any, ClassVar, Dict, Optional, Sequence, Union
 from google.api_core import retry as retries
 from google.api_core import exceptions
 import google.api_core.future.polling
-from google.api_core.future.polling import PollingFuture
 
 from google.cloud.bigquery import _helpers
-from google.cloud.bigquery.retry import DEFAULT_RETRY
+from google.cloud.bigquery.retry import DEFAULT_RETRY, POLLING_DEFAULT_VALUE
 from google.cloud.bigquery._helpers import _int_or_none
 
 
@@ -802,7 +801,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
         self,
         client=None,
         retry: "retries.Retry" = DEFAULT_RETRY,
-        timeout: Optional[Union[float, object]] = PollingFuture._DEFAULT_VALUE,
+        timeout: Optional[Union[float, object]] = POLLING_DEFAULT_VALUE,
     ):
         """API call:  refresh job properties via a GET request.
 
@@ -825,8 +824,11 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
 
         kwargs: Dict[str, Any] = {}
         if type(timeout) is object:
+            # When timeout is the sentinel value, we use the default API-level
+            # timeout at Client.get_job().
             pass
         elif timeout is None:
+            # If timeout is None, wait indefinitely even at API-level.
             kwargs["timeout"] = None
         elif isinstance(timeout, (int, float)):
             kwargs["timeout"] = timeout
@@ -922,7 +924,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
     def done(
         self,
         retry: "retries.Retry" = DEFAULT_RETRY,
-        timeout: Optional[Union[float, object]] = PollingFuture._DEFAULT_VALUE,
+        timeout: Optional[Union[float, object]] = POLLING_DEFAULT_VALUE,
         reload: bool = True,
     ) -> bool:
         """Checks if the job is complete.

--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -824,7 +824,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
         client = self._require_client(client)
 
         kwargs = {}
-        if timeout is PollingFuture._DEFAULT_VALUE:
+        if type(timeout) is object:
             pass
         elif timeout is None:
             kwargs["timeout"] = None

--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -823,7 +823,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
         """
         client = self._require_client(client)
 
-        kwargs = {}
+        kwargs: Dict[str, any] = {}
         if type(timeout) is object:
             pass
         elif timeout is None:

--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -817,7 +817,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
                 ``client`` stored on the current dataset.
 
             retry (Optional[google.api_core.retry.Retry]): How to retry the RPC.
-            timeout (Optinal[float]):
+            timeout (Optional[float]):
                 The number of seconds to wait for the underlying HTTP transport
                 before using ``retry``.
         """

--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -917,7 +917,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
             retry (Optional[google.api_core.retry.Retry]):
                 How to retry the RPC. If the job state is ``DONE``, retrying is aborted
                 early, as the job will not change anymore.
-            timeout (Optinal[float]):
+            timeout (Optional[float]):
                 The number of seconds to wait for the underlying HTTP transport
                 before using ``retry``.
             reload (Optional[bool]):

--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -19,7 +19,7 @@ import copy
 import http
 import threading
 import typing
-from typing import ClassVar, Dict, Optional, Sequence, Union
+from typing import Any, ClassVar, Dict, Optional, Sequence, Union
 
 from google.api_core import retry as retries
 from google.api_core import exceptions
@@ -823,7 +823,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
         """
         client = self._require_client(client)
 
-        kwargs: Dict[str, any] = {}
+        kwargs: Dict[str, Any] = {}
         if type(timeout) is object:
             pass
         elif timeout is None:

--- a/google/cloud/bigquery/job/query.py
+++ b/google/cloud/bigquery/job/query.py
@@ -1467,7 +1467,7 @@ class QueryJob(_AsyncJob):
                 The number of seconds to wait for the underlying HTTP transport
                 before using ``retry``. If ``None``, wait indefinitely
                 unless an error is returned. If unset, only the
-                underlying Client.get_job() API call has timeout, but we still
+                underlying API calls have their default timeouts, but we still
                 wait indefinitely for the job to finish.
             start_index (Optional[int]):
                 The zero-based index of the starting row to read.

--- a/google/cloud/bigquery/job/query.py
+++ b/google/cloud/bigquery/job/query.py
@@ -1466,7 +1466,7 @@ class QueryJob(_AsyncJob):
             ]]):
                 The number of seconds to wait for the underlying HTTP transport
                 before using ``retry``. If ``None``, wait indefinitely
-                unless a retriable error is returned. If unset, only the
+                unless an error is returned. If unset, only the
                 underlying Client.get_job() API call has timeout, but we still
                 wait indefinitely for the job to finish.
             start_index (Optional[int]):

--- a/google/cloud/bigquery/job/query.py
+++ b/google/cloud/bigquery/job/query.py
@@ -1461,7 +1461,7 @@ class QueryJob(_AsyncJob):
                 is ``DONE``, retrying is aborted early even if the
                 results are not available, as this will not change
                 anymore.
-            timeout (Optinal[Union[float, \
+            timeout (Optional[Union[float, \
                 google.api_core.future.polling.PollingFuture._DEFAULT_VALUE, \
             ]]):
                 The number of seconds to wait for the underlying HTTP transport

--- a/google/cloud/bigquery/job/query.py
+++ b/google/cloud/bigquery/job/query.py
@@ -1517,7 +1517,7 @@ class QueryJob(_AsyncJob):
 
         # When timeout has default sentinel value ``object()``, do not pass
         # anything to invoke default timeouts in subsequent calls.
-        kwargs: Dict[str, _helpers.TimeoutType] = {}
+        kwargs: Dict[str, Union[_helpers.TimeoutType, object]] = {}
         if type(timeout) is not object:
             kwargs["timeout"] = timeout
 

--- a/google/cloud/bigquery/retry.py
+++ b/google/cloud/bigquery/retry.py
@@ -14,6 +14,7 @@
 
 from google.api_core import exceptions
 from google.api_core import retry
+import google.api_core.future.polling
 from google.auth import exceptions as auth_exceptions  # type: ignore
 import requests.exceptions
 
@@ -144,4 +145,9 @@ The default job retry object.
 DEFAULT_GET_JOB_TIMEOUT = 128
 """
 Default timeout for Client.get_job().
+"""
+
+POLLING_DEFAULT_VALUE = google.api_core.future.polling.PollingFuture._DEFAULT_VALUE
+"""
+Default value defined in google.api_core.future.polling.PollingFuture.
 """

--- a/google/cloud/bigquery/retry.py
+++ b/google/cloud/bigquery/retry.py
@@ -132,3 +132,8 @@ DEFAULT_JOB_RETRY = retry.Retry(
 """
 The default job retry object.
 """
+
+DEFAULT_GET_JOB_TIMEOUT = 128
+"""
+Default timeout for Client.get_job().
+"""

--- a/tests/unit/job/test_base.py
+++ b/tests/unit/job/test_base.py
@@ -767,6 +767,10 @@ class Test_AsyncJob(unittest.TestCase):
         retry = DEFAULT_RETRY.with_deadline(1)
         job.reload(client=client, retry=retry, timeout=4.2)
 
+        # Unsupported timeout type
+        with pytest.raises(ValueError):
+            job.reload(client=client, retry=retry, timeout="4.2")
+
         call_api.assert_called_once_with(
             retry,
             span_name="BigQuery.getJob",

--- a/tests/unit/job/test_base.py
+++ b/tests/unit/job/test_base.py
@@ -20,8 +20,9 @@ from unittest import mock
 from google.api_core import exceptions
 import google.api_core.retry
 from google.api_core.future import polling
-from google.api_core.future.polling import PollingFuture
 import pytest
+
+from google.cloud.bigquery.retry import POLLING_DEFAULT_VALUE
 
 from ..helpers import make_connection
 
@@ -964,7 +965,7 @@ class Test_AsyncJob(unittest.TestCase):
 
         reload_.assert_called_once_with(
             retry=DEFAULT_RETRY,
-            timeout=PollingFuture._DEFAULT_VALUE,
+            timeout=POLLING_DEFAULT_VALUE,
         )
 
     def test_done_explicit_wo_state(self):

--- a/tests/unit/job/test_base.py
+++ b/tests/unit/job/test_base.py
@@ -22,7 +22,7 @@ import google.api_core.retry
 from google.api_core.future import polling
 import pytest
 
-from google.cloud.bigquery.retry import POLLING_DEFAULT_VALUE
+from google.cloud.bigquery.retry import DEFAULT_GET_JOB_TIMEOUT
 
 from ..helpers import make_connection
 
@@ -783,16 +783,6 @@ class Test_AsyncJob(unittest.TestCase):
         )
         self.assertEqual(job._properties, expected)
 
-    def test_reload_unsupported_timeout_type(self):
-        from google.cloud.bigquery.retry import DEFAULT_RETRY
-
-        job = self._set_properties_job()
-        client = _make_client(project=self.PROJECT)
-        retry = DEFAULT_RETRY.with_deadline(1)
-
-        with pytest.raises(ValueError):
-            job.reload(client=client, retry=retry, timeout="4.2")
-
     def test_reload_none_timeout(self):
         from google.cloud.bigquery.retry import DEFAULT_RETRY
 
@@ -995,7 +985,7 @@ class Test_AsyncJob(unittest.TestCase):
 
         reload_.assert_called_once_with(
             retry=DEFAULT_RETRY,
-            timeout=POLLING_DEFAULT_VALUE,
+            timeout=DEFAULT_GET_JOB_TIMEOUT,
         )
 
     def test_done_explicit_wo_state(self):

--- a/tests/unit/job/test_base.py
+++ b/tests/unit/job/test_base.py
@@ -984,6 +984,7 @@ class Test_AsyncJob(unittest.TestCase):
 
     def test_result_default_wo_state(self):
         from google.cloud.bigquery.retry import DEFAULT_GET_JOB_TIMEOUT
+
         begun_job_resource = _make_job_resource(
             job_id=self.JOB_ID, project_id=self.PROJECT, location="US", started=True
         )

--- a/tests/unit/job/test_copy.py
+++ b/tests/unit/job/test_copy.py
@@ -531,10 +531,10 @@ class TestCopyJob(_Base):
                 "path": PATH,
                 "job_id": self.JOB_ID,
                 "location": None,
-            }, 
+            },
             client2,
             None,
-            )
+        )
 
         conn1.api_request.assert_not_called()
         conn2.api_request.assert_called_once_with(

--- a/tests/unit/job/test_copy.py
+++ b/tests/unit/job/test_copy.py
@@ -477,6 +477,8 @@ class TestCopyJob(_Base):
         )
 
     def test_reload_w_bound_client(self):
+        from google.cloud.bigquery.retry import DEFAULT_GET_JOB_TIMEOUT
+
         PATH = "/projects/%s/jobs/%s" % (self.PROJECT, self.JOB_ID)
         RESOURCE = self._make_resource()
         conn = make_connection(RESOURCE)
@@ -489,14 +491,27 @@ class TestCopyJob(_Base):
         ) as final_attributes:
             job.reload()
 
-        final_attributes.assert_called_with({"path": PATH}, client, job)
+        final_attributes.assert_called_with(
+            {
+                "path": PATH,
+                "job_id": self.JOB_ID,
+                "location": None,
+            },
+            client,
+            None,
+        )
 
         conn.api_request.assert_called_once_with(
-            method="GET", path=PATH, query_params={}, timeout=None
+            method="GET",
+            path=PATH,
+            query_params={"projection": "full"},
+            timeout=DEFAULT_GET_JOB_TIMEOUT,
         )
         self._verifyResourceProperties(job, RESOURCE)
 
     def test_reload_w_alternate_client(self):
+        from google.cloud.bigquery.retry import DEFAULT_GET_JOB_TIMEOUT
+
         PATH = "/projects/%s/jobs/%s" % (self.PROJECT, self.JOB_ID)
         RESOURCE = self._make_resource()
         conn1 = make_connection()
@@ -511,10 +526,21 @@ class TestCopyJob(_Base):
         ) as final_attributes:
             job.reload(client=client2)
 
-        final_attributes.assert_called_with({"path": PATH}, client2, job)
+        final_attributes.assert_called_with(
+            {
+                "path": PATH,
+                "job_id": self.JOB_ID,
+                "location": None,
+            }, 
+            client2,
+            None,
+            )
 
         conn1.api_request.assert_not_called()
         conn2.api_request.assert_called_once_with(
-            method="GET", path=PATH, query_params={}, timeout=None
+            method="GET",
+            path=PATH,
+            query_params={"projection": "full"},
+            timeout=DEFAULT_GET_JOB_TIMEOUT,
         )
         self._verifyResourceProperties(job, RESOURCE)

--- a/tests/unit/job/test_extract.py
+++ b/tests/unit/job/test_extract.py
@@ -418,7 +418,7 @@ class TestExtractJob(_Base):
                 "path": PATH,
                 "job_id": self.JOB_ID,
                 "location": None,
-            }, 
+            },
             client,
             None,
         )
@@ -453,10 +453,10 @@ class TestExtractJob(_Base):
                 "path": PATH,
                 "job_id": self.JOB_ID,
                 "location": None,
-            }, 
+            },
             client2,
             None,
-            )
+        )
 
         conn1.api_request.assert_not_called()
         conn2.api_request.assert_called_once_with(

--- a/tests/unit/job/test_extract.py
+++ b/tests/unit/job/test_extract.py
@@ -399,6 +399,7 @@ class TestExtractJob(_Base):
 
     def test_reload_w_bound_client(self):
         from google.cloud.bigquery.dataset import DatasetReference
+        from google.cloud.bigquery.retry import DEFAULT_GET_JOB_TIMEOUT
 
         PATH = "/projects/%s/jobs/%s" % (self.PROJECT, self.JOB_ID)
         RESOURCE = self._make_resource()
@@ -412,14 +413,26 @@ class TestExtractJob(_Base):
         ) as final_attributes:
             job.reload()
 
-        final_attributes.assert_called_with({"path": PATH}, client, job)
+        final_attributes.assert_called_with(
+            {
+                "path": PATH,
+                "job_id": self.JOB_ID,
+                "location": None,
+            }, 
+            client,
+            None,
+        )
         conn.api_request.assert_called_once_with(
-            method="GET", path=PATH, query_params={}, timeout=None
+            method="GET",
+            path=PATH,
+            query_params={"projection": "full"},
+            timeout=DEFAULT_GET_JOB_TIMEOUT,
         )
         self._verifyResourceProperties(job, RESOURCE)
 
     def test_reload_w_alternate_client(self):
         from google.cloud.bigquery.dataset import DatasetReference
+        from google.cloud.bigquery.retry import DEFAULT_GET_JOB_TIMEOUT
 
         PATH = "/projects/%s/jobs/%s" % (self.PROJECT, self.JOB_ID)
         RESOURCE = self._make_resource()
@@ -435,10 +448,21 @@ class TestExtractJob(_Base):
         ) as final_attributes:
             job.reload(client=client2)
 
-        final_attributes.assert_called_with({"path": PATH}, client2, job)
+        final_attributes.assert_called_with(
+            {
+                "path": PATH,
+                "job_id": self.JOB_ID,
+                "location": None,
+            }, 
+            client2,
+            None,
+            )
 
         conn1.api_request.assert_not_called()
         conn2.api_request.assert_called_once_with(
-            method="GET", path=PATH, query_params={}, timeout=None
+            method="GET",
+            path=PATH,
+            query_params={"projection": "full"},
+            timeout=DEFAULT_GET_JOB_TIMEOUT,
         )
         self._verifyResourceProperties(job, RESOURCE)

--- a/tests/unit/job/test_load.py
+++ b/tests/unit/job/test_load.py
@@ -714,6 +714,8 @@ class TestLoadJob(_Base):
         )
 
     def test_reload_w_bound_client(self):
+        from google.cloud.bigquery.retry import DEFAULT_GET_JOB_TIMEOUT
+
         PATH = "/projects/%s/jobs/%s" % (self.PROJECT, self.JOB_ID)
         RESOURCE = self._make_resource()
         conn = make_connection(RESOURCE)
@@ -724,14 +726,27 @@ class TestLoadJob(_Base):
         ) as final_attributes:
             job.reload()
 
-        final_attributes.assert_called_with({"path": PATH}, client, job)
+        final_attributes.assert_called_with(
+            {
+                "path": PATH,
+                "job_id": self.JOB_ID,
+                "location": None,
+            }, 
+            client,
+            None,
+        )
 
         conn.api_request.assert_called_once_with(
-            method="GET", path=PATH, query_params={}, timeout=None
+            method="GET",
+            path=PATH,
+            query_params={"projection": "full"},
+            timeout=DEFAULT_GET_JOB_TIMEOUT,
         )
         self._verifyResourceProperties(job, RESOURCE)
 
     def test_reload_w_alternate_client(self):
+        from google.cloud.bigquery.retry import DEFAULT_GET_JOB_TIMEOUT
+
         PATH = "/projects/%s/jobs/%s" % (self.PROJECT, self.JOB_ID)
         RESOURCE = self._make_resource()
         conn1 = make_connection()
@@ -744,16 +759,28 @@ class TestLoadJob(_Base):
         ) as final_attributes:
             job.reload(client=client2)
 
-        final_attributes.assert_called_with({"path": PATH}, client2, job)
+        final_attributes.assert_called_with(
+            {
+                "path": PATH,
+                "job_id": self.JOB_ID,
+                "location": None,
+            }, 
+            client2,
+            None,
+            )
 
         conn1.api_request.assert_not_called()
         conn2.api_request.assert_called_once_with(
-            method="GET", path=PATH, query_params={}, timeout=None
+            method="GET",
+            path=PATH,
+            query_params={"projection": "full"},
+            timeout=DEFAULT_GET_JOB_TIMEOUT,
         )
         self._verifyResourceProperties(job, RESOURCE)
 
     def test_reload_w_job_reference(self):
         from google.cloud.bigquery import job
+        from google.cloud.bigquery.retry import DEFAULT_GET_JOB_TIMEOUT
 
         resource = self._make_resource(ended=True)
         resource["jobReference"]["projectId"] = "alternative-project"
@@ -768,16 +795,20 @@ class TestLoadJob(_Base):
             load_job.reload()
 
         final_attributes.assert_called_with(
-            {"path": "/projects/alternative-project/jobs/{}".format(self.JOB_ID)},
+            {
+                "path": "/projects/alternative-project/jobs/{}".format(self.JOB_ID),
+                "job_id": self.JOB_ID,
+                "location": "US",
+            },
             client,
-            load_job,
+            None,
         )
 
         conn.api_request.assert_called_once_with(
             method="GET",
             path="/projects/alternative-project/jobs/{}".format(self.JOB_ID),
-            query_params={"location": "US"},
-            timeout=None,
+            query_params={"projection": "full", "location": "US"},
+            timeout=DEFAULT_GET_JOB_TIMEOUT,
         )
 
     def test_cancel_w_bound_client(self):

--- a/tests/unit/job/test_load.py
+++ b/tests/unit/job/test_load.py
@@ -731,7 +731,7 @@ class TestLoadJob(_Base):
                 "path": PATH,
                 "job_id": self.JOB_ID,
                 "location": None,
-            }, 
+            },
             client,
             None,
         )
@@ -764,10 +764,10 @@ class TestLoadJob(_Base):
                 "path": PATH,
                 "job_id": self.JOB_ID,
                 "location": None,
-            }, 
+            },
             client2,
             None,
-            )
+        )
 
         conn1.api_request.assert_not_called()
         conn2.api_request.assert_called_once_with(

--- a/tests/unit/job/test_query.py
+++ b/tests/unit/job/test_query.py
@@ -2166,7 +2166,7 @@ class TestQueryJob(_Base):
                 "path": PATH,
                 "job_id": self.JOB_ID,
                 "location": None,
-            }, 
+            },
             client,
             None,
         )
@@ -2207,7 +2207,7 @@ class TestQueryJob(_Base):
                 "path": PATH,
                 "job_id": self.JOB_ID,
                 "location": None,
-            }, 
+            },
             client2,
             None,
         )
@@ -2245,7 +2245,7 @@ class TestQueryJob(_Base):
                 "path": PATH,
                 "job_id": self.JOB_ID,
                 "location": None,
-            }, 
+            },
             client,
             None,
         )

--- a/tests/unit/test__job_helpers.py
+++ b/tests/unit/test__job_helpers.py
@@ -20,9 +20,9 @@ import google.api_core.exceptions
 from google.api_core import retry as retries
 import pytest
 
-from google.cloud.bigquery.client import Client
-from google.cloud.bigquery import enums
 from google.cloud.bigquery import _job_helpers
+from google.cloud.bigquery import enums
+from google.cloud.bigquery.client import Client
 from google.cloud.bigquery.job import copy_ as job_copy
 from google.cloud.bigquery.job import extract as job_extract
 from google.cloud.bigquery.job import load as job_load

--- a/tests/unit/test__job_helpers.py
+++ b/tests/unit/test__job_helpers.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
 from typing import Any, Dict, Optional
 from unittest import mock
 

--- a/tests/unit/test__job_helpers.py
+++ b/tests/unit/test__job_helpers.py
@@ -22,6 +22,7 @@ import pytest
 
 from google.cloud.bigquery import _job_helpers
 from google.cloud.bigquery import enums
+from google.cloud.bigquery import retry
 from google.cloud.bigquery.client import Client
 from google.cloud.bigquery.job import copy_ as job_copy
 from google.cloud.bigquery.job import extract as job_extract
@@ -1050,7 +1051,7 @@ def test_query_and_wait_incomplete_query():
         method="GET",
         path=jobs_get_path,
         query_params={"projection": "full", "location": "response-location"},
-        timeout=None,
+        timeout=retry.DEFAULT_GET_JOB_TIMEOUT,
     )
 
     # Fetch the remaining two pages.

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -3143,6 +3143,7 @@ class TestClient(unittest.TestCase):
 
     def test_get_job_miss_w_explict_project(self):
         from google.cloud.exceptions import NotFound
+        from google.cloud.bigquery.retry import DEFAULT_GET_JOB_TIMEOUT
 
         OTHER_PROJECT = "OTHER_PROJECT"
         JOB_ID = "NONESUCH"
@@ -3157,11 +3158,12 @@ class TestClient(unittest.TestCase):
             method="GET",
             path="/projects/OTHER_PROJECT/jobs/NONESUCH",
             query_params={"projection": "full"},
-            timeout=DEFAULT_TIMEOUT,
+            timeout=DEFAULT_GET_JOB_TIMEOUT,
         )
 
     def test_get_job_miss_w_client_location(self):
         from google.cloud.exceptions import NotFound
+        from google.cloud.bigquery.retry import DEFAULT_GET_JOB_TIMEOUT
 
         JOB_ID = "NONESUCH"
         creds = _make_credentials()
@@ -3175,7 +3177,7 @@ class TestClient(unittest.TestCase):
             method="GET",
             path="/projects/client-proj/jobs/NONESUCH",
             query_params={"projection": "full", "location": "client-loc"},
-            timeout=DEFAULT_TIMEOUT,
+            timeout=DEFAULT_GET_JOB_TIMEOUT,
         )
 
     def test_get_job_hit_w_timeout(self):

--- a/tests/unit/test_job_retry.py
+++ b/tests/unit/test_job_retry.py
@@ -22,85 +22,86 @@ import google.api_core.exceptions
 import google.api_core.retry
 import freezegun
 
-from google.cloud.bigquery.client import Client
 from google.cloud.bigquery import _job_helpers
 import google.cloud.bigquery.retry
 
-from .helpers import make_connection
+from .helpers import make_client, make_connection
 
 
-# With job_retry_on_query, we're testing 4 scenarios:
+_RETRY_NOT_FOUND = {
+    "job_retry":
+        google.api_core.retry.Retry(
+            predicate=google.api_core.retry.if_exception_type(
+                google.api_core.exceptions.NotFound,
+            ),
+        ),
+}
+_RETRY_BAD_REQUEST = {
+    "job_retry":
+        google.api_core.retry.Retry(
+            predicate=google.api_core.retry.if_exception_type(
+                google.api_core.exceptions.BadRequest,
+            ),
+        ),
+}
+
+
+# Test retry of job failures, instead of API-invocation failures. 4 scenarios:
 # - No `job_retry` passed, retry on default rateLimitExceeded.
 # - Pass NotFound retry to `query`.
 # - Pass NotFound retry to `result`.
 # - Pass BadRequest retry to query, with the value passed to `result` overriding.
-@pytest.mark.parametrize("job_retry_on_query", [None, "Query", "Result", "Both"])
 @mock.patch("time.sleep")
-def test_retry_failed_jobs(sleep, client, job_retry_on_query):
-    """
-    Test retry of job failures, as opposed to API-invocation failures.
-    """
-
-    retry_notfound = google.api_core.retry.Retry(
-        predicate=google.api_core.retry.if_exception_type(
-            google.api_core.exceptions.NotFound
-        )
-    )
-    retry_badrequest = google.api_core.retry.Retry(
-        predicate=google.api_core.retry.if_exception_type(
-            google.api_core.exceptions.BadRequest
-        )
-    )
-
-    if job_retry_on_query is None:
-        reason = "rateLimitExceeded"
-    else:
-        reason = "notFound"
-
+@pytest.mark.parametrize(
+    "reason, job_retry, result_retry",
+    [
+        pytest.param(
+            "rateLimitExceeded",
+            {},
+            {},
+            id="no job_retry",
+        ),
+        pytest.param(
+            "notFound",
+            _RETRY_NOT_FOUND,
+            {},
+            id="Query NotFound",
+        ),
+        pytest.param(
+            "notFound",
+            _RETRY_NOT_FOUND,
+            _RETRY_NOT_FOUND,
+            id="Result NotFound",
+        ),
+        pytest.param(
+            "notFound",
+            _RETRY_BAD_REQUEST,
+            _RETRY_NOT_FOUND,
+            id="BadRequest",
+        ),
+    ],
+)
+def test_retry_failed_jobs(sleep, reason, job_retry, result_retry):
+    client = make_client()
     err = dict(reason=reason)
-    responses = [
-        dict(status=dict(state="DONE", errors=[err], errorResult=err)),
-        dict(status=dict(state="DONE", errors=[err], errorResult=err)),
-        dict(status=dict(state="DONE", errors=[err], errorResult=err)),
-        dict(status=dict(state="DONE")),
+    conn = client._connection = make_connection(
+        dict(status=dict(state="DONE", errors=[err], errorResult=err), jobReference={"jobId": "id_1"}),
+        dict(status=dict(state="DONE", errors=[err], errorResult=err), jobReference={"jobId": "id_1"}),
+        dict(status=dict(state="DONE", errors=[err], errorResult=err), jobReference={"jobId": "id_1"}),
+        dict(status=dict(state="DONE"), jobReference={"jobId": "id_2"}),
         dict(rows=[{"f": [{"v": "1"}]}], totalRows="1"),
-    ]
-
-    def api_request(method, path, query_params=None, data=None, **kw):
-        response = responses.pop(0)
-        if data:
-            response["jobReference"] = data["jobReference"]
-        else:
-            response["jobReference"] = dict(
-                jobId=path.split("/")[-1], projectId="PROJECT"
-            )
-        return response
-
-    conn = client._connection = make_connection()
-    conn.api_request.side_effect = api_request
-
-    if job_retry_on_query == "Query":
-        job_retry = dict(job_retry=retry_notfound)
-    elif job_retry_on_query == "Both":
-        # This will be overridden in `result`
-        job_retry = dict(job_retry=retry_badrequest)
-    else:
-        job_retry = {}
-    job = client.query("select 1", **job_retry)
-
-    orig_job_id = job.job_id
-    job_retry = (
-        dict(job_retry=retry_notfound)
-        if job_retry_on_query in ("Result", "Both")
-        else {}
     )
-    result = job.result(**job_retry)
+
+    job = client.query("select 1", **job_retry)
+    result = job.result(**result_retry)
+
     assert result.total_rows == 1
-    assert not responses  # We made all the calls we expected to.
+
+    # We made all the calls we expected to.
+    assert conn.api_request.call_count == 5
 
     # The job adjusts it's job id based on the id of the last attempt.
-    assert job.job_id != orig_job_id
-    assert job.job_id == conn.mock_calls[3][2]["data"]["jobReference"]["jobId"]
+    assert job.job_id == "id_2"
 
     # We had to sleep three times
     assert len(sleep.mock_calls) == 3
@@ -113,17 +114,19 @@ def test_retry_failed_jobs(sleep, client, job_retry_on_query):
     assert max(c[1][0] for c in sleep.mock_calls) <= 8
 
     # We can ask for the result again:
-    responses = [
-        dict(rows=[{"f": [{"v": "1"}]}], totalRows="1"),
-    ]
-    orig_job_id = job.job_id
+    conn = client._connection = make_connection(
+        dict(rows=[{"f": [{"v": "1"}]}], totalRows="1"), 
+    )
     result = job.result()
+
     assert result.total_rows == 1
-    assert not responses  # We made all the calls we expected to.
+
+    # We made all the calls we expected to.
+    assert conn.api_request.call_count == 1
 
     # We wouldn't (and didn't) fail, because we're dealing with a successful job.
     # So the job id hasn't changed.
-    assert job.job_id == orig_job_id
+    assert job.job_id == "id_2"
 
 
 def test_query_retry_with_default_retry_and_ambiguous_errors_only_retries_with_failed_job(
@@ -190,8 +193,7 @@ def test_query_retry_with_default_retry_and_ambiguous_errors_only_retries_with_f
         {"jobReference": job_reference_2, "status": {"state": "DONE"}},
     ]
 
-    conn = client._connection = make_connection()
-    conn.api_request.side_effect = responses
+    conn = client._connection = make_connection(*responses)
 
     with freezegun.freeze_time(
         # Note: because of exponential backoff and a bit of jitter,
@@ -224,8 +226,8 @@ def test_query_retry_with_default_retry_and_ambiguous_errors_only_retries_with_f
             mock.call(
                 method="GET",
                 path="/projects/PROJECT/jobs/1",
-                query_params={"location": "test-loc"},
-                timeout=None,
+                query_params={"location": "test-loc", "projection": "full"},
+                timeout=google.cloud.bigquery.retry.DEFAULT_GET_JOB_TIMEOUT,
             ),
             # jobs.getQueryResults x2
             mock.call(
@@ -244,8 +246,8 @@ def test_query_retry_with_default_retry_and_ambiguous_errors_only_retries_with_f
             mock.call(
                 method="GET",
                 path="/projects/PROJECT/jobs/1",
-                query_params={"location": "test-loc"},
-                timeout=None,
+                query_params={"location": "test-loc", "projection": "full"},
+                timeout=google.cloud.bigquery.retry.DEFAULT_GET_JOB_TIMEOUT,
             ),
             # jobs.insert
             mock.call(
@@ -267,8 +269,8 @@ def test_query_retry_with_default_retry_and_ambiguous_errors_only_retries_with_f
             mock.call(
                 method="GET",
                 path="/projects/PROJECT/jobs/2",
-                query_params={"location": "test-loc"},
-                timeout=None,
+                query_params={"location": "test-loc", "projection": "full"},
+                timeout=google.cloud.bigquery.retry.DEFAULT_GET_JOB_TIMEOUT,
             ),
             # jobs.getQueryResults
             mock.call(
@@ -281,8 +283,8 @@ def test_query_retry_with_default_retry_and_ambiguous_errors_only_retries_with_f
             mock.call(
                 method="GET",
                 path="/projects/PROJECT/jobs/2",
-                query_params={"location": "test-loc"},
-                timeout=None,
+                query_params={"location": "test-loc", "projection": "full"},
+                timeout=google.cloud.bigquery.retry.DEFAULT_GET_JOB_TIMEOUT,
             ),
         ]
     )
@@ -414,12 +416,9 @@ def test_query_and_wait_retries_job_for_DDL_queries():
     https://github.com/googleapis/python-bigquery/issues/1790
     """
     freezegun.freeze_time(auto_tick_seconds=1)
-    client = mock.create_autospec(Client)
-    client._call_api.__name__ = "_call_api"
-    client._call_api.__qualname__ = "Client._call_api"
-    client._call_api.__annotations__ = {}
-    client._call_api.__type_params__ = ()
-    client._call_api.side_effect = (
+
+    client = make_client()
+    conn = client._connection = make_connection(
         {
             "jobReference": {
                 "projectId": "response-project",
@@ -472,7 +471,7 @@ def test_query_and_wait_retries_job_for_DDL_queries():
     # and https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/getQueryResults
     query_request_path = "/projects/request-project/queries"
 
-    calls = client._call_api.call_args_list
+    calls = conn.api_request.call_args_list
     _, kwargs = calls[0]
     assert kwargs["method"] == "POST"
     assert kwargs["path"] == query_request_path

--- a/tests/unit/test_job_retry.py
+++ b/tests/unit/test_job_retry.py
@@ -219,8 +219,8 @@ def test_retry_connection_error_with_default_retries_and_successful_first_job(
             mock.call(
                 method="GET",
                 path="/projects/PROJECT/jobs/1",
-                query_params={"location": "test-loc"},
-                timeout=None,
+                query_params={"location": "test-loc", "projection": "full"},
+                timeout=google.cloud.bigquery.retry.DEFAULT_GET_JOB_TIMEOUT,
             ),
             # jobs.getQueryResults x2
             mock.call(
@@ -239,8 +239,8 @@ def test_retry_connection_error_with_default_retries_and_successful_first_job(
             mock.call(
                 method="GET",
                 path="/projects/PROJECT/jobs/1",
-                query_params={"location": "test-loc"},
-                timeout=None,
+                query_params={"location": "test-loc", "projection": "full"},
+                timeout=google.cloud.bigquery.retry.DEFAULT_GET_JOB_TIMEOUT,
             ),
             # jobs.getQueryResults
             mock.call(

--- a/tests/unit/test_job_retry.py
+++ b/tests/unit/test_job_retry.py
@@ -30,20 +30,18 @@ from .helpers import make_client, make_connection
 
 
 _RETRY_NOT_FOUND = {
-    "job_retry":
-        google.api_core.retry.Retry(
-            predicate=google.api_core.retry.if_exception_type(
-                google.api_core.exceptions.NotFound,
-            ),
+    "job_retry": google.api_core.retry.Retry(
+        predicate=google.api_core.retry.if_exception_type(
+            google.api_core.exceptions.NotFound,
         ),
+    ),
 }
 _RETRY_BAD_REQUEST = {
-    "job_retry":
-        google.api_core.retry.Retry(
-            predicate=google.api_core.retry.if_exception_type(
-                google.api_core.exceptions.BadRequest,
-            ),
+    "job_retry": google.api_core.retry.Retry(
+        predicate=google.api_core.retry.if_exception_type(
+            google.api_core.exceptions.BadRequest,
         ),
+    ),
 }
 
 
@@ -86,9 +84,18 @@ def test_retry_failed_jobs(sleep, reason, job_retry, result_retry):
     client = make_client()
     err = dict(reason=reason)
     conn = client._connection = make_connection(
-        dict(status=dict(state="DONE", errors=[err], errorResult=err), jobReference={"jobId": "id_1"}),
-        dict(status=dict(state="DONE", errors=[err], errorResult=err), jobReference={"jobId": "id_1"}),
-        dict(status=dict(state="DONE", errors=[err], errorResult=err), jobReference={"jobId": "id_1"}),
+        dict(
+            status=dict(state="DONE", errors=[err], errorResult=err),
+            jobReference={"jobId": "id_1"},
+        ),
+        dict(
+            status=dict(state="DONE", errors=[err], errorResult=err),
+            jobReference={"jobId": "id_1"},
+        ),
+        dict(
+            status=dict(state="DONE", errors=[err], errorResult=err),
+            jobReference={"jobId": "id_1"},
+        ),
         dict(status=dict(state="DONE"), jobReference={"jobId": "id_2"}),
         dict(rows=[{"f": [{"v": "1"}]}], totalRows="1"),
     )
@@ -116,7 +123,7 @@ def test_retry_failed_jobs(sleep, reason, job_retry, result_retry):
 
     # We can ask for the result again:
     conn = client._connection = make_connection(
-        dict(rows=[{"f": [{"v": "1"}]}], totalRows="1"), 
+        dict(rows=[{"f": [{"v": "1"}]}], totalRows="1"),
     )
     result = job.result()
 

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -2362,13 +2362,14 @@ class TestRowIterator(unittest.TestCase):
 
     def test__should_use_bqstorage_returns_false_w_warning_if_missing_dependency(self):
         iterator = self._make_one(first_page_response=None)  # not cached
- 
+
         def fail_bqstorage_import(name, globals, locals, fromlist, level):
             """Returns True if bigquery_storage has been imported."""
             # NOTE: *very* simplified, assuming a straightforward absolute import
             return "bigquery_storage" in name or (
                 fromlist is not None and "bigquery_storage" in fromlist
             )
+
         # maybe_fail_import() returns ImportError if the predicate is True
         no_bqstorage = maybe_fail_import(predicate=fail_bqstorage_import)
 


### PR DESCRIPTION
When calling `QueryJob.result()`, `QueryJob.reload()` is called in the background with an empty timeout value. This leads `QueryJob` to waiting indefinitely if `QueryJob.reload()` loses connection.

This PR:
- Reroutes `QueryJob.reload()` to call `Client.get_job()` instead of calling API directly
- Adds a 128s default timeout for `Client.get_job()`

Fixes #1922 🦕
