### PR TITLE
testing: remove testing identity override

### DIFF
--- a/samples/snippets/view.py
+++ b/samples/snippets/view.py
@@ -147,7 +147,7 @@ def grant_access(
     # Make an API request to get the view dataset ACLs.
     view_dataset = client.get_dataset(view_dataset_id)
 
-    analyst_group_email = "data_analysts@example.com"
+    analyst_group_email = "example-analyst-group@google.com"
     # [END bigquery_grant_view_access]
     # To facilitate testing, we replace values with alternatives
     # provided by the testing harness.

--- a/samples/snippets/view_test.py
+++ b/samples/snippets/view_test.py
@@ -114,7 +114,6 @@ def test_view(
 
     project_id, dataset_id, table_id = view_id.split(".")
     overrides: view.OverridesDict = {
-        "analyst_group_email": "cloud-dpes-bigquery@google.com",
         "view_dataset_id": view_dataset_id,
         "source_dataset_id": source_dataset_id,
         "view_reference": {
@@ -127,5 +126,5 @@ def test_view(
     assert len(view_dataset.access_entries) != 0
     assert len(source_dataset.access_entries) != 0
     out, _ = capsys.readouterr()
-    assert "cloud-dpes-bigquery@google.com" in out
+    assert "example-analyst-group@google.com" in out
     assert table_id in out


### PR DESCRIPTION
This PR removes a stale reference to a membership group in samples tests.
