### PR TITLE
feat: add ExternalCatalogTableOptions class and tests

### DIFF
--- a/google/cloud/bigquery/external_config.py
+++ b/google/cloud/bigquery/external_config.py
@@ -1109,7 +1109,7 @@ class ExternalCatalogTableOptions:
         self.storage_descriptor = storage_descriptor
 
     @property
-    def connection_id(self):
+    def connection_id(self) -> Optional[str]:
         """Optional. The connection specifying the credentials to be
         used to read external storage, such as Azure Blob, Cloud Storage, or
         S3. The connection is needed to read the open source table from
@@ -1125,7 +1125,7 @@ class ExternalCatalogTableOptions:
         self._properties["connectionId"] = value
 
     @property
-    def parameters(self) -> Any:
+    def parameters(self) -> Union[Dict[str, Any], None]:
         """Optional. A map of key value pairs defining the parameters and
         properties of the open source table. Corresponds with hive meta
         store table parameters. Maximum size of 4Mib.
@@ -1150,7 +1150,7 @@ class ExternalCatalogTableOptions:
         return None
 
     @storage_descriptor.setter
-    def storage_descriptor(self, value):
+    def storage_descriptor(self, value: Union[schema.StorageDescriptor, dict, None]):
         value = _helpers._isinstance_or_raise(
             value, (schema.StorageDescriptor, dict), none_allowed=True
         )

--- a/google/cloud/bigquery/external_config.py
+++ b/google/cloud/bigquery/external_config.py
@@ -30,6 +30,7 @@ from google.cloud.bigquery._helpers import _int_or_none
 from google.cloud.bigquery._helpers import _str_or_none
 from google.cloud.bigquery import _helpers
 from google.cloud.bigquery.format_options import AvroOptions, ParquetOptions
+from google.cloud.bigquery import schema
 from google.cloud.bigquery.schema import SchemaField
 
 
@@ -1073,6 +1074,112 @@ class ExternalCatalogDatasetOptions:
 
         Returns:
             An instance of the class initialized with data from 'resource'.
+        """
+        config = cls()
+        config._properties = api_repr
+        return config
+
+
+class ExternalCatalogTableOptions:
+    """Metadata about open source compatible table. The fields contained in these
+    options correspond to hive metastore's table level properties.
+
+    Args:
+        connection_id  (Optional[str]): The connection specifying the credentials to be
+            used to read external storage, such as Azure Blob, Cloud Storage, or
+            S3. The connection is needed to read the open source table from
+            BigQuery Engine. The connection_id can have the form `..` or
+            `projects//locations//connections/`.
+        parameters (Union[Dict[str, Any], None]): A map of key value pairs defining the parameters
+            and properties of the open source table. Corresponds with hive meta
+            store table parameters. Maximum size of 4Mib.
+        storage_descriptor (Optional[StorageDescriptor]): A storage descriptor containing information
+            about the physical storage of this table.
+    """
+
+    def __init__(
+        self,
+        connection_id: Optional[str] = None,
+        parameters: Union[Dict[str, Any], None] = None,
+        storage_descriptor: Optional[schema.StorageDescriptor] = None,
+    ):
+        self._properties: Dict[str, Any] = {}
+        self.connection_id = connection_id
+        self.parameters = parameters
+        self.storage_descriptor = storage_descriptor
+
+    @property
+    def connection_id(self):
+        """Optional. The connection specifying the credentials to be
+        used to read external storage, such as Azure Blob, Cloud Storage, or
+        S3. The connection is needed to read the open source table from
+        BigQuery Engine. The connection_id can have the form `..` or
+        `projects//locations//connections/`.
+        """
+
+        return self._properties.get("connectionId")
+
+    @connection_id.setter
+    def connection_id(self, value: Optional[str]):
+        value = _helpers._isinstance_or_raise(value, str, none_allowed=True)
+        self._properties["connectionId"] = value
+
+    @property
+    def parameters(self) -> Any:
+        """Optional. A map of key value pairs defining the parameters and
+        properties of the open source table. Corresponds with hive meta
+        store table parameters. Maximum size of 4Mib.
+        """
+
+        return self._properties.get("parameters")
+
+    @parameters.setter
+    def parameters(self, value: Union[Dict[str, Any], None]):
+        value = _helpers._isinstance_or_raise(value, dict, none_allowed=True)
+        self._properties["parameters"] = value
+
+    @property
+    def storage_descriptor(self) -> Any:
+        """Optional. A storage descriptor containing information about the
+        physical storage of this table."""
+
+        prop = _helpers._get_sub_prop(self._properties, ["storageDescriptor"])
+
+        if prop is not None:
+            return schema.StorageDescriptor.from_api_repr(prop)
+        return None
+
+    @storage_descriptor.setter
+    def storage_descriptor(self, value):
+        value = _helpers._isinstance_or_raise(
+            value, (schema.StorageDescriptor, dict), none_allowed=True
+        )
+        if isinstance(value, schema.StorageDescriptor):
+            self._properties["storageDescriptor"] = value.to_api_repr()
+        else:
+            self._properties["storageDescriptor"] = value
+
+    def to_api_repr(self) -> dict:
+        """Build an API representation of this object.
+
+        Returns:
+            Dict[str, Any]:
+                A dictionary in the format used by the BigQuery API.
+        """
+
+        return self._properties
+
+    @classmethod
+    def from_api_repr(cls, api_repr: dict) -> ExternalCatalogTableOptions:
+        """Factory: constructs an instance of the class (cls)
+        given its API representation.
+
+        Args:
+            api_repr (Dict[str, Any]):
+                API representation of the object to be instantiated.
+
+        Returns:
+            An instance of the class initialized with data from 'api_repr'.
         """
         config = cls()
         config._properties = api_repr

--- a/google/cloud/bigquery/magics/magics.py
+++ b/google/cloud/bigquery/magics/magics.py
@@ -56,7 +56,7 @@ except ImportError:
     bigquery_magics = None
 
 
-IPYTHON_USER_AGENT = "ipython-{}".format(IPython.__version__)
+IPYTHON_USER_AGENT = "ipython-{}".format(IPython.__version__)  # type: ignore
 
 
 class Context(object):

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -69,6 +69,7 @@ from google.cloud.bigquery.external_config import ExternalConfig
 from google.cloud.bigquery.schema import _build_schema_resource
 from google.cloud.bigquery.schema import _parse_schema_resource
 from google.cloud.bigquery.schema import _to_schema_fields
+from google.cloud.bigquery import external_config
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
     # Unconditionally import optional dependencies again to tell pytype that
@@ -408,6 +409,7 @@ class Table(_TableBase):
         "require_partition_filter": "requirePartitionFilter",
         "table_constraints": "tableConstraints",
         "max_staleness": "maxStaleness",
+        "external_catalog_table_options": "externalCatalogTableOptions",
     }
 
     def __init__(self, table_ref, schema=None) -> None:
@@ -1022,6 +1024,28 @@ class Table(_TableBase):
         if table_constraints is not None:
             table_constraints = TableConstraints.from_api_repr(table_constraints)
         return table_constraints
+
+    @property
+    def external_catalog_table_options(self):
+        """Options defining open source compatible datasets living in the
+        BigQuery catalog. Contains metadata of open source database, schema
+        or namespace represented by the current dataset."""
+
+        prop = self._properties.get(
+            self._PROPERTY_TO_API_FIELD["external_catalog_table_options"]
+        )
+        if prop is not None:
+            prop = external_config.ExternalCatalogTableOptions.from_api_repr(prop)
+        return prop
+
+    @external_catalog_table_options.setter
+    def external_catalog_table_options(self, value):
+        value = _helpers._isinstance_or_raise(
+            value, external_config.ExternalCatalogTableOptions, none_allowed=True
+        )
+        self._properties[
+            self._PROPERTY_TO_API_FIELD["external_catalog_table_options"]
+        ] = value.to_api_repr()
 
     @classmethod
     def from_string(cls, full_table_id: str) -> "Table":

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -1026,7 +1026,9 @@ class Table(_TableBase):
         return table_constraints
 
     @property
-    def external_catalog_table_options(self):
+    def external_catalog_table_options(
+        self,
+    ) -> Optional[external_config.ExternalCatalogTableOptions]:
         """Options defining open source compatible datasets living in the
         BigQuery catalog. Contains metadata of open source database, schema
         or namespace represented by the current dataset."""
@@ -1035,17 +1037,26 @@ class Table(_TableBase):
             self._PROPERTY_TO_API_FIELD["external_catalog_table_options"]
         )
         if prop is not None:
-            prop = external_config.ExternalCatalogTableOptions.from_api_repr(prop)
-        return prop
+            return external_config.ExternalCatalogTableOptions.from_api_repr(prop)
+        return None
 
     @external_catalog_table_options.setter
-    def external_catalog_table_options(self, value):
+    def external_catalog_table_options(
+        self, value: Union[external_config.ExternalCatalogTableOptions, dict, None]
+    ):
         value = _helpers._isinstance_or_raise(
-            value, external_config.ExternalCatalogTableOptions, none_allowed=True
+            value,
+            (external_config.ExternalCatalogTableOptions, dict),
+            none_allowed=True,
         )
-        self._properties[
-            self._PROPERTY_TO_API_FIELD["external_catalog_table_options"]
-        ] = value.to_api_repr()
+        if isinstance(value, external_config.ExternalCatalogTableOptions):
+            self._properties[
+                self._PROPERTY_TO_API_FIELD["external_catalog_table_options"]
+            ] = value.to_api_repr()
+        else:
+            self._properties[
+                self._PROPERTY_TO_API_FIELD["external_catalog_table_options"]
+            ] = value
 
     @classmethod
     def from_string(cls, full_table_id: str) -> "Table":


### PR DESCRIPTION
This PR adds the ExternalCatalogTableOptions class and the associated tests, plus minor tweaks to support both of those changes.

IN ADDITION, mypy was balking on an issue in magics, so a minor tweak to ignore the type of an object that comes from IPython was added.