### PR TITLE
ci: adds new github workflow focused on documentation in prep to deprecate kokoro presubmit

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,6 @@ jobs:
       run: |
         python -m pip install --upgrade setuptools pip wheel
         python -m pip install nox
-    - name: Run docsfx session
+    - name: Run docfx session
       run: |
-        nox -s docsfx-3.10
+        nox -s docfx-3.10

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         nox -s docs-3.10
 
-  docsfx:
+  docfx:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,39 @@
+on:
+  pull_request:
+    branches:
+      - main
+name: docs
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+    - name: Install nox
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install nox
+    - name: Run docs session
+      run: |
+        nox -s docs-3.10
+
+  docsfx:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+    - name: Install nox
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install nox
+    - name: Run docsfx session
+      run: |
+        nox -s docsfx-3.10


### PR DESCRIPTION
This involves a new GitHub workflow located in `.github/workflows/docs.yml`. This new workflow will now handle running the `docs` and `docfx` nox sessions, which were previously managed by the `.kokoro/presubmit/presubmit.cfg` workflow.

Here's how the new workflow operates:
- It activates when you make pull requests to the `main` branch.
- It executes two jobs: `docs` and `docfx`.
- Both of these jobs utilize Python 3.10.
- Each job installs nox and then runs its corresponding nox session (`docs-3.10` or `docfx-3.10`).

This adjustment is a step towards phasing out and removing the `.kokoro/presubmit/presubmit.cfg` file.