### PR TITLE
chore: updates continuous CI/CD tests against specific versions of Python

### DIFF
--- a/.kokoro/continuous/prerelease-deps.cfg
+++ b/.kokoro/continuous/prerelease-deps.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Only run this nox session.
+env_vars: {
+    key: "NOX_SESSION"
+    value: "prerelease_deps"
+}

--- a/.kokoro/continuous/prerelease-deps.cfg
+++ b/.kokoro/continuous/prerelease-deps.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Only run this nox session.
-env_vars: {
-    key: "NOX_SESSION"
-    value: "prerelease_deps"
-}

--- a/.kokoro/continuous/unit-tests-misc.cfg
+++ b/.kokoro/continuous/unit-tests-misc.cfg
@@ -1,0 +1,9 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Only run these nox sessions.
+# A subset based on Python versions that are neither our newest OR oldest
+# supported versions of Python
+env_vars: {
+    key: "NOX_SESSION"
+    value: "unit_noextras-3.9 unit_noextras-3.10 unit_noextras-3.11 unit-3.9 unit-3.10 unit-3.11"
+}

--- a/owlbot.py
+++ b/owlbot.py
@@ -70,6 +70,7 @@ s.move(
         # Include custom SNIPPETS_TESTS job for performance.
         # https://github.com/googleapis/python-bigquery/issues/191
         ".kokoro/presubmit/presubmit.cfg",
+        ".kokoro/continuous/prerelease-deps.cfg",
         ".github/workflows",  # exclude gh actions as credentials are needed for tests
 	"README.rst",
     ],


### PR DESCRIPTION
Updates the regular continuous CI/CD checks to test against specific versions of Python (versions that aren't our most recent supported version and aren't our oldest supported version).

Also removes a CI/CD check that is superceded by a more recent version of check (prerelease-deps >>> replaced by prerelease-deps-3.12).

Modifies owlbot to avoid it adding prerelease-deps back into the mix since that file is a default in synthtool.