### PR TITLE
fix: add default value in SchemaField.from_api_repr()

### DIFF
--- a/google/cloud/bigquery/schema.py
+++ b/google/cloud/bigquery/schema.py
@@ -228,6 +228,12 @@ class SchemaField(object):
         # fields. See https://github.com/googleapis/python-bigquery/issues/6
         placeholder._properties = api_repr
 
+        # Add the field `mode` with default value if it does not exist. Fixes
+        # an incompatibility issue with pandas-gbq:
+        # https://github.com/googleapis/python-bigquery-pandas/issues/854
+        if "mode" not in placeholder._properties:
+            placeholder._properties["mode"] = "NULLABLE"
+
         return placeholder
 
     @property


### PR DESCRIPTION
Fixing https://github.com/googleapis/python-bigquery-pandas/issues/854, do not merge until yanking 3.28.0 is complete.

In https://github.com/googleapis/python-bigquery/pull/2097/files#diff-dc8e320384c6a5d2b65e1e05c4853b853575618ff4706a6f2c74b9363d49ea14 in method `SchemaField.from_api_repr()`, we no longer set a default value for `mode` if it's not provided in the API representation, causing tests to fail in pandas-gbq. This PR adds it back.


