### PR TITLE
docs: update typo for type reference

### DIFF
--- a/google/cloud/bigquery/job/query.py
+++ b/google/cloud/bigquery/job/query.py
@@ -1529,7 +1529,7 @@ class QueryJob(_AsyncJob):
                 a DDL query, an ``_EmptyRowIterator`` instance is returned.
 
         Raises:
-            google.cloud.exceptions.GoogleAPICallError:
+            google.api_core.exceptions.GoogleAPICallError:
                 If the job failed and retries aren't successful.
             concurrent.futures.TimeoutError:
                 If the job did not complete in the given timeout.


### PR DESCRIPTION
Should be `google.api_core.exceptions.GoogleAPICallError`: https://googleapis.dev/python/google-api-core/latest/exceptions.html#google.api_core.exceptions.GoogleAPICallError

Fixes b/416054396 🦕
