### PR TITLE
chore: adds Python 3.7/3.8 EOL pending deprecation warning

### DIFF
--- a/google/cloud/bigquery/__init__.py
+++ b/google/cloud/bigquery/__init__.py
@@ -114,22 +114,22 @@ from google.cloud.bigquery.table import TableReference
 from google.cloud.bigquery.table import TimePartitioningType
 from google.cloud.bigquery.table import TimePartitioning
 from google.cloud.bigquery.encryption_configuration import EncryptionConfiguration
+from google.cloud.bigquery import _versions_helpers
 
 try:
     import bigquery_magics  # type: ignore
 except ImportError:
     bigquery_magics = None
 
-import sys
-import warnings
+sys_major, sys_minor, sys_micro = _versions_helpers.extract_runtime_version()
 
-if sys.version_info.major == 3 and sys.version_info.minor in (7, 8):
+if sys_major == 3 and sys_minor in (7, 8):
     warnings.warn(
         "The python-bigquery library will stop supporting Python 3.7 "
         "and Python 3.8 in a future major release expected in Q4 2024. "
-        f"Your Python version is {sys.version}. We recommend that you "
-        "update soon to ensure ongoing support. For more details, see: "
-        "<blog post URL>",
+        f"Your Python version is {sys_major}.{sys_minor}.{sys_micro}. We "
+        "recommend that you update soon to ensure ongoing support. For "
+        "more details, see: <blog post URL>",
         PendingDeprecationWarning,
     )
 

--- a/google/cloud/bigquery/__init__.py
+++ b/google/cloud/bigquery/__init__.py
@@ -129,7 +129,7 @@ if sys_major == 3 and sys_minor in (7, 8):
         "and Python 3.8 in a future major release expected in Q4 2024. "
         f"Your Python version is {sys_major}.{sys_minor}.{sys_micro}. We "
         "recommend that you update soon to ensure ongoing support. For "
-        "more details, see: <blog post URL>",
+        "more details, see: [Google Cloud Client Libraries Supported Python Versions policy](https://cloud.google.com/python/docs/supported-python-versions)",
         PendingDeprecationWarning,
     )
 

--- a/google/cloud/bigquery/__init__.py
+++ b/google/cloud/bigquery/__init__.py
@@ -120,6 +120,19 @@ try:
 except ImportError:
     bigquery_magics = None
 
+import sys
+import warnings
+
+if sys.version_info.major == 3 and sys.version_info.minor in (7, 8):
+    warnings.warn(
+        "The python-bigquery library will stop supporting Python 3.7 "
+        "and Python 3.8 in a future major release expected in Q4 2024. "
+        f"Your Python version is {sys.version}. We recommend that you "
+        "update soon to ensure ongoing support. For more details, see: "
+        "<blog post URL>",
+        PendingDeprecationWarning,
+    )
+
 __all__ = [
     "__version__",
     "Client",

--- a/google/cloud/bigquery/_versions_helpers.py
+++ b/google/cloud/bigquery/_versions_helpers.py
@@ -14,6 +14,7 @@
 
 """Shared helper functions for verifying versions of installed modules."""
 
+import sys
 from typing import Any
 
 import packaging.version
@@ -248,3 +249,16 @@ SUPPORTS_RANGE_PYARROW = (
     and PYARROW_VERSIONS.try_import() is not None
     and PYARROW_VERSIONS.installed_version >= _MIN_PYARROW_VERSION_RANGE
 )
+
+
+def extract_runtime_version():
+    # Retrieve the version information
+    version_info = sys.version_info
+
+    # Extract the major, minor, and micro components
+    major = version_info.major
+    minor = version_info.minor
+    micro = version_info.micro
+
+    # Display the version number in a clear format
+    return major, minor, micro

--- a/noxfile.py
+++ b/noxfile.py
@@ -404,10 +404,6 @@ def prerelease_deps(session):
     session.run("python", "-m", "pip", "freeze")
 
     # Run all tests, except a few samples tests which require extra dependencies.
-    # session.run("py.test", "tests/unit")
-    # session.run("py.test", "tests/system")
-    # session.run("py.test", "samples/tests")
-
     session.run(
         "py.test",
         "tests/unit",

--- a/noxfile.py
+++ b/noxfile.py
@@ -116,6 +116,7 @@ def default(session, install_extras=True):
     session.run(
         "py.test",
         "--quiet",
+        "-W default::PendingDeprecationWarning",
         "--cov=google/cloud/bigquery",
         "--cov=tests/unit",
         "--cov-append",
@@ -231,6 +232,7 @@ def system(session):
     session.run(
         "py.test",
         "--quiet",
+        "-W default::PendingDeprecationWarning",
         os.path.join("tests", "system"),
         *session.posargs,
     )
@@ -299,6 +301,7 @@ def snippets(session):
     session.run(
         "py.test",
         "samples",
+        "-W default::PendingDeprecationWarning",
         "--ignore=samples/desktopapp",
         "--ignore=samples/magics",
         "--ignore=samples/geography",
@@ -401,9 +404,30 @@ def prerelease_deps(session):
     session.run("python", "-m", "pip", "freeze")
 
     # Run all tests, except a few samples tests which require extra dependencies.
-    session.run("py.test", "tests/unit")
-    session.run("py.test", "tests/system")
-    session.run("py.test", "samples/tests")
+    #session.run("py.test", "tests/unit")
+    #session.run("py.test", "tests/system")
+    #session.run("py.test", "samples/tests")
+
+    session.run(
+        "py.test",
+        "tests/unit",
+        "-W default::PendingDeprecationWarning",
+    )
+
+    session.run(
+        "py.test",
+        "tests/system",
+        "-W default::PendingDeprecationWarning",
+    )
+
+    session.run(
+        "py.test",
+        "samples/tests",
+        "-W default::PendingDeprecationWarning",
+    )
+
+
+
 
 
 @nox.session(python=DEFAULT_PYTHON_VERSION)

--- a/noxfile.py
+++ b/noxfile.py
@@ -404,9 +404,9 @@ def prerelease_deps(session):
     session.run("python", "-m", "pip", "freeze")
 
     # Run all tests, except a few samples tests which require extra dependencies.
-    #session.run("py.test", "tests/unit")
-    #session.run("py.test", "tests/system")
-    #session.run("py.test", "samples/tests")
+    # session.run("py.test", "tests/unit")
+    # session.run("py.test", "tests/system")
+    # session.run("py.test", "samples/tests")
 
     session.run(
         "py.test",
@@ -425,9 +425,6 @@ def prerelease_deps(session):
         "samples/tests",
         "-W default::PendingDeprecationWarning",
     )
-
-
-
 
 
 @nox.session(python=DEFAULT_PYTHON_VERSION)


### PR DESCRIPTION
This is a work in progress (WIP). I want to see how it behaves in our CI/CD pipeline and if that is any different than what we see locally. 

Adds a pending deprecation warning and code logic to output that warning if the user attempts to install the repo using Python 3.7 or 3.8.

The expected outcome is that the system will display a `PendingDeprecationWarning` if it detects Python runtimes 3.7 or 3.8, will display nothing if using more recent Python runtimes 3.9 to 3.x



