### PR TITLE
feat: adds two from_api_tests: StorageDesc & SerDeInfo

### DIFF
--- a/google/cloud/bigquery/schema.py
+++ b/google/cloud/bigquery/schema.py
@@ -892,6 +892,6 @@ class SerDeInfo:
         Returns:
             An instance of the class initialized with data from 'resource'.
         """
-        config = cls()
+        config = cls("")
         config._properties = copy.deepcopy(resource)
         return config

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -1161,6 +1161,23 @@ class TestForeignTypeInfo:
         assert result.to_api_repr() == expected
 
 
+@pytest.fixture
+def _make_storage_descriptor():
+    serdeinfo = SerDeInfo(
+        serialization_library="testpath.to.LazySimpleSerDe",
+        name="serde_lib_name",
+        parameters={"key": "value"},
+    )
+
+    obj = StorageDescriptor(
+        input_format="testpath.to.OrcInputFormat",
+        location_uri="gs://test/path/",
+        output_format="testpath.to.OrcOutputFormat",
+        serde_info=serdeinfo,
+    )
+    return obj
+
+
 class TestStorageDescriptor:
     """Tests for the StorageDescriptor class."""
 
@@ -1251,7 +1268,34 @@ class TestStorageDescriptor:
 
         assert storage_descriptor.to_api_repr() == expected_repr
 
-    # TODO: needs a from_api_repr() test.
+    SERDEINFO = SerDeInfo(
+        serialization_library="testpath.to.LazySimpleSerDe",
+        name="serde_lib_name",
+        parameters={"key": "value"},
+    )
+
+    API_REPR = {
+        "inputFormat": "testpath.to.OrcInputFormat",
+        "locationUri": "gs://test/path/",
+        "outputFormat": "testpath.to.OrcOutputFormat",
+        "serDeInfo": SERDEINFO.to_api_repr(),
+    }
+
+    def test_from_api_repr(self, _make_storage_descriptor):
+        """GIVEN an api representation of a StorageDescriptor (i.e. API_REPR)
+        WHEN converted into a StorageDescriptor using from_api_repr() and
+        displayed as a dict
+        THEN it will have the same representation a StorageDescriptor created
+        directly (via the fixture) and displayed as a dict.
+        """
+        # generate via fixture
+        expected = _make_storage_descriptor
+        resource = self.API_REPR
+        klass = self._get_target_class()
+        # generate via API_REPR
+        result = klass.from_api_repr(resource)
+
+        assert result.to_api_repr() == expected.to_api_repr()
 
 
 class TestSerDeInfo:
@@ -1315,4 +1359,26 @@ class TestSerDeInfo:
         }
         assert serde_info.to_api_repr() == expected_repr
 
-    # TODO: needs a from_api_repr() test.
+    def test_from_api_repr(self, _make_storage_descriptor):
+        """GIVEN an api representation of a SerDeInfo object (i.e. resource)
+        WHEN converted into a SerDeInfo using from_api_repr() and
+        displayed as a dict
+        THEN it will have the same representation a SerDeInfo object created
+        directly (via _make_one()) and displayed as a dict.
+        """
+        resource = {
+            "serializationLibrary": "testpath.to.LazySimpleSerDe",
+            "name": "serde_name",
+            "parameters": {"key": "value"},
+        }
+        
+        expected = self._make_one(
+            serialization_library="testpath.to.LazySimpleSerDe",
+            name="serde_name",
+            parameters={"key": "value"},
+        )
+                
+        klass = self._get_target_class()
+        result = klass.from_api_repr(resource)
+
+        assert result.to_api_repr() == expected.to_api_repr()

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -1371,13 +1371,13 @@ class TestSerDeInfo:
             "name": "serde_name",
             "parameters": {"key": "value"},
         }
-        
+
         expected = self._make_one(
             serialization_library="testpath.to.LazySimpleSerDe",
             name="serde_name",
             parameters={"key": "value"},
         )
-                
+
         klass = self._get_target_class()
         result = klass.from_api_repr(resource)
 


### PR DESCRIPTION
Adds a test to each of the test sets for:

StorageDescriptor: test_from_api_repr
SerDeInfo: test_from_api_repr

