### PR TITLE
fix: Do not set job timeout extra property if None

### DIFF
--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -218,8 +218,11 @@ class _JobConfig(object):
                 err.__traceback__
             )
 
-        """ Docs indicate a string is expected by the API """
-        self._properties["jobTimeoutMs"] = str(value)
+        if value is not None:
+            # docs indicate a string is expected by the API
+            self._properties["jobTimeoutMs"] = str(value)
+        else:
+            self._properties.pop("jobTimeoutMs", None)
 
     @property
     def labels(self):

--- a/tests/unit/job/test_base.py
+++ b/tests/unit/job/test_base.py
@@ -1320,3 +1320,21 @@ class Test_JobConfig(unittest.TestCase):
         # Confirm that integers get converted to strings.
         job_config.job_timeout_ms = 5000
         assert job_config.job_timeout_ms == "5000"  # int is converted to string
+
+    def test_job_timeout_is_none_when_set_none(self):
+        job_config = self._make_one()
+        job_config.job_timeout_ms = None
+        # Confirm value is None and not literal string 'None'
+        assert job_config.job_timeout_ms is None
+
+    def test_job_timeout_properties(self):
+        # Make sure any value stored in properties is erased
+        # when setting job_timeout to None.
+        job_config = self._make_one()
+        job_config.job_timeout_ms = 4200
+        assert job_config.job_timeout_ms == "4200"
+        assert job_config._properties.get("jobTimeoutMs") == "4200"
+
+        job_config.job_timeout_ms = None
+        assert job_config.job_timeout_ms is None
+        assert "jobTimeoutMs" not in job_config._properties


### PR DESCRIPTION
### Description
`job_timeout_ms` declared as optional ([see docs](https://cloud.google.com/python/docs/reference/bigquery/latest/google.cloud.bigquery.job.CopyJobConfig#google_cloud_bigquery_job_CopyJobConfig_job_timeout_ms)), but setting it as None results in error:
```
google.api_core.exceptions.BadRequest: 400 POST https://bigquery.googleapis.com/bigquery/v2/projects/my-bq-project/jobs?prettyPrint=false: Invalid value at 'job.configuration.job_timeout_ms.value' (TYPE_INT64), "None"

Location: None
Job ID: 5f5bf5bd-dc77-7eda-a2d3-69420a6bf6d6
 [{'@type': 'type.googleapis.com/google.rpc.BadRequest', 'fieldViolations': [{'field': 'job.configuration.job_timeout_ms.value', 'description': 'Invalid value at \'job.configuration.job_timeout_ms.value\' (TYPE_INT64), "None"'}]}]
```

because of [allowing None](https://github.com/googleapis/python-bigquery/blob/main/google/cloud/bigquery/job/base.py#L215), but not handling it properly. This fix doesn't cast None to a string in setter. Getter still works as expected, but we do not send invalid value in remote call.

### Simple script to reproduce
```python
from typing import Optional

from google.cloud import bigquery

query = "SELECT * FROM `project.table` LIMIT 1"
client = bigquery.Client()
config = bigquery.QueryJobConfig(use_query_cache=True, allow_large_results=True)
my_timeout: Optional[int] = None
config.job_timeout_ms = my_timeout
client.query(query, job_config=config)
```
