### PR TITLE
feat: Adds dataset_view parameter to get_dataset method

### DIFF
--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -866,10 +866,22 @@ class Client(ClientWithProject):
                 How to retry the RPC.
             timeout (Optional[float]):
                 The number of seconds to wait for the underlying HTTP transport
-                before using ``retry``.
+                before using ``retry`
             dataset_view (Optional[google.cloud.bigquery.enums.DatasetView]):
-                Specifies the level of detail to return. Defaults to None, which
-                returns the default representation of the dataset.
+                # TODO clean up this docstring.
+                Specifies the level of detail to include for the dataset resource.
+                If provided and not None, this parameter controls which parts of the
+                dataset resource are returned.
+                Possible enum values:
+                - :attr:`~google.cloud.bigquery.enums.DatasetView.ACL`:
+                  Includes dataset metadata and the ACL.
+                - :attr:`~google.cloud.bigquery.enums.DatasetView.FULL`:
+                  Includes all dataset metadata, including the ACL and table metadata.
+                  This view is not supported by the `datasets.list` API method.
+                - :attr:`~google.cloud.bigquery.enums.DatasetView.METADATA`:
+                  Includes basic dataset metadata, but not the ACL.
+                - :attr:`~google.cloud.bigquery.enums.DatasetView.DATASET_VIEW_UNSPECIFIED`:
+                  The server will decide which view to use.
 
         Returns:
             google.cloud.bigquery.dataset.Dataset:
@@ -880,9 +892,12 @@ class Client(ClientWithProject):
                 dataset_ref, default_project=self.project
             )
         path = dataset_ref.path
-        params: Dict[str, Any] = {}
-        if dataset_view is not None:
-            params["view"] = dataset_view.value
+
+        if dataset_view:
+            query_params = {"view": dataset_view.value}
+        else:
+            query_params = {}
+
         span_attributes = {"path": path}
         api_response = self._call_api(
             retry,
@@ -891,7 +906,7 @@ class Client(ClientWithProject):
             method="GET",
             path=path,
             timeout=timeout,
-            query_params=params if params else None,
+            query_params=query_params,
         )
         return Dataset.from_api_repr(api_response)
 

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -884,7 +884,7 @@ class Client(ClientWithProject):
                 before using ``retry``.
             dataset_view (Optional[google.cloud.bigquery.enums.DatasetView]):
                 Specifies the view that determines which dataset information is
-                returned. By default, datase metadata (e.g. friendlyName, description,
+                returned. By default, dataset metadata (e.g. friendlyName, description,
                 labels, etc) and ACL information are returned. This argument can
                 take on the following possible enum values.
 

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -866,7 +866,7 @@ class Client(ClientWithProject):
                 How to retry the RPC.
             timeout (Optional[float]):
                 The number of seconds to wait for the underlying HTTP transport
-                before using ``retry`
+                before using ``retry``.
             dataset_view (Optional[google.cloud.bigquery.enums.DatasetView]):
                 # TODO clean up this docstring.
                 Specifies the level of detail to include for the dataset resource.

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -868,21 +868,20 @@ class Client(ClientWithProject):
                 The number of seconds to wait for the underlying HTTP transport
                 before using ``retry``.
             dataset_view (Optional[google.cloud.bigquery.enums.DatasetView]):
-                # TODO clean up this docstring.
-                Specifies the level of detail to include for the dataset resource.
-                If provided and not None, this parameter controls which parts of the
-                dataset resource are returned.
-                Possible enum values:
-                - :attr:`~google.cloud.bigquery.enums.DatasetView.ACL`:
-                  Includes dataset metadata and the ACL.
-                - :attr:`~google.cloud.bigquery.enums.DatasetView.FULL`:
-                  Includes all dataset metadata, including the ACL and table metadata.
-                  This view is not supported by the `datasets.list` API method.
-                - :attr:`~google.cloud.bigquery.enums.DatasetView.METADATA`:
-                  Includes basic dataset metadata, but not the ACL.
-                - :attr:`~google.cloud.bigquery.enums.DatasetView.DATASET_VIEW_UNSPECIFIED`:
-                  The server will decide which view to use.
+                Specifies the view that determines which dataset information is
+                returned. By default, datase metadata (e.g. friendlyName, description,
+                labels, etc) and ACL information are returned. This argument can
+                take on the following possible enum values.
 
+                * :attr:`~google.cloud.bigquery.enums.DatasetView.ACL`:
+                    Includes dataset metadata and the ACL.
+                * :attr:`~google.cloud.bigquery.enums.DatasetView.FULL`:
+                    Includes all dataset metadata, including the ACL and table metadata.
+                    This view is not supported by the `datasets.list` API method.
+                * :attr:`~google.cloud.bigquery.enums.DatasetView.METADATA`:
+                    Includes basic dataset metadata, but not the ACL.
+                * :attr:`~google.cloud.bigquery.enums.DatasetView.DATASET_VIEW_UNSPECIFIED`:
+                    The server will decide which view to use. Currently defaults to FULL.
         Returns:
             google.cloud.bigquery.dataset.Dataset:
                 A ``Dataset`` instance.

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -893,7 +893,7 @@ class Client(ClientWithProject):
         path = dataset_ref.path
 
         if dataset_view:
-            query_params = {"view": dataset_view.value}
+            query_params = {"datasetView": dataset_view.value}
         else:
             query_params = {}
 

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -90,7 +90,7 @@ from google.cloud.bigquery._job_helpers import make_job_id as _make_job_id
 from google.cloud.bigquery.dataset import Dataset
 from google.cloud.bigquery.dataset import DatasetListItem
 from google.cloud.bigquery.dataset import DatasetReference
-from google.cloud.bigquery.enums import AutoRowIDs
+from google.cloud.bigquery.enums import AutoRowIDs, DatasetView
 from google.cloud.bigquery.format_options import ParquetOptions
 from google.cloud.bigquery.job import (
     CopyJob,
@@ -849,6 +849,7 @@ class Client(ClientWithProject):
         dataset_ref: Union[DatasetReference, str],
         retry: retries.Retry = DEFAULT_RETRY,
         timeout: TimeoutType = DEFAULT_TIMEOUT,
+        dataset_view: Optional[DatasetView] = None,
     ) -> Dataset:
         """Fetch the dataset referenced by ``dataset_ref``
 
@@ -866,6 +867,9 @@ class Client(ClientWithProject):
             timeout (Optional[float]):
                 The number of seconds to wait for the underlying HTTP transport
                 before using ``retry``.
+            dataset_view (Optional[google.cloud.bigquery.enums.DatasetView]):
+                Specifies the level of detail to return. Defaults to None, which
+                returns the default representation of the dataset.
 
         Returns:
             google.cloud.bigquery.dataset.Dataset:
@@ -876,6 +880,9 @@ class Client(ClientWithProject):
                 dataset_ref, default_project=self.project
             )
         path = dataset_ref.path
+        params: Dict[str, Any] = {}
+        if dataset_view is not None:
+            params["view"] = dataset_view.value
         span_attributes = {"path": path}
         api_response = self._call_api(
             retry,
@@ -884,6 +891,7 @@ class Client(ClientWithProject):
             method="GET",
             path=path,
             timeout=timeout,
+            query_params=params if params else None,
         )
         return Dataset.from_api_repr(api_response)
 

--- a/google/cloud/bigquery/enums.py
+++ b/google/cloud/bigquery/enums.py
@@ -81,11 +81,21 @@ class CreateDisposition(object):
 
 
 class DatasetView(enum.Enum):
-    # TODO add descriptions
+    """DatasetView specifies which dataset information is returned."""
+
     DATASET_VIEW_UNSPECIFIED = "DATASET_VIEW_UNSPECIFIED"
+    """The default value. Currently maps to the FULL view."""
+
     METADATA = "METADATA"
+    """View metadata information for the dataset, such as friendlyName,
+    description, labels, etc."""
+
     ACL = "ACL"
+    """View ACL information for the dataset, which defines dataset access
+    for one or more entities."""
+
     FULL = "FULL"
+    """View both dataset metadata and ACL information."""
 
 
 class DefaultPandasDTypes(enum.Enum):

--- a/google/cloud/bigquery/enums.py
+++ b/google/cloud/bigquery/enums.py
@@ -80,6 +80,13 @@ class CreateDisposition(object):
     returned in the job result."""
 
 
+class DatasetView(enum.Enum):
+    DATASET_VIEW_UNSPECIFIED = "DATASET_VIEW_UNSPECIFIED"
+    METADATA = "METADATA"
+    ACL = "ACL"
+    FULL = "FULL"
+
+
 class DefaultPandasDTypes(enum.Enum):
     """Default Pandas DataFrem DTypes to convert BigQuery data. These
     Sentinel values are used instead of None to maintain backward compatibility,

--- a/google/cloud/bigquery/enums.py
+++ b/google/cloud/bigquery/enums.py
@@ -81,6 +81,7 @@ class CreateDisposition(object):
 
 
 class DatasetView(enum.Enum):
+    # TODO add descriptions
     DATASET_VIEW_UNSPECIFIED = "DATASET_VIEW_UNSPECIFIED"
     METADATA = "METADATA"
     ACL = "ACL"

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -840,7 +840,7 @@ class TestClient(unittest.TestCase):
                 self.assertEqual(dataset.dataset_id, self.DS_ID)
 
                 if expected_param_value:
-                    expected_query_params = {"view": expected_param_value}
+                    expected_query_params = {"datasetView": expected_param_value}
                 else:
                     expected_query_params = {}
 

--- a/tests/unit/test_create_dataset.py
+++ b/tests/unit/test_create_dataset.py
@@ -372,7 +372,12 @@ def test_create_dataset_alreadyexists_w_exists_ok_true(PROJECT, DS_ID, LOCATION)
                 },
                 timeout=DEFAULT_TIMEOUT,
             ),
-            mock.call(method="GET", path=get_path, timeout=DEFAULT_TIMEOUT),
+            mock.call(
+                method="GET",
+                path=get_path,
+                timeout=DEFAULT_TIMEOUT,
+                query_params={},
+            ),
         ]
     )
 


### PR DESCRIPTION
This commit introduces a new `dataset_view` parameter to the `get_dataset` method in the BigQuery client. This allows you to specify the level of detail (METADATA, ACL, FULL) returned when fetching a dataset, based on permissions in the access control list (ACLs) 

The `DatasetView` enum has been added to `enums.py`.

Unit tests have been added to verify:
- Correct query parameter (`view`) formation for each enum value.
- Correct behavior when `dataset_view` is None.
- AttributeError is raised for invalid `dataset_view` types