### PR TITLE
fix: Allow protobuf 5.x; require protobuf >=3.20.2; proto-plus >=1.22.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,8 +75,8 @@ extras = {
         "opentelemetry-instrumentation >= 0.20b0",
     ],
     "bigquery_v2": [
-        "proto-plus >= 1.22.0, <2.0.0dev",
-        "protobuf>=3.19.5,<5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",  # For the legacy proto-based types.
+        "proto-plus >= 1.22.3, <2.0.0dev",
+        "protobuf>=3.20.2,<6.0.0dev,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",  # For the legacy proto-based types.
     ],
 }
 

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -26,8 +26,8 @@ opentelemetry-instrumentation==0.20b0
 opentelemetry-sdk==1.1.0
 packaging==20.0.0
 pandas==1.1.0
-proto-plus==1.22.0
-protobuf==3.19.5
+proto-plus==1.22.3
+protobuf==3.20.2
 pyarrow==3.0.0
 python-dateutil==2.7.3
 requests==2.21.0


### PR DESCRIPTION
Update setup.py and constraints to match [setup.py here](https://github.com/googleapis/gapic-generator-python/blob/5ccdd31902c49c2cf703c998b6406fef4a4b14dc/gapic/templates/setup.py.j2#L37-L39)