### PR TITLE
ci: Remove unit tests and doc tests from kokoro presubmit.

### DIFF
--- a/.kokoro/presubmit/presubmit.cfg
+++ b/.kokoro/presubmit/presubmit.cfg
@@ -1,7 +1,3 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
 # Disable system tests.
-env_vars: {
-    key: "NOX_SESSION"
-    value: "unit_noextras unit cover docs docfx"
-}

--- a/.kokoro/presubmit/presubmit.cfg
+++ b/.kokoro/presubmit/presubmit.cfg
@@ -1,3 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Unit, unit_noextras, cover, docs, docfx are handled by github actions.

--- a/.kokoro/presubmit/presubmit.cfg
+++ b/.kokoro/presubmit/presubmit.cfg
@@ -1,3 +1,3 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Disable system tests.
+# Unit, unit_noextras, cover, docs, docfx are handled by github actions.


### PR DESCRIPTION
This commit removes the Kokoro presubmit configuration that runs `unit_noextras`, `unit`, `cover`, `docs`, and `docfx` nox sessions. These checks are already performed by GitHub Actions, making the Kokoro configuration redundant.

The change involves removing the `NOX_SESSION` environment variable definition from `.kokoro/presubmit/presubmit.cfg`.

