### PR TITLE
fix: updates tests on getters to resolve coverage issues

### DIFF
--- a/google/cloud/bigquery/_helpers.py
+++ b/google/cloud/bigquery/_helpers.py
@@ -15,7 +15,6 @@
 """Shared helper functions for BigQuery API classes."""
 
 import base64
-import copy
 import datetime
 import decimal
 import json
@@ -1038,19 +1037,3 @@ def _isinstance_or_raise(
 
     msg = f"Pass {value} as a '{dtype}'{or_none}. Got {type(value)}."
     raise TypeError(msg)
-
-
-def _from_api_repr(cls, resource: dict):
-    """Factory: constructs an instance of the class (cls)
-    given its API representation.
-
-    Args:
-        resource (Dict[str, Any]):
-            API representation of the object to be instantiated.
-
-    Returns:
-        An instance of the class initialized with data from 'resource'.
-    """
-    config = cls
-    config._properties = copy.deepcopy(resource)
-    return config

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -26,7 +26,6 @@ from unittest import mock
 import google.api_core
 from google.cloud.bigquery._helpers import (
     _isinstance_or_raise,
-    _from_api_repr,
 )
 
 
@@ -1695,25 +1694,5 @@ class Test__isinstance_or_raise:
         ],
     )
     def test__invalid_isinstance_or_raise(self, value, dtype, none_allowed, expected):
-        with expected as e:
-            result = _isinstance_or_raise(value, dtype, none_allowed=none_allowed)
-
-            assert result == e
-
-
-class _MockClass:
-    def __init__(self):
-        self._properties = {}
-
-
-@pytest.fixture
-def mock_class():
-    return _MockClass
-
-
-class Test__from_api_repr:
-    def test_from_api_repr(self, mock_class):
-        resource = {"foo": "bar", "baz": {"qux": 1}}
-        config = _from_api_repr(mock_class, resource)
-        assert config._properties == resource
-        assert config._properties is not resource
+        with expected:
+            _isinstance_or_raise(value, dtype, none_allowed=none_allowed)

--- a/tests/unit/test_external_config.py
+++ b/tests/unit/test_external_config.py
@@ -930,10 +930,12 @@ class TestExternalCatalogDatasetOptions:
             parameters=parameters,
         )
 
-        assert instance._properties == {
-            "defaultStorageLocationUri": default_storage_location_uri,
-            "parameters": parameters,
-        }
+        # assert instance._properties == {
+        #     "defaultStorageLocationUri": default_storage_location_uri,
+        #     "parameters": parameters,
+        # }
+        assert instance.default_storage_location_uri == default_storage_location_uri
+        assert instance.parameters == parameters
 
     def test_ctor_invalid_input(self):
         """Test ExternalCatalogDatasetOptions constructor with invalid input."""
@@ -1024,16 +1026,16 @@ class TestExternalCatalogTableOptions:
             parameters=parameters,
             storage_descriptor=storage_descriptor,
         )
-
-        assert instance._properties["connectionId"] == connection_id
-        assert instance._properties["parameters"] == parameters
+        
+        assert instance.connection_id == connection_id
+        assert instance.parameters == parameters
         if storage_descriptor is not None:
             assert (
-                instance._properties["storageDescriptor"]
+                instance.storage_descriptor.to_api_repr()
                 == storage_descriptor.to_api_repr()
             )
         else:
-            assert instance._properties["storageDescriptor"] == storage_descriptor
+            assert instance.storage_descriptor == None
 
     @pytest.mark.parametrize(
         "connection_id, parameters, storage_descriptor",

--- a/tests/unit/test_external_config.py
+++ b/tests/unit/test_external_config.py
@@ -930,10 +930,6 @@ class TestExternalCatalogDatasetOptions:
             parameters=parameters,
         )
 
-        # assert instance._properties == {
-        #     "defaultStorageLocationUri": default_storage_location_uri,
-        #     "parameters": parameters,
-        # }
         assert instance.default_storage_location_uri == default_storage_location_uri
         assert instance.parameters == parameters
 
@@ -1026,7 +1022,7 @@ class TestExternalCatalogTableOptions:
             parameters=parameters,
             storage_descriptor=storage_descriptor,
         )
-        
+
         assert instance.connection_id == connection_id
         assert instance.parameters == parameters
         if storage_descriptor is not None:
@@ -1035,7 +1031,7 @@ class TestExternalCatalogTableOptions:
                 == storage_descriptor.to_api_repr()
             )
         else:
-            assert instance.storage_descriptor == None
+            assert instance.storage_descriptor is None
 
     @pytest.mark.parametrize(
         "connection_id, parameters, storage_descriptor",

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -1197,7 +1197,7 @@ class TestForeignTypeInfo:
     def test_ctor_valid_input(self, type_system, expected):
         result = self._make_one(type_system=type_system)
 
-        assert result._properties["typeSystem"] == expected
+        assert result.type_system == expected
 
     def test_ctor_invalid_input(self):
         with pytest.raises(TypeError) as e:
@@ -1293,15 +1293,15 @@ class TestStorageDescriptor:
             output_format=output_format,
             serde_info=serde_info,
         )
-        assert storage_descriptor._properties["inputFormat"] == input_format
-        assert storage_descriptor._properties["locationUri"] == location_uri
-        assert storage_descriptor._properties["outputFormat"] == output_format
+        assert storage_descriptor.input_format == input_format
+        assert storage_descriptor.location_uri == location_uri
+        assert storage_descriptor.output_format == output_format
         if serde_info is not None:
             assert (
-                storage_descriptor._properties["serDeInfo"] == serde_info.to_api_repr()
+                storage_descriptor.serde_info == serde_info.to_api_repr()
             )
         else:
-            assert storage_descriptor._properties["serDeInfo"] == serde_info
+            assert storage_descriptor.serde_info == serde_info
 
     @pytest.mark.parametrize(
         "input_format,location_uri,output_format,serde_info",
@@ -1397,9 +1397,9 @@ class TestSerDeInfo:
             name=name,
             parameters=parameters,
         )
-        assert serde_info._properties["serializationLibrary"] == serialization_library
-        assert serde_info._properties["name"] == name
-        assert serde_info._properties["parameters"] == parameters
+        assert serde_info.serialization_library == serialization_library
+        assert serde_info.name == name
+        assert serde_info.parameters == parameters
 
     @pytest.mark.parametrize(
         "serialization_library,name,parameters",

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -1298,10 +1298,10 @@ class TestStorageDescriptor:
         assert storage_descriptor.output_format == output_format
         if serde_info is not None:
             assert (
-                storage_descriptor.serde_info == serde_info.to_api_repr()
+                storage_descriptor.serde_info.to_api_repr() == serde_info.to_api_repr()
             )
         else:
-            assert storage_descriptor.serde_info == serde_info
+            assert storage_descriptor.serde_info is None
 
     @pytest.mark.parametrize(
         "input_format,location_uri,output_format,serde_info",


### PR DESCRIPTION
fix: updates tests on getters to resolve coverage issues for the new PANGEA objects and removes a test that is no longer used.

Covers tests in:
* test_external_config.py
* test_schema.py
* test__helpers.py

