### PR TITLE
test: Add test for range_timestamp_dtype in type_mapper

### DIFF
--- a/google/cloud/bigquery/_pandas_helpers.py
+++ b/google/cloud/bigquery/_pandas_helpers.py
@@ -341,7 +341,7 @@ def default_types_mapper(
             # recognized by coverage, hence the pragma. See Issue: #2132
             elif (
                 range_timestamp_dtype is not None
-                and arrow_data_type.equals(  # pragma: NO COVER
+                and arrow_data_type.equals(
                     range_timestamp_dtype.pyarrow_dtype
                 )
             ):


### PR DESCRIPTION
WIP do not review.

This commit adds a new test case to `tests/unit/test__pandas_helpers.py` to cover the `range_timestamp_dtype` branch in the `default_types_mapper` function.

Due to issues importing `RangeTIMESTAMPDtype` directly, a mock class (`MockRangeTSDtype`) was used to simulate the necessary `pyarrow_dtype` attribute for the test. This ensures the logic of the `default_types_mapper` for `range_timestamp_dtype` is correctly tested.

The `pragma: NO COVER` comment associated with this branch in `google/cloud/bigquery/_pandas_helpers.py` has been removed as the branch is now covered by this new test.

