### PR TITLE
feat: Update the AccessEntry class with a new condition attribute and unit tests

### DIFF
--- a/google/cloud/bigquery/dataset.py
+++ b/google/cloud/bigquery/dataset.py
@@ -300,11 +300,11 @@ class AccessEntry(object):
         entity_id: Optional[Union[Dict[str, Any], str]] = None,
         **kwargs,
     ):
-        self._properties = {}
+        self._properties: Dict[str, Any] = {}
         if entity_type is not None:
             self._properties[entity_type] = entity_id
         self._properties["role"] = role
-        self._entity_type = entity_type
+        self._entity_type: Optional[str] = entity_type
         for prop, val in kwargs.items():
             setattr(self, prop, val)
 
@@ -491,9 +491,13 @@ class AccessEntry(object):
     @property
     def entity_id(self) -> Optional[Union[Dict[str, Any], str]]:
         """The entity_id of the entry."""
+        if self.entity_type:
+            entity_type = self.entity_type
+        else:
+            return None
         return typing.cast(
             Optional[Union[Dict[str, Any], str]],
-            self._properties.get(self.entity_type, None),
+            self._properties.get(entity_type, None),
         )
 
     def __eq__(self, other):

--- a/google/cloud/bigquery/dataset.py
+++ b/google/cloud/bigquery/dataset.py
@@ -484,7 +484,7 @@ class AccessEntry(object):
             except KeyError:
                 entity_type = None
 
-        self._entity_type = entity_type
+            self._entity_type = entity_type
 
         return self._entity_type
 

--- a/google/cloud/bigquery/dataset.py
+++ b/google/cloud/bigquery/dataset.py
@@ -493,7 +493,7 @@ class AccessEntry(object):
         """The entity_id of the entry."""
         return typing.cast(
             Optional[Union[Dict[str, Any], str]],
-            self._properties.get(self._entity_type) if self._entity_type else None,
+            self._properties.get(self._entity_type, None),
         )
 
     def __eq__(self, other):

--- a/google/cloud/bigquery/dataset.py
+++ b/google/cloud/bigquery/dataset.py
@@ -493,7 +493,7 @@ class AccessEntry(object):
         """The entity_id of the entry."""
         return typing.cast(
             Optional[Union[Dict[str, Any], str]],
-            self._properties.get(self._entity_type, None),
+            self._properties.get(self.entity_type, None),
         )
 
     def __eq__(self, other):

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -19,6 +19,7 @@ from google.cloud.bigquery.routine.routine import Routine, RoutineReference
 import pytest
 from google.cloud.bigquery.dataset import (
     AccessEntry,
+    Condition,
     Dataset,
     DatasetReference,
     Table,
@@ -1228,3 +1229,150 @@ class TestDatasetListItem(unittest.TestCase):
         self.assertEqual(table.table_id, "table_id")
         self.assertEqual(table.dataset_id, dataset_id)
         self.assertEqual(table.project, project)
+
+
+class TestCondition:
+    EXPRESSION = 'resource.name.startsWith("projects/my-project/instances/")'
+    TITLE = "Instance Access"
+    DESCRIPTION = "Access to instances in my-project"
+
+    @pytest.fixture
+    def condition_instance(self):
+        """Provides a Condition instance for tests."""
+        return Condition(
+            expression=self.EXPRESSION,
+            title=self.TITLE,
+            description=self.DESCRIPTION,
+        )
+
+    @pytest.fixture
+    def condition_api_repr(self):
+        """Provides the API representation for the test Condition."""
+        return {
+            "expression": self.EXPRESSION,
+            "title": self.TITLE,
+            "description": self.DESCRIPTION,
+        }
+
+    # --- Basic Functionality Tests ---
+
+    def test_constructor_and_getters_full(self, condition_instance):
+        """Test initialization with all arguments and subsequent attribute access."""
+        assert condition_instance.expression == self.EXPRESSION
+        assert condition_instance.title == self.TITLE
+        assert condition_instance.description == self.DESCRIPTION
+
+    def test_constructor_and_getters_minimal(self):
+        """Test initialization with only the required expression."""
+        condition = Condition(expression=self.EXPRESSION)
+        assert condition.expression == self.EXPRESSION
+        assert condition.title is None
+        assert condition.description is None
+
+    def test_setters(self, condition_instance):
+        """Test setting attributes after initialization."""
+        new_title = "New Title"
+        new_desc = "New Description"
+        new_expr = "request.time < timestamp('2024-01-01T00:00:00Z')"
+
+        condition_instance.title = new_title
+        assert condition_instance.title == new_title
+
+        condition_instance.description = new_desc
+        assert condition_instance.description == new_desc
+
+        condition_instance.expression = new_expr
+        assert condition_instance.expression == new_expr
+
+        # Test setting optional fields back to None
+        condition_instance.title = None
+        assert condition_instance.title is None
+        condition_instance.description = None
+        assert condition_instance.description is None
+
+    # --- API Representation Tests ---
+
+    def test_to_api_repr_full(self, condition_instance, condition_api_repr):
+        """Test converting a fully populated Condition to API representation."""
+        api_repr = condition_instance.to_api_repr()
+        assert api_repr == condition_api_repr
+
+    def test_to_api_repr_minimal(self):
+        """Test converting a minimally populated Condition to API representation."""
+        condition = Condition(expression=self.EXPRESSION)
+        expected_api_repr = {
+            "expression": self.EXPRESSION,
+            "title": None,
+            "description": None,
+        }
+        api_repr = condition.to_api_repr()
+        assert api_repr == expected_api_repr
+
+    def test_from_api_repr_full(self, condition_api_repr):
+        """Test creating a Condition from a full API representation."""
+        condition = Condition.from_api_repr(condition_api_repr)
+        assert condition.expression == self.EXPRESSION
+        assert condition.title == self.TITLE
+        assert condition.description == self.DESCRIPTION
+
+    def test_from_api_repr_minimal(self):
+        """Test creating a Condition from a minimal API representation."""
+        minimal_repr = {"expression": self.EXPRESSION}
+        condition = Condition.from_api_repr(minimal_repr)
+        assert condition.expression == self.EXPRESSION
+        assert condition.title is None
+        assert condition.description is None
+
+    def test_from_api_repr_with_extra_fields(self):
+        """Test creating a Condition from an API repr with unexpected fields."""
+        api_repr = {
+            "expression": self.EXPRESSION,
+            "title": self.TITLE,
+            "unexpected_field": "some_value",
+        }
+        condition = Condition.from_api_repr(api_repr)
+        assert condition.expression == self.EXPRESSION
+        assert condition.title == self.TITLE
+        assert condition.description is None
+        # Check that the extra field didn't get added to internal properties
+        assert "unexpected_field" not in condition._properties
+
+    #     # --- Validation Tests ---
+
+    @pytest.mark.parametrize(
+        "kwargs, error_msg",
+        [
+            ({"expression": None}, "Pass a non-empty string for expression"),  # type: ignore
+            ({"expression": ""}, "expression cannot be an empty string"),
+            ({"expression": 123}, "Pass a non-empty string for expression"),  # type: ignore
+            ({"expression": EXPRESSION, "title": 123}, "Pass a string for title, or None"),  # type: ignore
+            ({"expression": EXPRESSION, "description": False}, "Pass a string for description, or None"),  # type: ignore
+        ],
+    )
+    def test_validation_init(self, kwargs, error_msg):
+        """Test validation during __init__."""
+        with pytest.raises(ValueError, match=error_msg):
+            Condition(**kwargs)
+
+    @pytest.mark.parametrize(
+        "attribute, value, error_msg",
+        [
+            ("expression", None, "Pass a non-empty string for expression"),  # type: ignore
+            ("expression", "", "expression cannot be an empty string"),
+            ("expression", 123, "Pass a non-empty string for expression"),  # type: ignore
+            ("title", 123, "Pass a string for title, or None"),  # type: ignore
+            ("description", [], "Pass a string for description, or None"),  # type: ignore
+        ],
+    )
+    def test_validation_setters(self, condition_instance, attribute, value, error_msg):
+        """Test validation via setters."""
+        with pytest.raises(ValueError, match=error_msg):
+            setattr(condition_instance, attribute, value)
+
+    def test_validation_expression_required_from_api(self):
+        """Test ValueError is raised if expression is missing in from_api_repr."""
+        api_repr = {"title": self.TITLE}
+        with pytest.raises(
+            ValueError, match="API representation missing required 'expression' field."
+        ):
+            Condition.from_api_repr(api_repr)

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -1626,3 +1626,40 @@ class TestCondition:
             ValueError, match="API representation missing required 'expression' field."
         ):
             Condition.from_api_repr(api_repr)
+
+    def test___eq___equality(self, condition_1):
+        result = condition_1
+        expected = condition_1
+        assert result == expected
+
+    def test___eq___equality_not_condition(self, condition_1):
+        result = condition_1
+        other = "not a condition"
+        expected = result.__eq__(other)
+        assert expected is NotImplemented
+
+    def test__ne__not_equality(self):
+        result = condition_1
+        expected = condition_2
+        assert result != expected
+
+    def test__hash__function(self, condition_2):
+        cond1 = Condition(
+            expression=self.EXPRESSION, title=self.TITLE, description=self.DESCRIPTION
+        )
+        cond2 = cond1
+        cond_not_equal = condition_2
+        assert cond1 == cond2
+        assert cond1 is cond2
+        assert hash(cond1) == hash(cond2)
+        assert hash(cond1) is not None
+        assert cond_not_equal != cond1
+        assert hash(cond_not_equal) != hash(cond1)
+
+    def test__hash__with_minimal_inputs(self):
+        cond1 = Condition(
+            expression="example",
+            title=None,
+            description=None,
+        )
+        assert hash(cond1) is not None

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -1072,7 +1072,7 @@ class TestDataset(unittest.TestCase):
             dataset.path, "/projects/%s/datasets/%s" % (OTHER_PROJECT, self.DS_ID)
         )
         # creating a list of entries relies on AccessEntry.from_api_repr
-        # which does no create an object in exactly the same way as calling the
+        # which does not create an object in exactly the same way as calling the
         # class directly. We rely on calls to .entity_type and .entity_id to
         # finalize the settings on each class.
         entry_pairs = zip(dataset.access_entries, entries)

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -1116,7 +1116,7 @@ class TestDataset(unittest.TestCase):
         dataset.access_entries = entries
 
         # creating a list of entries relies on AccessEntry.from_api_repr
-        # which does no create an object in exactly the same way as calling the
+        # which does not create an object in exactly the same way as calling the
         # class directly. We rely on calls to .entity_type and .entity_id to
         # finalize the settings on each class.
         entry_pairs = zip(dataset.access_entries, entries)

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -588,6 +588,10 @@ class TestAccessEntryAndCondition:
         entry.condition = None
         assert entry.condition is None
 
+        # Set condition using a dict
+        entry.condition = condition_1_api_repr
+        assert entry._properties.get("condition") == condition_1_api_repr
+
     # Test setter validation
     def test_condition_setter_invalid_type(self):
         entry = AccessEntry("READER", "domain", "example.com")

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -729,12 +729,6 @@ class TestAccessEntryAndCondition:
         entry.condition = condition_1
 
         resource = entry.to_api_repr()
-        print(
-            f"""
-        DINOSAUR:
-        {resource}
-        """
-        )
         exp_resource = {
             "role": None,
             "dataset": {

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -301,7 +301,10 @@ class TestAccessEntry(unittest.TestCase):
         entry.dataset = dataset_ref
         resource = entry.to_api_repr()
         exp_resource = {
-            "dataset": {"dataset": dataset_ref, "targetTypes": None},
+            "dataset": {
+                "dataset": {"datasetId": "my_dataset", "projectId": "my-project"},
+                "targetTypes": None,
+            },
             "role": None,
         }
         self.assertEqual(resource, exp_resource)
@@ -726,10 +729,16 @@ class TestAccessEntryAndCondition:
         entry.condition = condition_1
 
         resource = entry.to_api_repr()
+        print(
+            f"""
+        DINOSAUR:
+        {resource}
+        """
+        )
         exp_resource = {
             "role": None,
             "dataset": {
-                "dataset": DatasetReference("my-project", "my_dataset"),
+                "dataset": {"datasetId": "my_dataset", "projectId": "my-project"},
                 "targetTypes": None,
             },
             "condition": {


### PR DESCRIPTION
Updates the `AccessEntry` class with a new `condition` attribute and unit tests.

Specifically:

* Adds a condition attribute to the AccessEntry class
* Updates the pre-existing Condition class with several dunder methods (__eq__, __hash__, etc)
* Adds unit tests to put the condition setters, getters, etc through their paces
* Adds unit tests to exercise the new Condition dunder methods

This work is in support of internal bug: b/330869964
