### PR TITLE
fix: make AccessEntry equality consistent with from_api_repr

### DIFF
--- a/google/cloud/bigquery/dataset.py
+++ b/google/cloud/bigquery/dataset.py
@@ -510,7 +510,8 @@ class AccessEntry(object):
         return (
             self.role == other.role
             and self.entity_type == other.entity_type
-            and self._normalize_entity_id(self.entity_id) == self._normalize_entity_id(other.entity_id)
+            and self._normalize_entity_id(self.entity_id)
+            == self._normalize_entity_id(other.entity_id)
             and self.condition == other.condition
         )
 

--- a/google/cloud/bigquery/dataset.py
+++ b/google/cloud/bigquery/dataset.py
@@ -555,20 +555,7 @@ class AccessEntry(object):
         Returns:
             Dict[str, object]: Access entry represented as an API resource
         """
-        resource = {}
-
-        if self.role is not None:
-            resource["role"] = self.role
-        if self.entity_type is not None:
-            resource[self.entity_type] = self.entity_id
-        if self.condition is not None:
-            resource["condition"] = self.condition.to_api_repr()
-
-        # Include any extra items preserved in _properties
-        for k, v in self._properties.items():
-            if k not in resource:
-                resource[k] = v
-
+        resource = copy.deepcopy(self._properties)
         return resource
 
     @classmethod
@@ -583,31 +570,9 @@ class AccessEntry(object):
             google.cloud.bigquery.dataset.AccessEntry:
                 Access entry parsed from ``resource``.
         """
-        role = resource.get("role")
-        condition = None
-        if "condition" in resource:
-            condition = Condition.from_api_repr(resource["condition"])
-
-        entity_type = None
-        entity_id = None
-
-        for key, value in resource.items():
-            if key in ("role","condition"):
-                continue
-            entity_type = key
-            entity_id = value
-            break
-
-        entry = cls(
-            role=role,
-            entity_type=entity_type,
-            entity_id=entity_id,
-            condition=condition,
-        )
-
-        # Preserve additional _properties for roundtrip consistency:
-        entry._properties = dict(resource)
-        return entry
+        access_entry = cls()
+        access_entry._properties = resource.copy()
+        return access_entry
 
 
 class Dataset(object):

--- a/google/cloud/bigquery/dataset.py
+++ b/google/cloud/bigquery/dataset.py
@@ -588,7 +588,6 @@ class AccessEntry(object):
         role = resource.get("role")
         condition = None
         if "condition" in resource:
-            from google.cloud.bigquery.dataset import Condition
             condition = Condition.from_api_repr(resource["condition"])
 
         entity_type = None

--- a/google/cloud/bigquery/dataset.py
+++ b/google/cloud/bigquery/dataset.py
@@ -507,7 +507,6 @@ class AccessEntry(object):
     def __eq__(self, other):
         if not isinstance(other, AccessEntry):
             return NotImplemented
-
         return (
             self.role == other.role
             and self.entity_type == other.entity_type
@@ -571,7 +570,6 @@ class AccessEntry(object):
                 resource[k] = v
 
         return resource
-        
 
     @classmethod
     def from_api_repr(cls, resource: dict) -> "AccessEntry":
@@ -585,7 +583,6 @@ class AccessEntry(object):
             google.cloud.bigquery.dataset.AccessEntry:
                 Access entry parsed from ``resource``.
         """
-        
         role = resource.get("role")
         condition = None
         if "condition" in resource:
@@ -595,7 +592,7 @@ class AccessEntry(object):
         entity_id = None
 
         for key, value in resource.items():
-            if key in ("role", "condition"):
+            if key in ("role","condition"):
                 continue
             entity_type = key
             entity_id = value

--- a/google/cloud/bigquery/dataset.py
+++ b/google/cloud/bigquery/dataset.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import
 
 import copy
+import json
 
 import typing
 from typing import Optional, List, Dict, Any, Union
@@ -518,7 +519,7 @@ class AccessEntry(object):
     def _normalize_entity_id(value):
         """Ensure consistent equality for dicts like 'view'."""
         if isinstance(value, dict):
-            return dict(sorted(value.items()))
+            return json.dumps(value, sort_keys=True)
         return value
 
     def __ne__(self, other):

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -1767,3 +1767,26 @@ class TestCondition:
             description=None,
         )
         assert hash(cond1) is not None
+        
+    def test_access_entry_view_equality(self):
+        
+        from google.cloud import bigquery
+        
+        entry1 = bigquery.dataset.AccessEntry(
+            entity_type="view",
+            entity_id={
+                "projectId": "my_project",
+                "datasetId": "my_dataset",
+                "tableId": "my_table",
+            },
+        )
+        entry2 = bigquery.dataset.AccessEntry.from_api_repr({
+            "view": {
+                "projectId": "my_project",
+                "datasetId": "my_dataset",
+                "tableId": "my_table",
+            }
+        })
+
+        assert entry1 == entry2
+

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -1767,26 +1767,65 @@ class TestCondition:
             description=None,
         )
         assert hash(cond1) is not None
-        
+
     def test_access_entry_view_equality(self):
-        
+
         from google.cloud import bigquery
-        
+
         entry1 = bigquery.dataset.AccessEntry(
             entity_type="view",
             entity_id={
-                "projectId": "my_project",
-                "datasetId": "my_dataset",
-                "tableId": "my_table",
+                "projectId":"my_project",
+                "datasetId":"my_dataset",
+                "tableId":"my_table",
             },
         )
         entry2 = bigquery.dataset.AccessEntry.from_api_repr({
-            "view": {
-                "projectId": "my_project",
-                "datasetId": "my_dataset",
-                "tableId": "my_table",
+            "view":{
+                "projectId":"my_project",
+                "datasetId":"my_dataset",
+                "tableId":"my_table",
+            }
+        })
+
+        entry3 = bigquery.dataset.AccessEntry(
+            entity_type="routine",
+            entity_id={
+                "projectId":"my_project",
+                "datasetId":"my_dataset",
+                "routineId":"my_routine",
+            },
+        )
+
+        entry4 = bigquery.dataset.AccessEntry.from_api_repr({
+            "routine":{
+                "projectId":"my_project",
+                "datasetId":"my_dataset",
+                "routineId":"my_routine",
+            }
+        })
+
+        entry5 = bigquery.dataset.AccessEntry(
+            entity_type="dataset",
+            entity_id={
+                "dataset": {
+                    "projectId":"my_project",
+                    "datasetId":"my_dataset",
+                },
+                "target_types":"VIEWS",
+            },
+        )
+
+        entry6 = bigquery.dataset.AccessEntry.from_api_repr({
+            "dataset":{
+                "dataset":{
+                    "projectId":"my_project",
+                    "datasetId":"my_dataset",
+                },
+                "target_types":"VIEWS",
             }
         })
 
         assert entry1 == entry2
-
+        assert entry3 == entry4
+        assert entry5 == entry6

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -1769,62 +1769,67 @@ class TestCondition:
         assert hash(cond1) is not None
 
     def test_access_entry_view_equality(self):
-
         from google.cloud import bigquery
 
         entry1 = bigquery.dataset.AccessEntry(
             entity_type="view",
             entity_id={
-                "projectId":"my_project",
-                "datasetId":"my_dataset",
-                "tableId":"my_table",
+                "projectId": "my_project",
+                "datasetId": "my_dataset",
+                "tableId": "my_table",
             },
         )
-        entry2 = bigquery.dataset.AccessEntry.from_api_repr({
-            "view":{
-                "projectId":"my_project",
-                "datasetId":"my_dataset",
-                "tableId":"my_table",
+        entry2 = bigquery.dataset.AccessEntry.from_api_repr(
+            {
+                "view": {
+                    "projectId": "my_project",
+                    "datasetId": "my_dataset",
+                    "tableId": "my_table",
+                }
             }
-        })
+        )
 
         entry3 = bigquery.dataset.AccessEntry(
             entity_type="routine",
             entity_id={
-                "projectId":"my_project",
-                "datasetId":"my_dataset",
-                "routineId":"my_routine",
+                "projectId": "my_project",
+                "datasetId": "my_dataset",
+                "routineId": "my_routine",
             },
         )
 
-        entry4 = bigquery.dataset.AccessEntry.from_api_repr({
-            "routine":{
-                "projectId":"my_project",
-                "datasetId":"my_dataset",
-                "routineId":"my_routine",
+        entry4 = bigquery.dataset.AccessEntry.from_api_repr(
+            {
+                "routine": {
+                    "projectId": "my_project",
+                    "datasetId": "my_dataset",
+                    "routineId": "my_routine",
+                }
             }
-        })
+        )
 
         entry5 = bigquery.dataset.AccessEntry(
             entity_type="dataset",
             entity_id={
                 "dataset": {
-                    "projectId":"my_project",
-                    "datasetId":"my_dataset",
+                    "projectId": "my_project",
+                    "datasetId": "my_dataset",
                 },
-                "target_types":"VIEWS",
+                "target_types": "VIEWS",
             },
         )
 
-        entry6 = bigquery.dataset.AccessEntry.from_api_repr({
-            "dataset":{
-                "dataset":{
-                    "projectId":"my_project",
-                    "datasetId":"my_dataset",
-                },
-                "target_types":"VIEWS",
+        entry6 = bigquery.dataset.AccessEntry.from_api_repr(
+            {
+                "dataset": {
+                    "dataset": {
+                        "projectId": "my_project",
+                        "datasetId": "my_dataset",
+                    },
+                    "target_types": "VIEWS",
+                }
             }
-        })
+        )
 
         assert entry1 == entry2
         assert entry3 == entry4


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)

Fixes #2217 🦕

### 🐛 Bug Fix: AccessEntry equality for "view" entity

This PR fixes a bug where two `AccessEntry` instances representing the same view would not compare as equal:

```python
AccessEntry(entity_type="view", entity_id={"projectId": ..., ...}) != AccessEntry.from_api_repr({...})
```

### ✅ Summary of Changes
- Updated the `__eq__` method in `AccessEntry` to correctly handle `entity_type="view"` by normalizing the nested dictionary in `entity_id`.
- Added a new unit test `test_access_entry_view_equality` in `tests/unit/test_dataset.py` to assert correctness of equality logic for views.
- Ensured compatibility with existing functionality and `from_api_repr` consistency.
