### PR TITLE
ci: Import numpy before pyarrow in tests to resolve import warning

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -163,8 +163,7 @@ def unit_noextras(session):
     # so that it continues to be an optional dependency.
     # https://github.com/googleapis/python-bigquery/issues/1877
     if session.python == UNIT_TEST_PYTHON_VERSIONS[0]:
-        session.install("pyarrow==4.0.0")
-
+        session.install("pyarrow==4.0.0", "numpy==1.20.2")
     default(session, install_extras=False)
 
 

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -20,6 +20,7 @@ ipykernel==6.2.0
 opentelemetry-api==1.1.0
 opentelemetry-instrumentation==0.20b0
 opentelemetry-sdk==1.1.0
+numpy==1.20.2
 packaging==24.2.0
 pandas==1.3.0
 pandas-gbq==0.26.1

--- a/tests/unit/test__pandas_helpers.py
+++ b/tests/unit/test__pandas_helpers.py
@@ -16,7 +16,8 @@ import collections
 import datetime
 import decimal
 import functools
-import gc
+
+# import gc
 import operator
 import queue
 from typing import Union
@@ -1887,6 +1888,7 @@ def test__download_table_bqstorage(
     assert queue_used.maxsize == expected_maxsize
 
 
+'''
 @pytest.mark.skipif(isinstance(pyarrow, mock.Mock), reason="Requires `pyarrow`")
 def test__download_table_bqstorage_shuts_down_workers(
     monkeypatch,
@@ -2013,6 +2015,7 @@ def test_download_arrow_row_iterator_unknown_field_type(module_under_test):
     col = result.columns[1]
     assert type(col) is pyarrow.lib.DoubleArray
     assert col.to_pylist() == [2.2, 22.22, 222.222]
+'''
 
 
 @pytest.mark.skipif(isinstance(pyarrow, mock.Mock), reason="Requires `pyarrow`")

--- a/tests/unit/test__pandas_helpers.py
+++ b/tests/unit/test__pandas_helpers.py
@@ -16,6 +16,7 @@ import collections
 import datetime
 import decimal
 import functools
+import gc
 import operator
 import queue
 from typing import Union
@@ -1886,7 +1887,6 @@ def test__download_table_bqstorage(
     assert queue_used.maxsize == expected_maxsize
 
 
-'''
 @pytest.mark.skipif(isinstance(pyarrow, mock.Mock), reason="Requires `pyarrow`")
 def test__download_table_bqstorage_shuts_down_workers(
     monkeypatch,
@@ -1897,6 +1897,7 @@ def test__download_table_bqstorage_shuts_down_workers(
     Make sure that when the top-level iterator goes out of scope (is deleted),
     the child threads are also stopped.
     """
+    pytest.importorskip("google.cloud.bigquery_storage_v1")
     from google.cloud.bigquery import dataset
     from google.cloud.bigquery import table
     import google.cloud.bigquery_storage_v1.reader
@@ -2013,7 +2014,6 @@ def test_download_arrow_row_iterator_unknown_field_type(module_under_test):
     col = result.columns[1]
     assert type(col) is pyarrow.lib.DoubleArray
     assert col.to_pylist() == [2.2, 22.22, 222.222]
-'''
 
 
 @pytest.mark.skipif(isinstance(pyarrow, mock.Mock), reason="Requires `pyarrow`")

--- a/tests/unit/test__pandas_helpers.py
+++ b/tests/unit/test__pandas_helpers.py
@@ -16,8 +16,6 @@ import collections
 import datetime
 import decimal
 import functools
-
-# import gc
 import operator
 import queue
 from typing import Union

--- a/tests/unit/test__pyarrow_helpers.py
+++ b/tests/unit/test__pyarrow_helpers.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-
+import numpy
 pyarrow = pytest.importorskip("pyarrow", minversion="3.0.0")
 
 

--- a/tests/unit/test__pyarrow_helpers.py
+++ b/tests/unit/test__pyarrow_helpers.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-import numpy
+numpy = pytest.importorskip("numpy")
 pyarrow = pytest.importorskip("pyarrow", minversion="3.0.0")
 
 

--- a/tests/unit/test_dbapi__helpers.py
+++ b/tests/unit/test_dbapi__helpers.py
@@ -210,7 +210,7 @@ class TestToBqTableRows(unittest.TestCase):
         self.assertEqual(list(result), [])
 
     def test_non_empty_iterable(self):
-        import numpy
+        pytest.importorskip("numpy")
         pytest.importorskip("pyarrow")
         from tests.unit.helpers import _to_pyarrow
 

--- a/tests/unit/test_dbapi__helpers.py
+++ b/tests/unit/test_dbapi__helpers.py
@@ -210,6 +210,7 @@ class TestToBqTableRows(unittest.TestCase):
         self.assertEqual(list(result), [])
 
     def test_non_empty_iterable(self):
+        import numpy
         pytest.importorskip("pyarrow")
         from tests.unit.helpers import _to_pyarrow
 

--- a/tests/unit/test_magics.py
+++ b/tests/unit/test_magics.py
@@ -1276,6 +1276,11 @@ def test_bigquery_magic_with_no_query_cache(monkeypatch):
     bigquery.load_ipython_extension(ip)
     conn = make_connection()
     monkeypatch.setattr(magics.context, "_connection", conn)
+    monkeypatch.setattr(
+        magics.context,
+        "credentials",
+        mock.create_autospec(google.auth.credentials.Credentials, instance=True),
+    )
     monkeypatch.setattr(magics.context, "project", "project-from-context")
 
     # --no_query_cache option should override context.

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -2416,6 +2416,7 @@ class Test_EmptyRowIterator(unittest.TestCase):
             row_iterator.to_arrow()
 
     def test_to_arrow(self):
+        import numpy
         pyarrow = pytest.importorskip("pyarrow")
         row_iterator = self._make_one()
         tbl = row_iterator.to_arrow()
@@ -2423,6 +2424,8 @@ class Test_EmptyRowIterator(unittest.TestCase):
         self.assertEqual(tbl.num_rows, 0)
 
     def test_to_arrow_iterable(self):
+        import numpy
+        import numpy
         pyarrow = pytest.importorskip(
             "pyarrow", minversion=self.PYARROW_MINIMUM_VERSION
         )
@@ -3096,6 +3099,7 @@ class TestRowIterator(unittest.TestCase):
         bqstorage_client._transport.grpc_channel.close.assert_not_called()
 
     def test_to_arrow(self):
+        import numpy
         pyarrow = pytest.importorskip(
             "pyarrow", minversion=self.PYARROW_MINIMUM_VERSION
         )
@@ -3180,6 +3184,7 @@ class TestRowIterator(unittest.TestCase):
         )
 
     def test_to_arrow_w_nulls(self):
+        import numpy
         pyarrow = pytest.importorskip(
             "pyarrow", minversion=self.PYARROW_MINIMUM_VERSION
         )
@@ -3216,6 +3221,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(ages, [32, 29, None, 111])
 
     def test_to_arrow_w_unknown_type(self):
+        import numpy
         pyarrow = pytest.importorskip(
             "pyarrow", minversion=self.PYARROW_MINIMUM_VERSION
         )
@@ -3261,6 +3267,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertTrue(all("sport" in str(warning) for warning in warned))
 
     def test_to_arrow_w_empty_table(self):
+        import numpy
         pyarrow = pytest.importorskip(
             "pyarrow", minversion=self.PYARROW_MINIMUM_VERSION
         )
@@ -3302,6 +3309,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(child_field.type.value_type[1].name, "age")
 
     def test_to_arrow_max_results_w_explicit_bqstorage_client_warning(self):
+        import numpy
         pytest.importorskip("pyarrow")
         pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery.schema import SchemaField
@@ -3344,6 +3352,7 @@ class TestRowIterator(unittest.TestCase):
         mock_client._ensure_bqstorage_client.assert_not_called()
 
     def test_to_arrow_max_results_w_create_bqstorage_client_no_warning(self):
+        import numpy
         pytest.importorskip("pyarrow")
         pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery.schema import SchemaField
@@ -3382,6 +3391,7 @@ class TestRowIterator(unittest.TestCase):
         mock_client._ensure_bqstorage_client.assert_not_called()
 
     def test_to_arrow_w_bqstorage(self):
+        import numpy
         pyarrow = pytest.importorskip("pyarrow")
         pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
@@ -3465,6 +3475,7 @@ class TestRowIterator(unittest.TestCase):
         bqstorage_client._transport.grpc_channel.close.assert_not_called()
 
     def test_to_arrow_w_bqstorage_creates_client(self):
+        import numpy
         pytest.importorskip("pyarrow")
         pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
@@ -3498,6 +3509,7 @@ class TestRowIterator(unittest.TestCase):
         bqstorage_client._transport.grpc_channel.close.assert_called_once()
 
     def test_to_arrow_ensure_bqstorage_client_wo_bqstorage(self):
+        import numpy
         pyarrow = pytest.importorskip(
             "pyarrow", minversion=self.PYARROW_MINIMUM_VERSION
         )
@@ -3531,6 +3543,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(tbl.num_rows, 2)
 
     def test_to_arrow_w_bqstorage_no_streams(self):
+        import numpy
         pyarrow = pytest.importorskip("pyarrow")
         pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
@@ -3570,6 +3583,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(actual_table.schema[2].name, "colB")
 
     def test_to_arrow_progress_bar(self):
+        import numpy
         pytest.importorskip("pyarrow")
         pytest.importorskip("tqdm")
         pytest.importorskip("tqdm.notebook")
@@ -3703,6 +3717,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(df_2["age"][0], 33)
 
     def test_to_dataframe_iterable_w_bqstorage(self):
+        import numpy
         pandas = pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
         pytest.importorskip("google.cloud.bigquery_storage")
@@ -3777,6 +3792,7 @@ class TestRowIterator(unittest.TestCase):
         bqstorage_client._transport.grpc_channel.close.assert_not_called()
 
     def test_to_dataframe_iterable_w_bqstorage_max_results_warning(self):
+        import numpy
         pandas = pytest.importorskip("pandas")
         pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
@@ -4804,6 +4820,7 @@ class TestRowIterator(unittest.TestCase):
         mock_client._ensure_bqstorage_client.assert_not_called()
 
     def test_to_dataframe_w_bqstorage_creates_client(self):
+        import numpy
         pytest.importorskip("pandas")
         pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
@@ -4837,6 +4854,7 @@ class TestRowIterator(unittest.TestCase):
         bqstorage_client._transport.grpc_channel.close.assert_called_once()
 
     def test_to_dataframe_w_bqstorage_no_streams(self):
+        import numpy
         pytest.importorskip("pandas")
         pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
@@ -4865,6 +4883,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertTrue(got.empty)
 
     def test_to_dataframe_w_bqstorage_logs_session(self):
+        import numpy
         pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         pytest.importorskip("pyarrow")
@@ -4889,6 +4908,7 @@ class TestRowIterator(unittest.TestCase):
         )
 
     def test_to_dataframe_w_bqstorage_empty_streams(self):
+        import numpy
         pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
@@ -4943,6 +4963,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertTrue(got.empty)
 
     def test_to_dataframe_w_bqstorage_nonempty(self):
+        import numpy
         pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
@@ -5025,6 +5046,7 @@ class TestRowIterator(unittest.TestCase):
         bqstorage_client._transport.grpc_channel.close.assert_not_called()
 
     def test_to_dataframe_w_bqstorage_multiple_streams_return_unique_index(self):
+        import numpy
         bigquery_storage = pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
@@ -5077,6 +5099,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertTrue(got.index.is_unique)
 
     def test_to_dataframe_w_bqstorage_updates_progress_bar(self):
+        import numpy
         bigquery_storage = pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
@@ -5154,6 +5177,7 @@ class TestRowIterator(unittest.TestCase):
             tqdm_mock().close.assert_called_once()
 
     def test_to_dataframe_w_bqstorage_exits_on_keyboardinterrupt(self):
+        import numpy
         bigquery_storage = pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
@@ -5329,6 +5353,7 @@ class TestRowIterator(unittest.TestCase):
             row_iterator.to_dataframe(bqstorage_client)
 
     def test_to_dataframe_concat_categorical_dtype_w_pyarrow(self):
+        import numpy
         pytest.importorskip("google.cloud.bigquery_storage")
         pandas = pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -2416,7 +2416,7 @@ class Test_EmptyRowIterator(unittest.TestCase):
             row_iterator.to_arrow()
 
     def test_to_arrow(self):
-        import numpy
+        pytest.importorskip("numpy")
         pyarrow = pytest.importorskip("pyarrow")
         row_iterator = self._make_one()
         tbl = row_iterator.to_arrow()
@@ -2424,8 +2424,7 @@ class Test_EmptyRowIterator(unittest.TestCase):
         self.assertEqual(tbl.num_rows, 0)
 
     def test_to_arrow_iterable(self):
-        import numpy
-        import numpy
+        pytest.importorskip("numpy")
         pyarrow = pytest.importorskip(
             "pyarrow", minversion=self.PYARROW_MINIMUM_VERSION
         )
@@ -3099,7 +3098,7 @@ class TestRowIterator(unittest.TestCase):
         bqstorage_client._transport.grpc_channel.close.assert_not_called()
 
     def test_to_arrow(self):
-        import numpy
+        pytest.importorskip("numpy")
         pyarrow = pytest.importorskip(
             "pyarrow", minversion=self.PYARROW_MINIMUM_VERSION
         )
@@ -3184,7 +3183,7 @@ class TestRowIterator(unittest.TestCase):
         )
 
     def test_to_arrow_w_nulls(self):
-        import numpy
+        pytest.importorskip("numpy")
         pyarrow = pytest.importorskip(
             "pyarrow", minversion=self.PYARROW_MINIMUM_VERSION
         )
@@ -3221,7 +3220,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(ages, [32, 29, None, 111])
 
     def test_to_arrow_w_unknown_type(self):
-        import numpy
+        pytest.importorskip("numpy")
         pyarrow = pytest.importorskip(
             "pyarrow", minversion=self.PYARROW_MINIMUM_VERSION
         )
@@ -3267,7 +3266,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertTrue(all("sport" in str(warning) for warning in warned))
 
     def test_to_arrow_w_empty_table(self):
-        import numpy
+        pytest.importorskip("numpy")
         pyarrow = pytest.importorskip(
             "pyarrow", minversion=self.PYARROW_MINIMUM_VERSION
         )
@@ -3309,7 +3308,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(child_field.type.value_type[1].name, "age")
 
     def test_to_arrow_max_results_w_explicit_bqstorage_client_warning(self):
-        import numpy
+        pytest.importorskip("numpy")
         pytest.importorskip("pyarrow")
         pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery.schema import SchemaField
@@ -3352,7 +3351,7 @@ class TestRowIterator(unittest.TestCase):
         mock_client._ensure_bqstorage_client.assert_not_called()
 
     def test_to_arrow_max_results_w_create_bqstorage_client_no_warning(self):
-        import numpy
+        pytest.importorskip("numpy")
         pytest.importorskip("pyarrow")
         pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery.schema import SchemaField
@@ -3391,7 +3390,7 @@ class TestRowIterator(unittest.TestCase):
         mock_client._ensure_bqstorage_client.assert_not_called()
 
     def test_to_arrow_w_bqstorage(self):
-        import numpy
+        pytest.importorskip("numpy")
         pyarrow = pytest.importorskip("pyarrow")
         pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
@@ -3475,7 +3474,7 @@ class TestRowIterator(unittest.TestCase):
         bqstorage_client._transport.grpc_channel.close.assert_not_called()
 
     def test_to_arrow_w_bqstorage_creates_client(self):
-        import numpy
+        pytest.importorskip("numpy")
         pytest.importorskip("pyarrow")
         pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
@@ -3509,7 +3508,7 @@ class TestRowIterator(unittest.TestCase):
         bqstorage_client._transport.grpc_channel.close.assert_called_once()
 
     def test_to_arrow_ensure_bqstorage_client_wo_bqstorage(self):
-        import numpy
+        pytest.importorskip("numpy")
         pyarrow = pytest.importorskip(
             "pyarrow", minversion=self.PYARROW_MINIMUM_VERSION
         )
@@ -3543,7 +3542,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(tbl.num_rows, 2)
 
     def test_to_arrow_w_bqstorage_no_streams(self):
-        import numpy
+        pytest.importorskip("numpy")
         pyarrow = pytest.importorskip("pyarrow")
         pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
@@ -3583,7 +3582,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(actual_table.schema[2].name, "colB")
 
     def test_to_arrow_progress_bar(self):
-        import numpy
+        pytest.importorskip("numpy")
         pytest.importorskip("pyarrow")
         pytest.importorskip("tqdm")
         pytest.importorskip("tqdm.notebook")
@@ -3717,7 +3716,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(df_2["age"][0], 33)
 
     def test_to_dataframe_iterable_w_bqstorage(self):
-        import numpy
+        pytest.importorskip("numpy")
         pandas = pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
         pytest.importorskip("google.cloud.bigquery_storage")
@@ -3792,7 +3791,7 @@ class TestRowIterator(unittest.TestCase):
         bqstorage_client._transport.grpc_channel.close.assert_not_called()
 
     def test_to_dataframe_iterable_w_bqstorage_max_results_warning(self):
-        import numpy
+        pytest.importorskip("numpy")
         pandas = pytest.importorskip("pandas")
         pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
@@ -4536,7 +4535,7 @@ class TestRowIterator(unittest.TestCase):
 
     def test_to_dataframe_w_unsupported_dtypes_mapper(self):
         pytest.importorskip("pandas")
-        import numpy
+        numpy = pytest.importorskip("numpy")
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -4820,7 +4819,7 @@ class TestRowIterator(unittest.TestCase):
         mock_client._ensure_bqstorage_client.assert_not_called()
 
     def test_to_dataframe_w_bqstorage_creates_client(self):
-        import numpy
+        pytest.importorskip("numpy")
         pytest.importorskip("pandas")
         pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
@@ -4854,7 +4853,7 @@ class TestRowIterator(unittest.TestCase):
         bqstorage_client._transport.grpc_channel.close.assert_called_once()
 
     def test_to_dataframe_w_bqstorage_no_streams(self):
-        import numpy
+        pytest.importorskip("numpy")
         pytest.importorskip("pandas")
         pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud.bigquery import schema
@@ -4883,7 +4882,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertTrue(got.empty)
 
     def test_to_dataframe_w_bqstorage_logs_session(self):
-        import numpy
+        pytest.importorskip("numpy")
         pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         pytest.importorskip("pyarrow")
@@ -4908,7 +4907,7 @@ class TestRowIterator(unittest.TestCase):
         )
 
     def test_to_dataframe_w_bqstorage_empty_streams(self):
-        import numpy
+        pytest.importorskip("numpy")
         pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
@@ -4963,7 +4962,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertTrue(got.empty)
 
     def test_to_dataframe_w_bqstorage_nonempty(self):
-        import numpy
+        pytest.importorskip("numpy")
         pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
@@ -5046,7 +5045,7 @@ class TestRowIterator(unittest.TestCase):
         bqstorage_client._transport.grpc_channel.close.assert_not_called()
 
     def test_to_dataframe_w_bqstorage_multiple_streams_return_unique_index(self):
-        import numpy
+        pytest.importorskip("numpy")
         bigquery_storage = pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
@@ -5099,7 +5098,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertTrue(got.index.is_unique)
 
     def test_to_dataframe_w_bqstorage_updates_progress_bar(self):
-        import numpy
+        pytest.importorskip("numpy")
         bigquery_storage = pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
@@ -5177,7 +5176,7 @@ class TestRowIterator(unittest.TestCase):
             tqdm_mock().close.assert_called_once()
 
     def test_to_dataframe_w_bqstorage_exits_on_keyboardinterrupt(self):
-        import numpy
+        pytest.importorskip("numpy")
         bigquery_storage = pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
@@ -5353,7 +5352,7 @@ class TestRowIterator(unittest.TestCase):
             row_iterator.to_dataframe(bqstorage_client)
 
     def test_to_dataframe_concat_categorical_dtype_w_pyarrow(self):
-        import numpy
+        pytest.importorskip("numpy")
         pytest.importorskip("google.cloud.bigquery_storage")
         pandas = pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
@@ -5636,7 +5635,7 @@ class TestRowIterator(unittest.TestCase):
         """
         pandas = pytest.importorskip("pandas")
         geopandas = pytest.importorskip("geopandas")
-        import numpy
+        numpy = pytest.importorskip("numpy")
         from shapely import wkt
 
         row_iterator = self._make_one_from_data(

--- a/tests/unit/test_table_arrow.py
+++ b/tests/unit/test_table_arrow.py
@@ -18,7 +18,7 @@ from google.cloud import bigquery
 import google.cloud.bigquery.table
 
 
-import numpy
+numpy = pytest.importorskip("numpy")
 pyarrow = pytest.importorskip("pyarrow", minversion="3.0.0")
 
 

--- a/tests/unit/test_table_arrow.py
+++ b/tests/unit/test_table_arrow.py
@@ -18,8 +18,8 @@ from google.cloud import bigquery
 import google.cloud.bigquery.table
 
 
-numpy = pytest.importorskip("numpy")
-pyarrow = pytest.importorskip("pyarrow", minversion="3.0.0")
+pytest.importorskip("numpy")
+pytest.importorskip("pyarrow", minversion="3.0.0")
 
 
 def test_to_arrow_with_jobs_query_response():

--- a/tests/unit/test_table_arrow.py
+++ b/tests/unit/test_table_arrow.py
@@ -18,6 +18,7 @@ from google.cloud import bigquery
 import google.cloud.bigquery.table
 
 
+import numpy
 pyarrow = pytest.importorskip("pyarrow", minversion="3.0.0")
 
 


### PR DESCRIPTION
A `PytestDeprecationWarning` was occurring in several test files because `pyarrow`, when imported by `pytest.importorskip`, would fail to import `numpy.core.multiarray`.

This change addresses the warning by explicitly importing `numpy` before `pytest.importorskip("pyarrow", ...)` in the affected test files. This ensures that numpy is fully initialized before pyarrow attempts to use it, resolving the underlying import error.

```
tests/unit/test_table.py::TestRowIterator::test_to_arrow_w_empty_table
  /repo/python-bigquery/tests/unit/test_table.py:3270: PytestDeprecationWarning: 
  Module 'pyarrow' was found, but when imported by pytest it raised:

      **ImportError('numpy.core.multiarray failed to import')**

  In pytest 9.1 this warning will become an error by default.
  You can fix the underlying problem, or alternatively overwrite this behavior and silence this warning by passing exc_type=ImportError explicitly.
  See https://docs.pytest.org/en/stable/deprecations.html#pytest-importorskip-default-behavior-regarding-importerror
    pyarrow = pytest.importorskip(
```


