### PR TITLE
test: add unit test covering the case where worker streams are stopped early

### DIFF
--- a/samples/tests/test_download_public_data.py
+++ b/samples/tests/test_download_public_data.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
 import pytest
 
 from .. import download_public_data
@@ -21,20 +19,9 @@ from .. import download_public_data
 pytest.importorskip("google.cloud.bigquery_storage_v1")
 
 
-def test_download_public_data(
-    caplog: pytest.LogCaptureFixture, capsys: pytest.CaptureFixture[str]
-) -> None:
-    # Enable debug-level logging to verify the BigQuery Storage API is used.
-    caplog.set_level(logging.DEBUG)
-
+def test_download_public_data(capsys: pytest.CaptureFixture[str]) -> None:
     download_public_data.download_public_data()
     out, _ = capsys.readouterr()
     assert "year" in out
     assert "gender" in out
     assert "name" in out
-
-    assert any(
-        "Started reading table 'bigquery-public-data.usa_names.usa_1910_current' with BQ Storage API session"
-        in message
-        for message in caplog.messages
-    )

--- a/samples/tests/test_download_public_data_sandbox.py
+++ b/samples/tests/test_download_public_data_sandbox.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
 import pytest
 
 from .. import download_public_data_sandbox
@@ -21,20 +19,9 @@ from .. import download_public_data_sandbox
 pytest.importorskip("google.cloud.bigquery_storage_v1")
 
 
-def test_download_public_data_sandbox(
-    caplog: pytest.LogCaptureFixture, capsys: pytest.CaptureFixture[str]
-) -> None:
-    # Enable debug-level logging to verify the BigQuery Storage API is used.
-    caplog.set_level(logging.DEBUG)
-
+def test_download_public_data_sandbox(capsys: pytest.CaptureFixture[str]) -> None:
     download_public_data_sandbox.download_public_data_sandbox()
-    out, err = capsys.readouterr()
+    out, _ = capsys.readouterr()
     assert "year" in out
     assert "gender" in out
     assert "name" in out
-
-    assert any(
-        # An anonymous table is used because this sample reads from query results.
-        ("Started reading table" in message and "BQ Storage API session" in message)
-        for message in caplog.messages
-    )

--- a/tests/unit/test__pandas_helpers.py
+++ b/tests/unit/test__pandas_helpers.py
@@ -1874,10 +1874,10 @@ def test__download_table_bqstorage_shuts_down_workers(
         ]
     )
     arrow_rows = pyarrow.record_batch(
-        {
-            "int_col": [0, 1, 2],
-            "str_col": ["a", "b", "c"],
-        },
+        [
+            pyarrow.array([0, 1, 2], type=pyarrow.int64()),
+            pyarrow.array(["a", "b", "c"], type=pyarrow.string()),
+        ],
         schema=arrow_schema,
     )
     session = google.cloud.bigquery_storage_v1.types.ReadSession()

--- a/tests/unit/test__pandas_helpers.py
+++ b/tests/unit/test__pandas_helpers.py
@@ -16,6 +16,7 @@ import collections
 import datetime
 import decimal
 import functools
+import gc
 import operator
 import queue
 from typing import Union
@@ -1929,7 +1930,11 @@ def test__download_table_bqstorage_shuts_down_workers(
     assert download_state.started_workers == 3
     assert download_state.finished_workers == 0
 
+    # Stop iteration early and simulate the variables going out of scope
+    # to be doubly sure that the worker threads are supposed to be cleaned up.
     del result_gen, result_gen_iter
+    gc.collect()
+
     assert download_state.started_workers == 3
     assert download_state.finished_workers == 3
 


### PR DESCRIPTION
This PR is a follow-up to https://github.com/googleapis/python-bigquery/pull/2034 with the purpose of testing the error condition.

Note: I have confirmed that this test fails without the changes from https://github.com/googleapis/python-bigquery/pull/2034. Actually, it hangs forever because the child threads aren't shutdown but the assertions do fail when I step through with a debugger.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #2032 🦕
