### PR TITLE
Bug: revises Exception type

### DIFF
--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -49,7 +49,7 @@ _ERROR_REASON_TO_EXCEPTION = {
     "notImplemented": http.client.NOT_IMPLEMENTED,
     "policyViolation": http.client.FORBIDDEN,
     "quotaExceeded": http.client.FORBIDDEN,
-    "rateLimitExceeded": exceptions.TooManyRequests,
+    "rateLimitExceeded": http.client.TOO_MANY_REQUESTS,
     "resourceInUse": http.client.BAD_REQUEST,
     "resourcesExceeded": http.client.BAD_REQUEST,
     "responseTooLarge": http.client.FORBIDDEN,

--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -49,7 +49,7 @@ _ERROR_REASON_TO_EXCEPTION = {
     "notImplemented": http.client.NOT_IMPLEMENTED,
     "policyViolation": http.client.FORBIDDEN,
     "quotaExceeded": http.client.FORBIDDEN,
-    "rateLimitExceeded": http.client.FORBIDDEN,
+    "rateLimitExceeded": exceptions.TooManyRequests,
     "resourceInUse": http.client.BAD_REQUEST,
     "resourcesExceeded": http.client.BAD_REQUEST,
     "responseTooLarge": http.client.FORBIDDEN,

--- a/tests/unit/test_job_retry.py
+++ b/tests/unit/test_job_retry.py
@@ -442,7 +442,7 @@ def test_disable_retry_failed_jobs(sleep, client, job_retry_on_query):
 
     orig_job_id = job.job_id
     job_retry = dict(job_retry=None) if job_retry_on_query == "Result" else {}
-    with pytest.raises(google.api_core.exceptions.GoogleAPICallError):
+    with pytest.raises(google.api_core.exceptions.TooManyRequests):
         job.result(**job_retry)
 
     assert job.job_id == orig_job_id

--- a/tests/unit/test_job_retry.py
+++ b/tests/unit/test_job_retry.py
@@ -442,7 +442,7 @@ def test_disable_retry_failed_jobs(sleep, client, job_retry_on_query):
 
     orig_job_id = job.job_id
     job_retry = dict(job_retry=None) if job_retry_on_query == "Result" else {}
-    with pytest.raises(google.api_core.exceptions.Forbidden):
+    with pytest.raises(google.api_core.exceptions.GoogleAPICallError):
         job.result(**job_retry)
 
     assert job.job_id == orig_job_id


### PR DESCRIPTION
Revises an exception type to a type that is more descriptive of the true problem.

Specifically, migrates from an http.client.FORBIDDEN exception to an TooManyRequests Error if a user experiences a rateLimitExceeded condition. This enables automated systems to more appropriately respond in situations where the rate limit is exceeded.

Fixes #1985 🦕
