### PR TITLE
test: remove pragma

### DIFF
--- a/google/cloud/bigquery/_pandas_helpers.py
+++ b/google/cloud/bigquery/_pandas_helpers.py
@@ -339,11 +339,8 @@ def default_types_mapper(
 
             # TODO: this section does not have a test yet OR at least not one that is
             # recognized by coverage, hence the pragma. See Issue: #2132
-            elif (
-                range_timestamp_dtype is not None
-                and arrow_data_type.equals(  # pragma: NO COVER
-                    range_timestamp_dtype.pyarrow_dtype
-                )
+            elif range_timestamp_dtype is not None and arrow_data_type.equals(
+                range_timestamp_dtype.pyarrow_dtype
             ):
                 return range_timestamp_dtype
 

--- a/google/cloud/bigquery/_pandas_helpers.py
+++ b/google/cloud/bigquery/_pandas_helpers.py
@@ -337,8 +337,6 @@ def default_types_mapper(
             ):
                 return range_date_dtype
 
-            # TODO: this section does not have a test yet OR at least not one that is
-            # recognized by coverage, hence the pragma. See Issue: #2132
             elif range_timestamp_dtype is not None and arrow_data_type.equals(
                 range_timestamp_dtype.pyarrow_dtype
             ):

--- a/tests/unit/job/test_query_pandas.py
+++ b/tests/unit/job/test_query_pandas.py
@@ -647,12 +647,6 @@ def test_to_dataframe_bqstorage_no_pyarrow_compression():
     )
 
 
-# TODO: The test needs work to account for pandas 2.0+. See Issue: #2132
-# pragma added due to issues with coverage.
-@pytest.mark.skipif(
-    pandas.__version__.startswith("2."),
-    reason="pandas 2.0 changes some default dtypes and we haven't update the test to account for those",
-)
 @pytest.mark.skipif(pyarrow is None, reason="Requires `pyarrow`")
 def test_to_dataframe_column_dtypes():
     from google.cloud.bigquery.job import QueryJob as target_class
@@ -704,13 +698,17 @@ def test_to_dataframe_column_dtypes():
     exp_columns = [field["name"] for field in query_resource["schema"]["fields"]]
     assert list(df) == exp_columns  # verify the column names
 
-    assert df.start_timestamp.dtype.name == "datetime64[ns, UTC]"
     assert df.seconds.dtype.name == "Int64"
     assert df.miles.dtype.name == "float64"
     assert df.km.dtype.name == "float16"
     assert df.payment_type.dtype.name == "object"
     assert df.complete.dtype.name == "boolean"
     assert df.date.dtype.name == "dbdate"
+
+    if pandas.__version__.startswith("2."):
+        assert df.start_timestamp.dtype.name == "datetime64[us, UTC]"
+    else:
+        assert df.start_timestamp.dtype.name == "datetime64[ns, UTC]"
 
 
 def test_to_dataframe_column_date_dtypes():

--- a/tests/unit/test_table_pandas.py
+++ b/tests/unit/test_table_pandas.py
@@ -34,12 +34,6 @@ def class_under_test():
     return RowIterator
 
 
-# TODO: The test needs work to account for pandas 2.0+. See Issue: #2132
-# pragma added due to issues with coverage.
-@pytest.mark.skipif(
-    pandas.__version__.startswith("2."),
-    reason="pandas 2.0 changes some default dtypes and we haven't update the test to account for those",
-)
 def test_to_dataframe_nullable_scalars(
     monkeypatch, class_under_test
 ):  # pragma: NO COVER
@@ -113,14 +107,18 @@ def test_to_dataframe_nullable_scalars(
     assert df.dtypes["bool_col"].name == "boolean"
     assert df.dtypes["bytes_col"].name == "object"
     assert df.dtypes["date_col"].name == "dbdate"
-    assert df.dtypes["datetime_col"].name == "datetime64[ns]"
     assert df.dtypes["float64_col"].name == "float64"
     assert df.dtypes["int64_col"].name == "Int64"
     assert df.dtypes["numeric_col"].name == "object"
     assert df.dtypes["string_col"].name == "object"
     assert df.dtypes["time_col"].name == "dbtime"
-    assert df.dtypes["timestamp_col"].name == "datetime64[ns, UTC]"
     assert df.dtypes["json_col"].name == "object"
+    if pandas.__version__.startswith("2."):
+        assert df.dtypes["datetime_col"].name == "datetime64[us]"
+        assert df.dtypes["timestamp_col"].name == "datetime64[us, UTC]"
+    else:
+        assert df.dtypes["datetime_col"].name == "datetime64[ns]"
+        assert df.dtypes["timestamp_col"].name == "datetime64[ns, UTC]"
 
     # Check for expected values.
     assert df["bignumeric_col"][0] == decimal.Decimal("123.456789101112131415")


### PR DESCRIPTION
Three more fixes for Issue: 2132. This will close out that Issue.

* Removes a `# pragma: no cover` statement. There was a test that covered the condition in question but for some reason, during the process of removing Python `3.7` and `3.8` runtime dependencies, `coverage` was not detecting it. `coverage` now correctly identifies the existing test as providing unit test coverage.

* Added conditionals to handle differences between how `pandas 1.3` and `pandas 2.0+` handle timestamps (`us` vs `ns`).

Fixes #2132 🦕
