### PR TITLE
feat: include LegacyPandasError in init imports

### DIFF
--- a/google/cloud/bigquery/__init__.py
+++ b/google/cloud/bigquery/__init__.py
@@ -44,6 +44,7 @@ from google.cloud.bigquery.enums import KeyResultStatementKind
 from google.cloud.bigquery.enums import SqlTypeNames
 from google.cloud.bigquery.enums import StandardSqlTypeNames
 from google.cloud.bigquery.exceptions import LegacyBigQueryStorageError
+from google.cloud.bigquery.exceptions import LegacyPandasError
 from google.cloud.bigquery.exceptions import LegacyPyarrowError
 from google.cloud.bigquery.external_config import ExternalConfig
 from google.cloud.bigquery.external_config import BigtableOptions


### PR DESCRIPTION
LegacyPandasError was included in the __all__ list, but wasn't explicitly imported.

Fixes: https://github.com/googleapis/python-bigquery/issues/2000