### PR TITLE
Revert "fix: table iterator should not use bqstorage when page_size is not None (#2154)"

### DIFF
--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -1897,11 +1897,6 @@ class RowIterator(HTTPIterator):
         """total bytes processed from job statistics, if present."""
         return self._total_bytes_processed
 
-    @property
-    def page_size(self) -> Optional[int]:
-        """The maximum number of rows in each page of results from this request, if present."""
-        return self._page_size
-
     def _is_almost_completely_cached(self):
         """Check if all results are completely cached.
 
@@ -1953,7 +1948,7 @@ class RowIterator(HTTPIterator):
         if self._is_almost_completely_cached():
             return False
 
-        if self.max_results is not None or self.page_size is not None:
+        if self.max_results is not None:
             return False
 
         try:
@@ -2023,9 +2018,7 @@ class RowIterator(HTTPIterator):
             bqstorage_client:
                 The BigQuery Storage client intended to use for downloading result rows.
         """
-        if bqstorage_client is not None and (
-            self.max_results is not None or self.page_size is not None
-        ):
+        if bqstorage_client is not None and self.max_results is not None:
             warnings.warn(
                 "Cannot use bqstorage_client if max_results is set, "
                 "reverting to fetching data with the REST endpoint.",

--- a/tests/unit/test_dbapi_cursor.py
+++ b/tests/unit/test_dbapi_cursor.py
@@ -161,7 +161,6 @@ class TestCursor(unittest.TestCase):
             mock_rows,
         )
         mock_rows.max_results = None
-        mock_rows.page_size = None
         type(mock_rows).job_id = mock.PropertyMock(return_value="test-job-id")
         type(mock_rows).location = mock.PropertyMock(return_value="test-location")
         type(mock_rows).num_dml_affected_rows = mock.PropertyMock(

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -2858,13 +2858,6 @@ class TestRowIterator(unittest.TestCase):
         )
         self.assertFalse(result)
 
-    def test__should_use_bqstorage_returns_false_if_page_size_set(self):
-        iterator = self._make_one(page_size=10, first_page_response=None)  # not cached
-        result = iterator._should_use_bqstorage(
-            bqstorage_client=None, create_bqstorage_client=True
-        )
-        self.assertFalse(result)
-
     def test__should_use_bqstorage_returns_false_w_warning_if_missing_dependency(self):
         iterator = self._make_one(first_page_response=None)  # not cached
 


### PR DESCRIPTION
Fixes internal issue 418814848🦕

reverts changes introduced by https://github.com/googleapis/python-bigquery/pull/2154