### PR TITLE
fix: fix rows returned when both start_index and page_size are provided

### DIFF
--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -2005,16 +2005,19 @@ class Client(ClientWithProject):
                 before using ``retry``. If set, this connection timeout may be
                 increased to a minimum value. This prevents retries on what
                 would otherwise be a successful response.
-            page_size (int):
+            page_size (Optional[int]):
                 Maximum number of rows in a single response. See maxResults in
                 the jobs.getQueryResults REST API.
+            start_index (Optional[int]):
+                Zero-based index of the starting row. See startIndex in the
+                jobs.getQueryResults REST API.
 
         Returns:
             google.cloud.bigquery.query._QueryResults:
                 A new ``_QueryResults`` instance.
         """
 
-        extra_params: Dict[str, Any] = {"maxResults": page_size, "startIndex": start_index}
+        extra_params: Dict[str, Any] = {"maxResults": page_size}
 
         if timeout is not None:
             if not isinstance(timeout, (int, float)):
@@ -2036,6 +2039,9 @@ class Client(ClientWithProject):
 
         if location is not None:
             extra_params["location"] = location
+
+        if start_index is not None:
+            extra_params["startIndex"] = start_index
 
         path = "/projects/{}/queries/{}".format(project, job_id)
 

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -1975,6 +1975,7 @@ class Client(ClientWithProject):
         location: Optional[str] = None,
         timeout: TimeoutType = DEFAULT_TIMEOUT,
         page_size: int = 0,
+        start_index: Optional[int] = None,
     ) -> _QueryResults:
         """Get the query results object for a query job.
 
@@ -2002,7 +2003,7 @@ class Client(ClientWithProject):
                 A new ``_QueryResults`` instance.
         """
 
-        extra_params: Dict[str, Any] = {"maxResults": page_size}
+        extra_params: Dict[str, Any] = {"maxResults": page_size, "startIndex": start_index}
 
         if timeout is not None:
             if not isinstance(timeout, (int, float)):
@@ -2040,6 +2041,7 @@ class Client(ClientWithProject):
             query_params=extra_params,
             timeout=timeout,
         )
+        breakpoint()
         return _QueryResults.from_api_repr(resource)
 
     def job_from_resource(
@@ -4146,6 +4148,7 @@ class Client(ClientWithProject):
             params["startIndex"] = start_index
 
         params["formatOptions.useInt64Timestamp"] = True
+        # breakpoint()
         row_iterator = RowIterator(
             client=self,
             api_request=functools.partial(self._call_api, retry, timeout=timeout),

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -2041,7 +2041,6 @@ class Client(ClientWithProject):
             query_params=extra_params,
             timeout=timeout,
         )
-        breakpoint()
         return _QueryResults.from_api_repr(resource)
 
     def job_from_resource(
@@ -4148,7 +4147,6 @@ class Client(ClientWithProject):
             params["startIndex"] = start_index
 
         params["formatOptions.useInt64Timestamp"] = True
-        # breakpoint()
         row_iterator = RowIterator(
             client=self,
             api_request=functools.partial(self._call_api, retry, timeout=timeout),

--- a/google/cloud/bigquery/job/query.py
+++ b/google/cloud/bigquery/job/query.py
@@ -1422,6 +1422,9 @@ class QueryJob(_AsyncJob):
             page_size (int):
                 Maximum number of rows in a single response. See maxResults in
                 the jobs.getQueryResults REST API.
+            start_index (Optional[int]):
+                Zero-based index of the starting row. See startIndex in the
+                jobs.getQueryResults REST API.
         """
         # Optimization: avoid a call to jobs.getQueryResults if it's already
         # been fetched, e.g. from jobs.query first page of results.

--- a/google/cloud/bigquery/job/query.py
+++ b/google/cloud/bigquery/job/query.py
@@ -1409,6 +1409,7 @@ class QueryJob(_AsyncJob):
         retry: "retries.Retry" = DEFAULT_RETRY,
         timeout: Optional[float] = None,
         page_size: int = 0,
+        start_index: Optional[int] = None,
     ):
         """Refresh the cached query results unless already cached and complete.
 
@@ -1468,6 +1469,7 @@ class QueryJob(_AsyncJob):
             location=self.location,
             timeout=transport_timeout,
             page_size=page_size,
+            start_index=start_index,
         )
 
     def result(  # type: ignore  # (incompatible with supertype)
@@ -1569,6 +1571,9 @@ class QueryJob(_AsyncJob):
 
         if page_size is not None:
             reload_query_results_kwargs["page_size"] = page_size
+
+        if start_index is not None:
+            reload_query_results_kwargs["start_index"] = start_index
 
         try:
             retry_do_query = getattr(self, "_retry_do_query", None)

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -1991,12 +1991,14 @@ class RowIterator(HTTPIterator):
             return response
 
         params = self._get_query_params()
+        import copy
+        params_copy = copy.deepcopy(params)
         if self._page_size is not None:
             if self.page_number and "startIndex" in params:
-                del params["startIndex"]
+                del params_copy["startIndex"]
 
         return self.api_request(
-            method=self._HTTP_METHOD, path=self.path, query_params=params
+            method=self._HTTP_METHOD, path=self.path, query_params=params_copy
         )
 
     @property

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -1991,8 +1991,13 @@ class RowIterator(HTTPIterator):
             return response
 
         params = self._get_query_params()
-        import copy
-        params_copy = copy.deepcopy(params)
+
+        # If the user has provided page_size and start_index, we need to pass
+        # start_index for the first page, but for all subsequent pages, we
+        # should not pass start_index. We make a shallow copy of params and do
+        # not alter the original, so if the user iterates the results again,
+        # start_index is preserved.
+        params_copy = copy.copy(params)
         if self._page_size is not None:
             if self.page_number and "startIndex" in params:
                 del params_copy["startIndex"]

--- a/tests/unit/job/test_query.py
+++ b/tests/unit/job/test_query.py
@@ -1696,6 +1696,9 @@ class TestQueryJob(_Base):
             "schema": {"fields": [{"name": "col1", "type": "STRING"}]},
             "totalRows": "7",
         }
+
+        # Although the result has 7 rows, the response only returns 6, because
+        # start_index is 1.
         tabledata_resource_1 = {
             "totalRows": "7",
             "pageToken": "page_token_1",

--- a/tests/unit/job/test_query.py
+++ b/tests/unit/job/test_query.py
@@ -1682,6 +1682,73 @@ class TestQueryJob(_Base):
             tabledata_list_request[1]["query_params"]["maxResults"], page_size
         )
 
+    def test_result_with_start_index_multi_page(self):
+        # When there are multiple pages of response and the user has set
+        # start_index, we should supply start_index to the server in the first
+        # request. However, in the subsequent requests, we will pass only
+        # page_token but not start_index, because the server only allows one
+        # of them.
+        from google.cloud.bigquery.table import RowIterator
+
+        query_resource = {
+            "jobComplete": True,
+            "jobReference": {"projectId": self.PROJECT, "jobId": self.JOB_ID},
+            "schema": {"fields": [{"name": "col1", "type": "STRING"}]},
+            "totalRows": "7",
+        }
+        tabledata_resource_1 = {
+            "totalRows": "7",
+            "pageToken": "page_token_1",
+            "rows": [
+                {"f": [{"v": "abc"}]},
+                {"f": [{"v": "def"}]},
+                {"f": [{"v": "ghi"}]},
+            ],
+        }
+        tabledata_resource_2 = {
+            "totalRows": "7",
+            "pageToken": None,
+            "rows": [
+                {"f": [{"v": "jkl"}]},
+                {"f": [{"v": "mno"}]},
+                {"f": [{"v": "pqe"}]},
+            ],
+        }
+
+        connection = make_connection(query_resource, tabledata_resource_1, tabledata_resource_2)
+        client = _make_client(self.PROJECT, connection=connection)
+        resource = self._make_resource(ended=True)
+        job = self._get_target_class().from_api_repr(resource, client)
+
+        start_index = 1
+        page_size = 3
+
+        result = job.result(page_size=page_size, start_index=start_index)
+
+        self.assertIsInstance(result, RowIterator)
+        self.assertEqual(result.total_rows, 7)
+
+        rows = list(result)
+
+        self.assertEqual(len(rows), 6)
+        self.assertEqual(len(connection.api_request.call_args_list), 3)
+
+        # First call has both startIndex and maxResults.
+        tabledata_list_request_1 = connection.api_request.call_args_list[1]
+        self.assertEqual(
+            tabledata_list_request_1[1]["query_params"]["startIndex"], start_index
+        )
+        self.assertEqual(
+            tabledata_list_request_1[1]["query_params"]["maxResults"], page_size
+        )
+
+        # Second call only has maxResults.
+        tabledata_list_request_2 = connection.api_request.call_args_list[2]
+        self.assertFalse("startIndex" in tabledata_list_request_2[1]["query_params"])
+        self.assertEqual(
+            tabledata_list_request_2[1]["query_params"]["maxResults"], page_size
+        )
+
     def test_result_error(self):
         from google.cloud import exceptions
 

--- a/tests/unit/job/test_query.py
+++ b/tests/unit/job/test_query.py
@@ -1715,7 +1715,9 @@ class TestQueryJob(_Base):
             ],
         }
 
-        connection = make_connection(query_resource, tabledata_resource_1, tabledata_resource_2)
+        connection = make_connection(
+            query_resource, tabledata_resource_1, tabledata_resource_2
+        )
         client = _make_client(self.PROJECT, connection=connection)
         resource = self._make_resource(ended=True)
         job = self._get_target_class().from_api_repr(resource, client)


### PR DESCRIPTION
TODO:
- [x] move deep copy import
- [x] double check total rows - done, total rows should not be affected by start_index
- [x] unit and system tests

Fixes #2173 🦕
