### PR TITLE
ci: Configure Renovate to keep Python at 3.10 for docs workflow

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -76,7 +76,7 @@ s.move(
         ".kokoro/continuous/prerelease-deps.cfg",
         ".kokoro/samples/python3.7/**",
         ".kokoro/samples/python3.8/**",
-        ".github/workflows",  # exclude gh actions as credentials are needed for tests
+        ".github/workflows/**",  # exclude gh actions as credentials are needed for tests
         "README.rst",
     ],
 )

--- a/owlbot.py
+++ b/owlbot.py
@@ -65,6 +65,7 @@ s.move(
     templated_files,
     excludes=[
         "noxfile.py",
+        "renovate.json",
         "docs/multiprocessing.rst",
         "docs/index.rst",
         ".coveragerc",

--- a/renovate.json
+++ b/renovate.json
@@ -8,12 +8,5 @@
   "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/unittest.yml"],
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
-  },
-  "packageRules": [
-    {
-      "matchFileNames": [".github/workflows/docs.yml"],
-      "matchStrings": ["uses: actions/setup-python@.*\\n          with:\\n            python-version: '(.*)'"],
-      "allowedVersions": "<3.11"
-    }
-  ]
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,12 @@
   "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/unittest.yml"],
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
-  }
+  },
+  "packageRules": [
+    {
+      "matchFileNames": [".github/workflows/docs.yml"],
+      "matchStrings": ["uses: actions/setup-python@.*\\n          with:\\n            python-version: '(.*)'"],
+      "allowedVersions": "<3.11"
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -5,14 +5,8 @@
     ":preserveSemverRanges",
     ":disableDependencyDashboard"
   ],
-  "ignorePaths": [
-    ".pre-commit-config.yaml",
-    ".kokoro/requirements.txt",
-    "setup.py",
-    ".github/workflows/unittest.yml",
-    ".github/workflows/docs.yml"
-  ],
+  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/unittest.yml"],
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
-  },
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -5,13 +5,7 @@
     ":preserveSemverRanges",
     ":disableDependencyDashboard"
   ],
-  "ignorePaths": [
-    ".pre-commit-config.yaml",
-    ".kokoro/requirements.txt",
-    "setup.py",
-    ".github/workflows/unittest.yml",
-    ".github/workflows/docs.yml",
-  ],
+  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/unittest.yml"],
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
   }

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,13 @@
     ":preserveSemverRanges",
     ":disableDependencyDashboard"
   ],
-  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/unittest.yml"],
+  "ignorePaths": [
+    ".pre-commit-config.yaml",
+    ".kokoro/requirements.txt",
+    "setup.py",
+    ".github/workflows/unittest.yml",
+    ".github/workflows/docs.yml",
+  ],
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
   }

--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,12 @@
   "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/unittest.yml"],
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
-  }
+  },
+  "packageRules": [
+    {
+      "matchFileNames": ["pyproject.toml"],
+      "matchStrings": ["matplotlib (.*); python_version == '3.9'"],
+      "allowedVersions": ">= 3.7.1, <= 3.9.2"
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -5,8 +5,14 @@
     ":preserveSemverRanges",
     ":disableDependencyDashboard"
   ],
-  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/unittest.yml"],
+  "ignorePaths": [
+    ".pre-commit-config.yaml",
+    ".kokoro/requirements.txt",
+    "setup.py",
+    ".github/workflows/unittest.yml",
+    ".github/workflows/docs.yml"
+  ],
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
-  }
+  },
 }


### PR DESCRIPTION
When Renovate Bot checks for potential updates to dependency versions, it is currently updating a file that it should not be looking at: `docs.yml` and it is updating a `matplotlib` dependency in `pyproject.toml` that we need to have locked down tight when using Python 3.9.

This PR puts `docs.yml` on an excludes list so that Owlbot will ignore it.
It adds a regex line to `renovate.json` to ensure that the `matplotlib` dependency does not change.
