### PR TITLE
Fix: Update type hints for various BigQuery files

### DIFF
--- a/google/cloud/bigquery/external_config.py
+++ b/google/cloud/bigquery/external_config.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import, annotations
 
 import base64
 import copy
+import typing
 from typing import Any, Dict, FrozenSet, Iterable, Optional, Union
 
 from google.cloud.bigquery._helpers import _to_bytes
@@ -835,9 +836,9 @@ class ExternalConfig(object):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#ExternalDataConfiguration.FIELDS.schema
         """
-        # TODO: The typehinting for this needs work. Setting this pragma to temporarily
-        # manage a pytype issue that came up in another PR. See Issue: #2132
-        prop: Dict[str, Any] = self._properties.get("schema", {})
+        prop: Dict[str, Any] = typing.cast(
+            Dict[str, Any], self._properties.get("schema", {})
+        )
         return [SchemaField.from_api_repr(field) for field in prop.get("fields", [])]
 
     @schema.setter

--- a/google/cloud/bigquery/external_config.py
+++ b/google/cloud/bigquery/external_config.py
@@ -837,8 +837,8 @@ class ExternalConfig(object):
         """
         # TODO: The typehinting for this needs work. Setting this pragma to temporarily
         # manage a pytype issue that came up in another PR. See Issue: #2132
-        prop = self._properties.get("schema", {})  # type: ignore
-        return [SchemaField.from_api_repr(field) for field in prop.get("fields", [])]  # type: ignore
+        prop: Dict[str, Any] = self._properties.get("schema", {})
+        return [SchemaField.from_api_repr(field) for field in prop.get("fields", [])]
 
     @schema.setter
     def schema(self, value):

--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -435,8 +435,6 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
     @property
     def configuration(self) -> _JobConfig:
         """Job-type specific configurtion."""
-        # TODO: The typehinting for this needs work. Setting this pragma to temporarily
-        # manage a pytype issue that came up in another PR. See Issue: #2132
         configuration: _JobConfig = self._CONFIG_CLASS()  # pytype: disable=not-callable
         configuration._properties = self._properties.setdefault("configuration", {})
         return configuration

--- a/google/cloud/bigquery/job/base.py
+++ b/google/cloud/bigquery/job/base.py
@@ -437,7 +437,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
         """Job-type specific configurtion."""
         # TODO: The typehinting for this needs work. Setting this pragma to temporarily
         # manage a pytype issue that came up in another PR. See Issue: #2132
-        configuration = self._CONFIG_CLASS()  # pytype: disable=not-callable
+        configuration: _JobConfig = self._CONFIG_CLASS()  # pytype: disable=not-callable
         configuration._properties = self._properties.setdefault("configuration", {})
         return configuration
 

--- a/google/cloud/bigquery/routine/routine.py
+++ b/google/cloud/bigquery/routine/routine.py
@@ -518,22 +518,16 @@ class RoutineReference(object):
     @property
     def project(self):
         """str: ID of the project containing the routine."""
-        # TODO: The typehinting for this needs work. Setting this pragma to temporarily
-        # manage a pytype issue that came up in another PR. See Issue: #2132
         return self._properties.get("projectId", "")
 
     @property
     def dataset_id(self):
         """str: ID of dataset containing the routine."""
-        # TODO: The typehinting for this needs work. Setting this pragma to temporarily
-        # manage a pytype issue that came up in another PR. See Issue: #2132
         return self._properties.get("datasetId", "")
 
     @property
     def routine_id(self):
         """str: The routine ID."""
-        # TODO: The typehinting for this needs work. Setting this pragma to temporarily
-        # manage a pytype issue that came up in another PR. See Issue: #2132
         return self._properties.get("routineId", "")
 
     @property

--- a/google/cloud/bigquery/routine/routine.py
+++ b/google/cloud/bigquery/routine/routine.py
@@ -520,21 +520,21 @@ class RoutineReference(object):
         """str: ID of the project containing the routine."""
         # TODO: The typehinting for this needs work. Setting this pragma to temporarily
         # manage a pytype issue that came up in another PR. See Issue: #2132
-        return self._properties["projectId"]  # pytype: disable=typed-dict-error
+        return self._properties.get("projectId", "")
 
     @property
     def dataset_id(self):
         """str: ID of dataset containing the routine."""
         # TODO: The typehinting for this needs work. Setting this pragma to temporarily
         # manage a pytype issue that came up in another PR. See Issue: #2132
-        return self._properties["datasetId"]  # pytype: disable=typed-dict-error
+        return self._properties.get("datasetId", "")
 
     @property
     def routine_id(self):
         """str: The routine ID."""
         # TODO: The typehinting for this needs work. Setting this pragma to temporarily
         # manage a pytype issue that came up in another PR. See Issue: #2132
-        return self._properties["routineId"]  # pytype: disable=typed-dict-error
+        return self._properties.get("routineId", "")
 
     @property
     def path(self):

--- a/google/cloud/bigquery/schema.py
+++ b/google/cloud/bigquery/schema.py
@@ -234,11 +234,7 @@ class SchemaField(object):
         if policy_tags is not _DEFAULT_VALUE:
             # TODO: The typehinting for this needs work. Setting this pragma to temporarily
             # manage a pytype issue that came up in another PR. See Issue: #2132
-            self._properties["policyTags"] = (
-                policy_tags.to_api_repr()  # pytype: disable=attribute-error
-                if policy_tags is not None
-                else None
-            )
+            self._properties["policyTags"] = policy_tags.to_api_repr() if policy_tags is not None else None
         if isinstance(range_element_type, str):
             self._properties["rangeElementType"] = {"type": range_element_type}
         if isinstance(range_element_type, FieldElementType):

--- a/google/cloud/bigquery/schema.py
+++ b/google/cloud/bigquery/schema.py
@@ -232,9 +232,11 @@ class SchemaField(object):
         if max_length is not _DEFAULT_VALUE:
             self._properties["maxLength"] = max_length
         if policy_tags is not _DEFAULT_VALUE:
-            # TODO: The typehinting for this needs work. Setting this pragma to temporarily
-            # manage a pytype issue that came up in another PR. See Issue: #2132
-            self._properties["policyTags"] = policy_tags.to_api_repr() if policy_tags is not None else None
+            self._properties["policyTags"] = (
+                policy_tags.to_api_repr()
+                if isinstance(policy_tags, PolicyTagList)
+                else None
+            )
         if isinstance(range_element_type, str):
             self._properties["rangeElementType"] = {"type": range_element_type}
         if isinstance(range_element_type, FieldElementType):

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -139,7 +139,7 @@ def _reference_getter(table):
 
 # TODO: The typehinting for this needs work. Setting this pragma to temporarily
 # manage a pytype issue that came up in another PR. See Issue: #2132
-def _view_use_legacy_sql_getter(table):
+def _view_use_legacy_sql_getter(table: "Table") -> bool:
     """bool: Specifies whether to execute the view with Legacy or Standard SQL.
 
     This boolean specifies whether to execute the view with Legacy SQL
@@ -151,10 +151,10 @@ def _view_use_legacy_sql_getter(table):
         ValueError: For invalid value types.
     """
 
-    view = table._properties.get("view")  # type: ignore
+    view: Optional[Dict[str, Any]] = table._properties.get("view")
     if view is not None:
         # The server-side default for useLegacySql is True.
-        return view.get("useLegacySql", True)  # type: ignore
+        return view.get("useLegacySql", True) if view is not None else True
     # In some cases, such as in a table list no view object is present, but the
     # resource still represents a view. Use the type as a fallback.
     if table.table_type == "VIEW":

--- a/google/cloud/bigquery/table.py
+++ b/google/cloud/bigquery/table.py
@@ -137,9 +137,9 @@ def _reference_getter(table):
     return TableReference(dataset_ref, table.table_id)
 
 
-# TODO: The typehinting for this needs work. Setting this pragma to temporarily
-# manage a pytype issue that came up in another PR. See Issue: #2132
-def _view_use_legacy_sql_getter(table: "Table") -> bool:
+def _view_use_legacy_sql_getter(
+    table: Union["Table", "TableListItem"]
+) -> Optional[bool]:
     """bool: Specifies whether to execute the view with Legacy or Standard SQL.
 
     This boolean specifies whether to execute the view with Legacy SQL
@@ -160,6 +160,7 @@ def _view_use_legacy_sql_getter(table: "Table") -> bool:
     if table.table_type == "VIEW":
         # The server-side default for useLegacySql is True.
         return True
+    return None  # explicit return statement to appease mypy
 
 
 class _TableBase:


### PR DESCRIPTION
This commit addresses several elements of Issue #2132 by updating type hints in the following files:

- google/cloud/bigquery/external_config.py
- google/cloud/bigquery/job/base.py
- google/cloud/bigquery/routine/routine.py
- google/cloud/bigquery/schema.py
- google/cloud/bigquery/table.py

These changes improve code clarity and maintainability by providing more accurate type information.

Partially fixes #2132  🦕
