### PR TITLE
docs: fixes several typos and updates a try except block

### DIFF
--- a/google/cloud/bigquery/_helpers.py
+++ b/google/cloud/bigquery/_helpers.py
@@ -388,7 +388,7 @@ CELL_DATA_PARSER = CellDataParser()
 
 
 class DataFrameCellDataParser(CellDataParser):
-    """Override of CellDataParser to handle differences in expection of values in DataFrame-like outputs.
+    """Override of CellDataParser to handle differences in expression of values in DataFrame-like outputs.
 
     This is used to turn the output of the REST API into a pyarrow Table,
     emulating the serialized arrow from the BigQuery Storage Read API.

--- a/google/cloud/bigquery/_pandas_helpers.py
+++ b/google/cloud/bigquery/_pandas_helpers.py
@@ -1144,7 +1144,7 @@ def determine_requested_streams(
     """
 
     if preserve_order:
-        # If preserve order is set, it takes precendence.
+        # If preserve order is set, it takes precedence.
         # Limit the requested streams to 1, to ensure that order
         # is preserved)
         return 1

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -4134,7 +4134,7 @@ class Client(ClientWithProject):
                 rows that were affected.
             query (Optional[str]):
                 The query text used.
-            total_bytes_processed (Optinal[int]):
+            total_bytes_processed (Optional[int]):
                 total bytes processed from job statistics, if present.
 
         Returns:

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -44,7 +44,7 @@ try:
     import geopandas  # type: ignore
 except ImportError:
     geopandas = None
-else:
+finally:
     _COORDINATE_REFERENCE_SYSTEM = "EPSG:4326"
 
 try:
@@ -1786,7 +1786,7 @@ class RowIterator(HTTPIterator):
             the first page is requested.
         query (Optional[str]):
             The query text used.
-        total_bytes_processed (Optinal[int]):
+        total_bytes_processed (Optional[int]):
             total bytes processed from job statistics, if present.
     """
 


### PR DESCRIPTION
Fixes several typos and a try/except block that impacts internal google3 tests.

The needed fixes were identified during an import of this codebase to google3.
See this internal CL: `cl/757834380` for details on the typos.
Reference internal private chat for details on the try/except block. 
