### PR TITLE
deps: updates required checks list in github

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -10,8 +10,8 @@ branchProtectionRules:
   requiresStrictStatusChecks: true
   requiredStatusCheckContexts:
     - 'Kokoro'
-    - 'Kokoro snippets-3.12'
     - 'Kokoro system-3.12'
+    - 'Kokoro snippets-3.12'
     - 'cla/google'
     - 'Samples - Lint'
     - 'Samples - Python 3.9'

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -10,9 +10,7 @@ branchProtectionRules:
   requiresStrictStatusChecks: true
   requiredStatusCheckContexts:
     - 'Kokoro'
-    - 'Kokoro snippets-3.9'
     - 'Kokoro snippets-3.12'
-    - 'Kokoro system-3.9'
     - 'Kokoro system-3.12'
     - 'cla/google'
     - 'Samples - Lint'
@@ -26,7 +24,6 @@ branchProtectionRules:
   requiresStrictStatusChecks: true
   requiredStatusCheckContexts:
     - 'Kokoro'
-    - 'Kokoro snippets-3.9'
     - 'cla/google'
     - 'Samples - Lint'
     - 'Samples - Python 3.9'

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -10,14 +10,12 @@ branchProtectionRules:
   requiresStrictStatusChecks: true
   requiredStatusCheckContexts:
     - 'Kokoro'
-    - 'Kokoro snippets-3.8'
+    - 'Kokoro snippets-3.9'
     - 'Kokoro snippets-3.12'
-    - 'Kokoro system-3.8'
+    - 'Kokoro system-3.9'
     - 'Kokoro system-3.12'
     - 'cla/google'
     - 'Samples - Lint'
-    - 'Samples - Python 3.7'
-    - 'Samples - Python 3.8'
     - 'Samples - Python 3.9'
     - 'Samples - Python 3.10'
     - 'Samples - Python 3.11'
@@ -28,8 +26,8 @@ branchProtectionRules:
   requiresStrictStatusChecks: true
   requiredStatusCheckContexts:
     - 'Kokoro'
-    - 'Kokoro snippets-3.8'
+    - 'Kokoro snippets-3.9'
     - 'cla/google'
     - 'Samples - Lint'
-    - 'Samples - Python 3.7'
-    - 'Samples - Python 3.8'
+    - 'Samples - Python 3.9'
+    - 'Samples - Python 3.10'


### PR DESCRIPTION
Removes Required status for github checks against Python versions 3.7 and 3.8. These checks have been removed upstream in google3 and will no longer run. Thus these github checks will never finish, blocking the ability to merge PRs.

PR #2133 will further update this file to require checks of 3.9, as part of a larger effort.