### PR TITLE
docs: improve QueryJobConfig.destination docstring

### DIFF
--- a/google/cloud/bigquery/job/query.py
+++ b/google/cloud/bigquery/job/query.py
@@ -476,6 +476,9 @@ class QueryJobConfig(_JobConfig):
           ID, each separated by ``.``. For example:
           ``your-project.your_dataset.your_table``.
 
+        .. note::
+            Only table ID is passed to the backend, so any configuration
+            in `~google.cloud.bigquery.table.Table` is discarded.
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#JobConfigurationQuery.FIELDS.destination_table
         """

--- a/google/cloud/bigquery/job/query.py
+++ b/google/cloud/bigquery/job/query.py
@@ -477,8 +477,10 @@ class QueryJobConfig(_JobConfig):
           ``your-project.your_dataset.your_table``.
 
         .. note::
+
             Only table ID is passed to the backend, so any configuration
             in `~google.cloud.bigquery.table.Table` is discarded.
+
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#JobConfigurationQuery.FIELDS.destination_table
         """


### PR DESCRIPTION
Improve the docstring to note that only table ID is sent to the backend, thus no configs in `Table` will be preserved.

See b/365471371 for more info.

