### PR TITLE
test: update the results of test based on change to hacker news data

### DIFF
--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -1820,8 +1820,6 @@ class TestBigQuery(unittest.TestCase):
             ],
         ]
 
-        print(f"DINOSAUR fetched:\n{fetched_data}")
-        print(f"DINOSAUR expected:\n{expected_data}")
         self.assertEqual(fetched_data, expected_data)
 
     def test_dbapi_dry_run_query(self):

--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -1789,22 +1789,39 @@ class TestBigQuery(unittest.TestCase):
 
         expected_data = [
             [
+                ("by", "pg"),
+                ("id", 1),
+                (
+                    "timestamp",
+                    datetime.datetime(
+                        2006, 10, 9, 18, 21, 51, tzinfo=datetime.timezone.utc
+                    ),
+                ),
+            ],
+            [
                 ("by", "phyllis"),
                 ("id", 2),
-                ("timestamp", datetime.datetime(2006, 10, 9, 18, 30, 28, tzinfo=UTC)),
+                (
+                    "timestamp",
+                    datetime.datetime(
+                        2006, 10, 9, 18, 30, 28, tzinfo=datetime.timezone.utc
+                    ),
+                ),
             ],
             [
                 ("by", "phyllis"),
                 ("id", 3),
-                ("timestamp", datetime.datetime(2006, 10, 9, 18, 40, 33, tzinfo=UTC)),
-            ],
-            [
-                ("by", "onebeerdave"),
-                ("id", 4),
-                ("timestamp", datetime.datetime(2006, 10, 9, 18, 47, 42, tzinfo=UTC)),
+                (
+                    "timestamp",
+                    datetime.datetime(
+                        2006, 10, 9, 18, 40, 33, tzinfo=datetime.timezone.utc
+                    ),
+                ),
             ],
         ]
 
+        print(f"DINOSAUR fetched:\n{fetched_data}")
+        print(f"DINOSAUR expected:\n{expected_data}")
         self.assertEqual(fetched_data, expected_data)
 
     def test_dbapi_dry_run_query(self):


### PR DESCRIPTION
Several tests were failing. presubmit testing. This PR updates the expected results to match the fetched results.

The reason for the problem is because we updated the online version of the hacker-news data dump and the data changed slightly. This now matches the data dump.

