### PR TITLE
refactor: Fix DeprecationWarnings for datetime methods in job tests

### DIFF
--- a/tests/unit/job/helpers.py
+++ b/tests/unit/job/helpers.py
@@ -106,7 +106,7 @@ class _Base(unittest.TestCase):
         from google.cloud._helpers import UTC
 
         self.WHEN_TS = 1437767599.006
-        self.WHEN = datetime.datetime.utcfromtimestamp(self.WHEN_TS).replace(tzinfo=UTC)
+        self.WHEN = datetime.datetime.fromtimestamp(self.WHEN_TS, datetime.UTC).replace(tzinfo=UTC)
         self.ETAG = "ETAG"
         self.FULL_JOB_ID = "%s:%s" % (self.PROJECT, self.JOB_ID)
         self.RESOURCE_URL = "{}/bigquery/v2/projects/{}/jobs/{}".format(

--- a/tests/unit/job/helpers.py
+++ b/tests/unit/job/helpers.py
@@ -106,7 +106,9 @@ class _Base(unittest.TestCase):
         from google.cloud._helpers import UTC
 
         self.WHEN_TS = 1437767599.006
-        self.WHEN = datetime.datetime.fromtimestamp(self.WHEN_TS, datetime.UTC).replace(tzinfo=UTC)
+        self.WHEN = datetime.datetime.fromtimestamp(self.WHEN_TS, UTC).replace(
+            tzinfo=UTC
+        )
         self.ETAG = "ETAG"
         self.FULL_JOB_ID = "%s:%s" % (self.PROJECT, self.JOB_ID)
         self.RESOURCE_URL = "{}/bigquery/v2/projects/{}/jobs/{}".format(

--- a/tests/unit/job/test_base.py
+++ b/tests/unit/job/test_base.py
@@ -332,7 +332,7 @@ class Test_AsyncJob(unittest.TestCase):
         from google.cloud._helpers import _millis
 
         now = datetime.datetime.now(datetime.UTC).replace(
-            microsecond=123000.
+            microsecond=123000,
             tzinfo=datetime.timezone.utc,  # stats timestamps have ms precision
         )
         return now, _millis(now)

--- a/tests/unit/job/test_base.py
+++ b/tests/unit/job/test_base.py
@@ -332,7 +332,7 @@ class Test_AsyncJob(unittest.TestCase):
         from google.cloud._helpers import _millis
 
         now = datetime.datetime.now(datetime.UTC).replace(
-            microsecond=123000,
+            microsecond=123000.
             tzinfo=datetime.timezone.utc,  # stats timestamps have ms precision
         )
         return now, _millis(now)

--- a/tests/unit/job/test_base.py
+++ b/tests/unit/job/test_base.py
@@ -331,7 +331,7 @@ class Test_AsyncJob(unittest.TestCase):
         import datetime
         from google.cloud._helpers import _millis
 
-        now = datetime.datetime.now(datetime.UTC).replace(
+        now = datetime.datetime.now(datetime.timezone.utc).replace(
             microsecond=123000,
             tzinfo=datetime.timezone.utc,  # stats timestamps have ms precision
         )

--- a/tests/unit/job/test_base.py
+++ b/tests/unit/job/test_base.py
@@ -331,7 +331,7 @@ class Test_AsyncJob(unittest.TestCase):
         import datetime
         from google.cloud._helpers import _millis
 
-        now = datetime.datetime.utcnow().replace(
+        now = datetime.datetime.now(datetime.UTC).replace(
             microsecond=123000,
             tzinfo=datetime.timezone.utc,  # stats timestamps have ms precision
         )

--- a/tests/unit/test__pandas_helpers.py
+++ b/tests/unit/test__pandas_helpers.py
@@ -886,7 +886,7 @@ def test_list_columns_and_indexes_with_named_index_same_as_column_name(
 
 @pytest.mark.skipif(pandas is None, reason="Requires `pandas`")
 def test_dataframe_to_json_generator(module_under_test):
-    utcnow = datetime.datetime.utcnow()
+    utcnow = datetime.datetime.now(datetime.timezone.utc)
     dataframe = pandas.DataFrame(
         {
             "a_series": [1, 2, 3, 4],

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -5853,7 +5853,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.bigquery.schema import SchemaField
 
         WHEN_TS = 1437767599.006
-        WHEN = datetime.datetime.utcfromtimestamp(WHEN_TS).replace(tzinfo=UTC)
+        WHEN = datetime.datetime.fromtimestamp(WHEN_TS, UTC).replace(tzinfo=UTC)
         PATH = "projects/%s/datasets/%s/tables/%s/insertAll" % (
             self.PROJECT,
             self.DS_ID,
@@ -5914,7 +5914,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.bigquery.table import Table
 
         WHEN_TS = 1437767599.006
-        WHEN = datetime.datetime.utcfromtimestamp(WHEN_TS).replace(tzinfo=UTC)
+        WHEN = datetime.datetime.fromtimestamp(WHEN_TS, UTC).replace(tzinfo=UTC)
         PATH = "projects/%s/datasets/%s/tables/%s/insertAll" % (
             self.PROJECT,
             self.DS_ID,
@@ -6097,6 +6097,7 @@ class TestClient(unittest.TestCase):
         )
 
     def test_insert_rows_w_repeated_fields(self):
+        from google.cloud._helpers import UTC
         from google.cloud.bigquery.schema import SchemaField
         from google.cloud.bigquery.table import Table
 
@@ -6126,12 +6127,8 @@ class TestClient(unittest.TestCase):
                     (
                         12,
                         [
-                            datetime.datetime(
-                                2018, 12, 1, 12, 0, 0, tzinfo=datetime.timezone.utc
-                            ),
-                            datetime.datetime(
-                                2018, 12, 1, 13, 0, 0, tzinfo=datetime.timezone.utc
-                            ),
+                            datetime.datetime(2018, 12, 1, 12, 0, 0, tzinfo=UTC),
+                            datetime.datetime(2018, 12, 1, 13, 0, 0, tzinfo=UTC),
                         ],
                         [1.25, 2.5],
                     ),
@@ -6966,7 +6963,9 @@ class TestClient(unittest.TestCase):
         )
         WHEN_TS = 1437767599006000
 
-        WHEN = datetime.datetime.utcfromtimestamp(WHEN_TS / 1e6).replace(tzinfo=UTC)
+        WHEN = datetime.datetime.fromtimestamp(
+            WHEN_TS / 1e6, datetime.timezone.utc
+        ).replace(tzinfo=UTC)
         WHEN_1 = WHEN + datetime.timedelta(microseconds=1)
         WHEN_2 = WHEN + datetime.timedelta(microseconds=2)
         ROWS = 1234

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -945,7 +945,9 @@ class TestDataset(unittest.TestCase):
         from google.cloud._helpers import UTC
 
         self.WHEN_TS = 1437767599.006
-        self.WHEN = datetime.datetime.utcfromtimestamp(self.WHEN_TS).replace(tzinfo=UTC)
+        self.WHEN = datetime.datetime.fromtimestamp(self.WHEN_TS, UTC).replace(
+            tzinfo=UTC
+        )
         self.ETAG = "ETAG"
         self.DS_FULL_ID = "%s:%s" % (self.PROJECT, self.DS_ID)
         self.RESOURCE_URL = "http://example.com/path/to/resource"

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -637,9 +637,9 @@ class Test_ScalarQueryParameter(unittest.TestCase):
         self.assertEqual(param.to_api_repr(), EXPECTED)
 
     def test_to_api_repr_w_timestamp_micros(self):
-        from google.cloud._helpers import _microseconds_from_datetime
+        from google.cloud._helpers import _microseconds_from_datetime, UTC
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(UTC)
         seconds = _microseconds_from_datetime(now) / 1.0e6
         EXPECTED = {
             "parameterType": {"type": "TIMESTAMP"},
@@ -650,9 +650,9 @@ class Test_ScalarQueryParameter(unittest.TestCase):
         self.assertEqual(param.to_api_repr(), EXPECTED)
 
     def test_to_api_repr_w_datetime_datetime(self):
-        from google.cloud._helpers import _datetime_to_rfc3339
+        from google.cloud._helpers import _datetime_to_rfc3339, UTC
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(UTC)
         EXPECTED = {
             "parameterType": {"type": "DATETIME"},
             "parameterValue": {
@@ -664,9 +664,9 @@ class Test_ScalarQueryParameter(unittest.TestCase):
         self.assertEqual(param.to_api_repr(), EXPECTED)
 
     def test_to_api_repr_w_datetime_string(self):
-        from google.cloud._helpers import _datetime_to_rfc3339
+        from google.cloud._helpers import _datetime_to_rfc3339, UTC
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(UTC)
         now_str = _datetime_to_rfc3339(now)
         EXPECTED = {
             "parameterType": {"type": "DATETIME"},
@@ -1047,9 +1047,10 @@ class Test_RangeQueryParameter(unittest.TestCase):
         self.assertEqual(param.to_api_repr(), EXPECTED)
 
     def test_to_api_repr_w_datetime_datetime(self):
+        from google.cloud._helpers import UTC  # type: ignore
         from google.cloud.bigquery._helpers import _RFC3339_MICROS_NO_ZULU
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(UTC)
         now_str = now.strftime(_RFC3339_MICROS_NO_ZULU)
         EXPECTED = {
             "parameterType": {
@@ -1089,7 +1090,7 @@ class Test_RangeQueryParameter(unittest.TestCase):
     def test_to_api_repr_w_timestamp_timestamp(self):
         from google.cloud._helpers import UTC  # type: ignore
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(UTC)
         now = now.astimezone(UTC)
         now_str = str(now)
         EXPECTED = {

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -395,7 +395,9 @@ class TestTable(unittest.TestCase, _SchemaBase):
         from google.cloud._helpers import UTC
 
         self.WHEN_TS = 1437767599.006
-        self.WHEN = datetime.datetime.utcfromtimestamp(self.WHEN_TS).replace(tzinfo=UTC)
+        self.WHEN = datetime.datetime.fromtimestamp(self.WHEN_TS, UTC).replace(
+            tzinfo=UTC
+        )
         self.ETAG = "ETAG"
         self.TABLE_FULL_ID = "%s:%s.%s" % (self.PROJECT, self.DS_ID, self.TABLE_NAME)
         self.RESOURCE_URL = "http://example.com/path/to/resource"
@@ -1952,7 +1954,9 @@ class TestTableListItem(unittest.TestCase):
         from google.cloud._helpers import UTC
 
         self.WHEN_TS = 1437767599.125
-        self.WHEN = datetime.datetime.utcfromtimestamp(self.WHEN_TS).replace(tzinfo=UTC)
+        self.WHEN = datetime.datetime.fromtimestamp(self.WHEN_TS, UTC).replace(
+            tzinfo=UTC
+        )
         self.EXP_TIME = datetime.datetime(2015, 8, 1, 23, 59, 59, tzinfo=UTC)
 
     def test_ctor(self):


### PR DESCRIPTION
Replaced calls to deprecated `datetime.datetime.utcnow()` with `datetime.datetime.now(datetime.UTC)` in `tests/unit/job/test_base.py`.

Replaced calls to deprecated `datetime.datetime.utcfromtimestamp()` with `datetime.datetime.fromtimestamp(timestamp, datetime.UTC)` in `tests/unit/job/helpers.py`.

These changes address the specific warnings identified in the issue for these two files.

#### Example 1: `utcnow()`:
```
/tmpfs/src/github/python-bigquery/tests/unit/job/test_base.py:334: DeprecationWarning:
datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use
timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    now = datetime.datetime.utcnow().replace(
```

#### Example 2: `utcfromtimestamp()`:
```
/tmpfs/src/github/python-bigquery/tests/unit/job/helpers.py:109: DeprecationWarning:
datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future
version. Use timezone-aware objects to represent datetimes in UTC:
datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
```