### PR TITLE
feat: support setting max_stream_count when fetching query result

### DIFF
--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -1842,6 +1842,10 @@ class RowIterator(HTTPIterator):
                 using BigQuery Storage API. Ignored if
                 BigQuery Storage API is not used.
 
+                This setting also has no effect if the query result
+                is deterministically ordered with ORDER BY,
+                in which case, the number of download stream is always 1.
+
                 By default, this value is unnset, and the number of download
                 streams is determined by BigQuery the server. However, this behaviour
                 can require a lot of memory to store temporary download result,
@@ -2026,6 +2030,10 @@ class RowIterator(HTTPIterator):
                 The maximum number of parallel download streams when
                 using BigQuery Storage API. Ignored if
                 BigQuery Storage API is not used.
+
+                This setting also has no effect if the query result
+                is deterministically ordered with ORDER BY,
+                in which case, the number of download stream is always 1.
 
                 By default, this value is unnset, and the number of download
                 streams is determined by BigQuery the server. However, this behaviour

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -1846,11 +1846,12 @@ class RowIterator(HTTPIterator):
                 is deterministically ordered with ORDER BY,
                 in which case, the number of download stream is always 1.
 
-                By default, this value is unnset, and the number of download
+                If set to 0 or None (the default), the number of download
                 streams is determined by BigQuery the server. However, this behaviour
                 can require a lot of memory to store temporary download result,
-                especially with very large queries. If that's the case,
-                this parameter can be used to reduce memory consumption.
+                especially with very large queries. In that case,
+                setting this parameter value to a value > 0 can help
+                reduce system resource consumption.
 
         Returns:
             pyarrow.RecordBatch:
@@ -2035,11 +2036,12 @@ class RowIterator(HTTPIterator):
                 is deterministically ordered with ORDER BY,
                 in which case, the number of download stream is always 1.
 
-                By default, this value is unnset, and the number of download
+                If set to 0 or None (the default), the number of download
                 streams is determined by BigQuery the server. However, this behaviour
                 can require a lot of memory to store temporary download result,
-                especially with very large queries. If that's the case,
-                this parameter can be used to reduce memory consumption.
+                especially with very large queries. In that case,
+                setting this parameter value to a value > 0 can help
+                reduce system resource consumption.
 
         Returns:
             pandas.DataFrame:

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -1812,6 +1812,7 @@ class RowIterator(HTTPIterator):
         self,
         bqstorage_client: Optional["bigquery_storage.BigQueryReadClient"] = None,
         max_queue_size: int = _pandas_helpers._MAX_QUEUE_SIZE_DEFAULT,  # type: ignore
+        max_stream_count: Optional[int] = None,
     ) -> Iterator["pyarrow.RecordBatch"]:
         """[Beta] Create an iterable of class:`pyarrow.RecordBatch`, to process the table as a stream.
 
@@ -1836,6 +1837,17 @@ class RowIterator(HTTPIterator):
                 created by the server. If ``max_queue_size`` is :data:`None`, the queue
                 size is infinite.
 
+            max_stream_count (Optional[int]):
+                The maximum number of parallel download streams when
+                using BigQuery Storage API. Ignored if
+                BigQuery Storage API is not used.
+
+                By default, this value is unnset, and the number of download
+                streams is determined by BigQuery the server. However, this behaviour
+                can require a lot of memory to store temporary download result,
+                especially with very large queries. If that's the case,
+                this parameter can be used to reduce memory consumption.
+
         Returns:
             pyarrow.RecordBatch:
                 A generator of :class:`~pyarrow.RecordBatch`.
@@ -1852,6 +1864,7 @@ class RowIterator(HTTPIterator):
             preserve_order=self._preserve_order,
             selected_fields=self._selected_fields,
             max_queue_size=max_queue_size,
+            max_stream_count=max_stream_count,
         )
         tabledata_list_download = functools.partial(
             _pandas_helpers.download_arrow_row_iterator, iter(self.pages), self.schema
@@ -1978,6 +1991,7 @@ class RowIterator(HTTPIterator):
         bqstorage_client: Optional["bigquery_storage.BigQueryReadClient"] = None,
         dtypes: Optional[Dict[str, Any]] = None,
         max_queue_size: int = _pandas_helpers._MAX_QUEUE_SIZE_DEFAULT,  # type: ignore
+        max_stream_count: Optional[int] = None,
     ) -> "pandas.DataFrame":
         """Create an iterable of pandas DataFrames, to process the table as a stream.
 
@@ -2008,6 +2022,17 @@ class RowIterator(HTTPIterator):
 
                 .. versionadded:: 2.14.0
 
+            max_stream_count (Optional[int]):
+                The maximum number of parallel download streams when
+                using BigQuery Storage API. Ignored if
+                BigQuery Storage API is not used.
+
+                By default, this value is unnset, and the number of download
+                streams is determined by BigQuery the server. However, this behaviour
+                can require a lot of memory to store temporary download result,
+                especially with very large queries. If that's the case,
+                this parameter can be used to reduce memory consumption.
+
         Returns:
             pandas.DataFrame:
                 A generator of :class:`~pandas.DataFrame`.
@@ -2034,6 +2059,7 @@ class RowIterator(HTTPIterator):
             preserve_order=self._preserve_order,
             selected_fields=self._selected_fields,
             max_queue_size=max_queue_size,
+            max_stream_count=max_stream_count,
         )
         tabledata_list_download = functools.partial(
             _pandas_helpers.download_dataframe_row_iterator,

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -2724,6 +2724,7 @@ class _EmptyRowIterator(RowIterator):
         bqstorage_client: Optional["bigquery_storage.BigQueryReadClient"] = None,
         dtypes: Optional[Dict[str, Any]] = None,
         max_queue_size: Optional[int] = None,
+        max_stream_count: Optional[int] = None,
     ) -> Iterator["pandas.DataFrame"]:
         """Create an iterable of pandas DataFrames, to process the table as a stream.
 
@@ -2737,6 +2738,9 @@ class _EmptyRowIterator(RowIterator):
                 Ignored. Added for compatibility with RowIterator.
 
             max_queue_size:
+                Ignored. Added for compatibility with RowIterator.
+
+            max_stream_count:
                 Ignored. Added for compatibility with RowIterator.
 
         Returns:
@@ -2753,6 +2757,7 @@ class _EmptyRowIterator(RowIterator):
         self,
         bqstorage_client: Optional["bigquery_storage.BigQueryReadClient"] = None,
         max_queue_size: Optional[int] = None,
+        max_stream_count: Optional[int] = None,
     ) -> Iterator["pyarrow.RecordBatch"]:
         """Create an iterable of pandas DataFrames, to process the table as a stream.
 
@@ -2763,6 +2768,9 @@ class _EmptyRowIterator(RowIterator):
                 Ignored. Added for compatibility with RowIterator.
 
             max_queue_size:
+                Ignored. Added for compatibility with RowIterator.
+
+            max_stream_count:
                 Ignored. Added for compatibility with RowIterator.
 
         Returns:

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -5851,8 +5851,7 @@ def test_to_arrow_iterable_w_bqstorage_max_stream_count(preserve_order):
     result_iterable = row_iterator.to_arrow_iterable(
         bqstorage_client=bqstorage_client, max_stream_count=max_stream_count
     )
-    for _ in result_iterable:  # pragma: NO COVER
-        pass
+    list(result_iterable)
     bqstorage_client.create_read_session.assert_called_once_with(
         parent=mock.ANY,
         read_session=mock.ANY,
@@ -5887,8 +5886,7 @@ def test_to_dataframe_iterable_w_bqstorage_max_stream_count(preserve_order):
     result_iterable = row_iterator.to_dataframe_iterable(
         bqstorage_client=bqstorage_client, max_stream_count=max_stream_count
     )
-    for _ in result_iterable:  # pragma: NO COVER
-        pass
+    list(result_iterable)
     bqstorage_client.create_read_session.assert_called_once_with(
         parent=mock.ANY,
         read_session=mock.ANY,

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -5822,3 +5822,75 @@ def test_table_reference_to_bqstorage_v1_stable(table_path):
     for klass in (mut.TableReference, mut.Table, mut.TableListItem):
         got = klass.from_string(table_path).to_bqstorage()
         assert got == expected
+
+
+@pytest.mark.parametrize("preserve_order", [True, False])
+def test_to_arrow_iterable_w_bqstorage_max_stream_count(preserve_order):
+    pytest.importorskip("pandas")
+    pytest.importorskip("google.cloud.bigquery_storage")
+    from google.cloud.bigquery import schema
+    from google.cloud.bigquery import table as mut
+    from google.cloud import bigquery_storage
+
+    bqstorage_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
+    session = bigquery_storage.types.ReadSession()
+    bqstorage_client.create_read_session.return_value = session
+
+    row_iterator = mut.RowIterator(
+        _mock_client(),
+        api_request=None,
+        path=None,
+        schema=[
+            schema.SchemaField("colA", "INTEGER"),
+        ],
+        table=mut.TableReference.from_string("proj.dset.tbl"),
+    )
+    row_iterator._preserve_order = preserve_order
+
+    max_stream_count = 132
+    result_iterable = row_iterator.to_arrow_iterable(
+        bqstorage_client=bqstorage_client, max_stream_count=max_stream_count
+    )
+    for _ in result_iterable:  # pragma: NO COVER
+        pass
+    bqstorage_client.create_read_session.assert_called_once_with(
+        parent=mock.ANY,
+        read_session=mock.ANY,
+        max_stream_count=max_stream_count if not preserve_order else 1,
+    )
+
+
+@pytest.mark.parametrize("preserve_order", [True, False])
+def test_to_dataframe_iterable_w_bqstorage_max_stream_count(preserve_order):
+    pytest.importorskip("pandas")
+    pytest.importorskip("google.cloud.bigquery_storage")
+    from google.cloud.bigquery import schema
+    from google.cloud.bigquery import table as mut
+    from google.cloud import bigquery_storage
+
+    bqstorage_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
+    session = bigquery_storage.types.ReadSession()
+    bqstorage_client.create_read_session.return_value = session
+
+    row_iterator = mut.RowIterator(
+        _mock_client(),
+        api_request=None,
+        path=None,
+        schema=[
+            schema.SchemaField("colA", "INTEGER"),
+        ],
+        table=mut.TableReference.from_string("proj.dset.tbl"),
+    )
+    row_iterator._preserve_order = preserve_order
+
+    max_stream_count = 132
+    result_iterable = row_iterator.to_dataframe_iterable(
+        bqstorage_client=bqstorage_client, max_stream_count=max_stream_count
+    )
+    for _ in result_iterable:  # pragma: NO COVER
+        pass
+    bqstorage_client.create_read_session.assert_called_once_with(
+        parent=mock.ANY,
+        read_session=mock.ANY,
+        max_stream_count=max_stream_count if not preserve_order else 1,
+    )


### PR DESCRIPTION
Allow user to set max_stream_count when fetching result using BigQuery Storage API with incremental methods:

* to_arrow_iterable
* to_dataframe_iterable

Fixes #2030 🦕
