### PR TITLE
chore: Fix two types of warnings in unit tests

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -4719,7 +4719,7 @@ class TestClient(unittest.TestCase):
         client._connection = make_connection({})
 
         with self.assertRaises(TypeError) as exc:
-            client.query(query, job_id="abcd", api_method="QUERY")
+            client.query(query, job_id="abcd", api_method="QUERY", job_retry=None)
         self.assertIn(
             "`job_id` was provided, but the 'QUERY' `api_method` was requested",
             exc.exception.args[0],
@@ -4774,7 +4774,7 @@ class TestClient(unittest.TestCase):
         conn = client._connection = make_connection(resource)
 
         client.query(
-            query, job_id=job_id, project="other-project", location=self.LOCATION
+            query, job_id=job_id, project="other-project", location=self.LOCATION, job_retry=None
         )
 
         # Check that query actually starts the job.
@@ -4833,7 +4833,7 @@ class TestClient(unittest.TestCase):
         original_config_copy = copy.deepcopy(job_config)
 
         client.query(
-            query, job_id=job_id, location=self.LOCATION, job_config=job_config
+            query, job_id=job_id, location=self.LOCATION, job_config=job_config, job_retry=None
         )
 
         # Check that query actually starts the job.
@@ -5178,7 +5178,7 @@ class TestClient(unittest.TestCase):
         config.udf_resources = udf_resources
         config.use_legacy_sql = True
 
-        job = client.query(QUERY, job_config=config, job_id=JOB)
+        job = client.query(QUERY, job_config=config, job_id=JOB, job_retry=None)
 
         self.assertIsInstance(job, QueryJob)
         self.assertIs(job._client, client)
@@ -5234,7 +5234,7 @@ class TestClient(unittest.TestCase):
         config = QueryJobConfig()
         config.query_parameters = query_parameters
 
-        job = client.query(QUERY, job_config=config, job_id=JOB)
+        job = client.query(QUERY, job_config=config, job_id=JOB, job_retry=None)
 
         self.assertIsInstance(job, QueryJob)
         self.assertIs(job._client, client)
@@ -5277,7 +5277,7 @@ class TestClient(unittest.TestCase):
         )
         with job_begin_patcher:
             with pytest.raises(Unknown, match="Not sure what went wrong."):
-                client.query("SELECT 1;", job_id="123")
+                client.query("SELECT 1;", job_id="123", job_retry=None)
 
     def test_query_job_rpc_fail_w_conflict_job_id_given(self):
         from google.api_core.exceptions import Conflict
@@ -5293,7 +5293,7 @@ class TestClient(unittest.TestCase):
         )
         with job_begin_patcher:
             with pytest.raises(Conflict, match="Job already exists."):
-                client.query("SELECT 1;", job_id="123")
+                client.query("SELECT 1;", job_id="123", job_retry=None)
 
     def test_query_job_rpc_fail_w_conflict_random_id_job_fetch_fails(self):
         from google.api_core.exceptions import Conflict

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -4892,7 +4892,11 @@ class TestClient(unittest.TestCase):
         original_config_copy = copy.deepcopy(job_config)
 
         client.query(
-            query, job_id=job_id, location=self.LOCATION, job_config=job_config
+            query,
+            job_id=job_id,
+            location=self.LOCATION,
+            job_config=job_config,
+            job_retry=None,
         )
 
         # Check that query actually starts the job.
@@ -4948,7 +4952,13 @@ class TestClient(unittest.TestCase):
         )
         conn = client._connection = make_connection(resource)
 
-        client.query(query, job_id=job_id, location=self.LOCATION, job_config=None)
+        client.query(
+            query,
+            job_id=job_id,
+            location=self.LOCATION,
+            job_config=None,
+            job_retry=None,
+        )
 
         # Check that query actually starts the job.
         conn.api_request.assert_called_once_with(
@@ -4986,7 +4996,11 @@ class TestClient(unittest.TestCase):
 
         with self.assertRaises(TypeError) as exc:
             client.query(
-                query, job_id=job_id, location=self.LOCATION, job_config=job_config
+                query,
+                job_id=job_id,
+                location=self.LOCATION,
+                job_config=job_config,
+                job_retry=None,
             )
         self.assertIn("Expected an instance of QueryJobConfig", exc.exception.args[0])
 
@@ -5035,7 +5049,11 @@ class TestClient(unittest.TestCase):
         job_config.default_dataset = None
 
         client.query(
-            query, job_id=job_id, location=self.LOCATION, job_config=job_config
+            query,
+            job_id=job_id,
+            location=self.LOCATION,
+            job_config=job_config,
+            job_retry=None,
         )
 
         # Check that query actually starts the job.
@@ -5080,7 +5098,7 @@ class TestClient(unittest.TestCase):
         )
         conn = client._connection = make_connection(resource)
 
-        client.query(query, job_id=job_id, location=self.LOCATION)
+        client.query(query, job_id=job_id, location=self.LOCATION, job_retry=None)
 
         # Check that query actually starts the job.
         conn.api_request.assert_called_once_with(
@@ -5122,7 +5140,7 @@ class TestClient(unittest.TestCase):
         )
         conn = client._connection = make_connection(resource)
 
-        client.query(query, job_id=job_id, project="other-project")
+        client.query(query, job_id=job_id, project="other-project", job_retry=None)
 
         # Check that query actually starts the job.
         conn.api_request.assert_called_once_with(

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -4721,7 +4721,7 @@ class TestClient(unittest.TestCase):
         with self.assertRaises(TypeError) as exc:
             client.query(query, job_id="abcd", api_method="QUERY", job_retry=None)
         self.assertIn(
-            "`job_id` was provided, but the 'QUERY' `api_method` was requested.",
+            "`job_id` was provided, but the 'QUERY' `api_method` was requested",
             exc.exception.args[0],
         )
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -4721,7 +4721,7 @@ class TestClient(unittest.TestCase):
         with self.assertRaises(TypeError) as exc:
             client.query(query, job_id="abcd", api_method="QUERY", job_retry=None)
         self.assertIn(
-            "`job_id` was provided, but the 'QUERY' `api_method` was requested",
+            "`job_id` was provided, but the 'QUERY' `api_method` was requested.",
             exc.exception.args[0],
         )
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -4774,7 +4774,11 @@ class TestClient(unittest.TestCase):
         conn = client._connection = make_connection(resource)
 
         client.query(
-            query, job_id=job_id, project="other-project", location=self.LOCATION, job_retry=None
+            query,
+            job_id=job_id,
+            project="other-project",
+            location=self.LOCATION,
+            job_retry=None,
         )
 
         # Check that query actually starts the job.
@@ -4833,7 +4837,11 @@ class TestClient(unittest.TestCase):
         original_config_copy = copy.deepcopy(job_config)
 
         client.query(
-            query, job_id=job_id, location=self.LOCATION, job_config=job_config, job_retry=None
+            query,
+            job_id=job_id,
+            location=self.LOCATION,
+            job_config=job_config,
+            job_retry=None,
         )
 
         # Check that query actually starts the job.

--- a/tests/unit/test_opentelemetry_tracing.py
+++ b/tests/unit/test_opentelemetry_tracing.py
@@ -42,7 +42,6 @@ TEST_SPAN_NAME = "bar"
 TEST_SPAN_ATTRIBUTES = {"foo": "baz"}
 
 
-@pytest.mark.skipif(opentelemetry is None, reason="Require `opentelemetry`")
 @pytest.fixture
 def setup():
     importlib.reload(opentelemetry_tracing)


### PR DESCRIPTION
This commit reduces the number of times two warnings appear when running unit tests:

1.  `PytestRemovedIn9Warning` in `tests/unit/test_opentelemetry_tracing.py`: Removed a `@pytest.mark.skipif` decorator from a fixture. The skip condition is already present on the test methods that use the fixture.

#### Example warning:
```
/tmpfs/src/github/python-bigquery/tests/unit/test_opentelemetry_tracing.py:45:
  PytestRemovedIn9Warning: Marks applied to fixtures have no effect
  See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
  @pytest.mark.skipif(opentelemetry is None, reason="Require `opentelemetry`")
```    


2.  `FutureWarning` in `tests/unit/test_client.py`: Updated calls to `client.query()` to include `job_retry=None` when `job_id` is also specified. This is to avoid ambiguity as BigQuery cannot retry a failed job with the exact same ID.

#### Example warning:
```
tests/unit/test_client.py::TestClient::test_query_preserving_explicit_default_job_config
  /tmpfs/src/github/python-bigquery/tests/unit/test_client.py:4951:
  FutureWarning: job_retry must be explicitly set to None if job_id is set.
  BigQuery cannot retry a failed job by using the exact
  same ID. Setting job_id without explicitly disabling
  job_retry will raise an error in the future. To avoid this
  warning, either use job_id_prefix instead (preferred) or
  set job_retry=None.
    client.query(query, job_id=job_id, location=self.LOCATION, job_config=None)
```



