### PR TITLE
feat: Adds source_column_match and associated tests

### DIFF
--- a/google/cloud/bigquery/enums.py
+++ b/google/cloud/bigquery/enums.py
@@ -462,3 +462,21 @@ class JobCreationMode(object):
     The conditions under which BigQuery can decide to not create a Job are
     subject to change.
     """
+
+
+class SourceColumnMatch(str, enum.Enum):
+    """Uses sensible defaults based on how the schema is provided.
+    If autodetect is used, then columns are matched by name. Otherwise, columns
+    are matched by position. This is done to keep the behavior backward-compatible.
+    """
+
+    SOURCE_COLUMN_MATCH_UNSPECIFIED = "SOURCE_COLUMN_MATCH_UNSPECIFIED"
+    """Unspecified column name match option."""
+
+    POSITION = "POSITION"
+    """Matches by position. This assumes that the columns are ordered the same
+    way as the schema."""
+
+    NAME = "NAME"
+    """Matches by name. This reads the header row as column names and reorders
+    columns to match the field names in the schema."""

--- a/google/cloud/bigquery/external_config.py
+++ b/google/cloud/bigquery/external_config.py
@@ -482,6 +482,7 @@ class CSVOptions(object):
         default is chosen based on how the schema is provided. If autodetect is
         used, then columns are matched by name. Otherwise, columns are matched by
         position. This is done to keep the behavior backward-compatible.
+
         Acceptable values are:
             SOURCE_COLUMN_MATCH_UNSPECIFIED - Unspecified column name match option.
             POSITION - matches by position. This assumes that the columns are ordered

--- a/google/cloud/bigquery/external_config.py
+++ b/google/cloud/bigquery/external_config.py
@@ -492,7 +492,7 @@ class CSVOptions(object):
             reorders columns to match the field names in the schema.
 
         See
-        https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#ExternalDataConfiguration.FIELDS.source_column_match
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#CsvOptions.FIELDS.source_column_match
         """
 
         value = self._properties.get("sourceColumnMatch")

--- a/google/cloud/bigquery/external_config.py
+++ b/google/cloud/bigquery/external_config.py
@@ -30,6 +30,7 @@ from google.cloud.bigquery._helpers import _bytes_to_json
 from google.cloud.bigquery._helpers import _int_or_none
 from google.cloud.bigquery._helpers import _str_or_none
 from google.cloud.bigquery import _helpers
+from google.cloud.bigquery.enums import SourceColumnMatch
 from google.cloud.bigquery.format_options import AvroOptions, ParquetOptions
 from google.cloud.bigquery import schema
 from google.cloud.bigquery.schema import SchemaField
@@ -473,6 +474,36 @@ class CSVOptions(object):
     @skip_leading_rows.setter
     def skip_leading_rows(self, value):
         self._properties["skipLeadingRows"] = str(value)
+
+    @property
+    def source_column_match(self) -> Optional[SourceColumnMatch]:
+        """Optional[google.cloud.bigquery.enums.SourceColumnMatch]: Controls the
+        strategy used to match loaded columns to the schema. If not set, a sensible
+        default is chosen based on how the schema is provided. If autodetect is
+        used, then columns are matched by name. Otherwise, columns are matched by
+        position. This is done to keep the behavior backward-compatible.
+        Acceptable values are:
+            SOURCE_COLUMN_MATCH_UNSPECIFIED - Unspecified column name match option.
+            POSITION - matches by position. This assumes that the columns are ordered
+                the same way as the schema.
+            NAME - matches by name. This reads the header row as column names and
+                reorders columns to match the field names in the schema.
+        See
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#ExternalDataConfiguration.FIELDS.source_column_match
+        """
+
+        value = self._properties.get("sourceColumnMatch")
+        if value is not None:
+            return SourceColumnMatch(value)
+        return None
+
+    @source_column_match.setter
+    def source_column_match(self, value: Optional[SourceColumnMatch]):
+        if value is not None and not isinstance(value, SourceColumnMatch):
+            raise TypeError(
+                "value must be a google.cloud.bigquery.enums.SourceColumnMatch or None"
+            )
+        self._properties["sourceColumnMatch"] = value.value if value else None
 
     def to_api_repr(self) -> dict:
         """Build an API representation of this object.

--- a/google/cloud/bigquery/external_config.py
+++ b/google/cloud/bigquery/external_config.py
@@ -496,9 +496,9 @@ class CSVOptions(object):
         """
 
         value = self._properties.get("sourceColumnMatch")
-        if value is not None:
-            return SourceColumnMatch(value)
-        return None
+        # if value is not None:
+        return SourceColumnMatch(value) if value is not None else None
+        # return None
 
     @source_column_match.setter
     def source_column_match(self, value: Optional[SourceColumnMatch]):

--- a/google/cloud/bigquery/external_config.py
+++ b/google/cloud/bigquery/external_config.py
@@ -487,9 +487,10 @@ class CSVOptions(object):
 
             SOURCE_COLUMN_MATCH_UNSPECIFIED: Unspecified column name match option.
             POSITION: matches by position. This assumes that the columns are ordered
-                the same way as the schema.
+            the same way as the schema.
             NAME: matches by name. This reads the header row as column names and
-                reorders columns to match the field names in the schema.
+            reorders columns to match the field names in the schema.
+
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#ExternalDataConfiguration.FIELDS.source_column_match
         """

--- a/google/cloud/bigquery/external_config.py
+++ b/google/cloud/bigquery/external_config.py
@@ -484,10 +484,11 @@ class CSVOptions(object):
         position. This is done to keep the behavior backward-compatible.
 
         Acceptable values are:
-            SOURCE_COLUMN_MATCH_UNSPECIFIED - Unspecified column name match option.
-            POSITION - matches by position. This assumes that the columns are ordered
+
+            SOURCE_COLUMN_MATCH_UNSPECIFIED: Unspecified column name match option.
+            POSITION: matches by position. This assumes that the columns are ordered
                 the same way as the schema.
-            NAME - matches by name. This reads the header row as column names and
+            NAME: matches by name. This reads the header row as column names and
                 reorders columns to match the field names in the schema.
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#ExternalDataConfiguration.FIELDS.source_column_match

--- a/google/cloud/bigquery/external_config.py
+++ b/google/cloud/bigquery/external_config.py
@@ -496,17 +496,17 @@ class CSVOptions(object):
         """
 
         value = self._properties.get("sourceColumnMatch")
-        # if value is not None:
         return SourceColumnMatch(value) if value is not None else None
-        # return None
 
     @source_column_match.setter
-    def source_column_match(self, value: Optional[SourceColumnMatch]):
-        if value is not None and not isinstance(value, SourceColumnMatch):
+    def source_column_match(self, value: Union[SourceColumnMatch, str, None]):
+        if value is not None and not isinstance(value, (SourceColumnMatch, str)):
             raise TypeError(
-                "value must be a google.cloud.bigquery.enums.SourceColumnMatch or None"
+                "value must be a google.cloud.bigquery.enums.SourceColumnMatch, str, or None"
             )
-        self._properties["sourceColumnMatch"] = value.value if value else None
+        if isinstance(value, SourceColumnMatch):
+            value = value.value
+        self._properties["sourceColumnMatch"] = value if value else None
 
     @property
     def null_markers(self) -> Optional[Iterable[str]]:

--- a/google/cloud/bigquery/job/load.py
+++ b/google/cloud/bigquery/job/load.py
@@ -556,6 +556,7 @@ class LoadJobConfig(_JobConfig):
         default is chosen based on how the schema is provided. If autodetect is
         used, then columns are matched by name. Otherwise, columns are matched by
         position. This is done to keep the behavior backward-compatible.
+
         Acceptable values are:
             SOURCE_COLUMN_MATCH_UNSPECIFIED - Unspecified column name match option.
             POSITION - matches by position. This assumes that the columns are ordered

--- a/google/cloud/bigquery/job/load.py
+++ b/google/cloud/bigquery/job/load.py
@@ -18,6 +18,7 @@ import typing
 from typing import FrozenSet, List, Iterable, Optional
 
 from google.cloud.bigquery.encryption_configuration import EncryptionConfiguration
+from google.cloud.bigquery.enums import SourceColumnMatch
 from google.cloud.bigquery.external_config import HivePartitioningOptions
 from google.cloud.bigquery.format_options import ParquetOptions
 from google.cloud.bigquery import _helpers
@@ -549,6 +550,35 @@ class LoadJobConfig(_JobConfig):
         self._set_sub_prop("sourceFormat", value)
 
     @property
+    def source_column_match(self) -> Optional[SourceColumnMatch]:
+        """Optional[google.cloud.bigquery.enums.SourceColumnMatch]: Controls the
+        strategy used to match loaded columns to the schema. If not set, a sensible
+        default is chosen based on how the schema is provided. If autodetect is
+        used, then columns are matched by name. Otherwise, columns are matched by
+        position. This is done to keep the behavior backward-compatible.
+        Acceptable values are:
+            SOURCE_COLUMN_MATCH_UNSPECIFIED - Unspecified column name match option.
+            POSITION - matches by position. This assumes that the columns are ordered
+                the same way as the schema.
+            NAME - matches by name. This reads the header row as column names and
+                reorders columns to match the field names in the schema.
+        See:
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#JobConfigurationLoad.FIELDS.source_column_match
+        """
+        value = self._get_sub_prop("sourceColumnMatch")
+        if value is not None:
+            return SourceColumnMatch(value)
+        return None
+
+    @source_column_match.setter
+    def source_column_match(self, value: Optional[SourceColumnMatch]):
+        if value is not None and not isinstance(value, SourceColumnMatch):
+            raise TypeError(
+                "value must be a google.cloud.bigquery.enums.SourceColumnMatch or None"
+            )
+        self._set_sub_prop("sourceColumnMatch", value.value if value else None)
+
+    @property
     def time_partitioning(self):
         """Optional[google.cloud.bigquery.table.TimePartitioning]: Specifies time-based
         partitioning for the destination table.
@@ -888,6 +918,13 @@ class LoadJob(_AsyncJob):
         :attr:`google.cloud.bigquery.job.LoadJobConfig.clustering_fields`.
         """
         return self.configuration.clustering_fields
+
+    @property
+    def source_column_match(self):
+        """See
+        :attr:`google.cloud.bigquery.job.LoadJobConfig.source_column_match`.
+        """
+        return self.configuration.source_column_match
 
     @property
     def schema_update_options(self):

--- a/google/cloud/bigquery/job/load.py
+++ b/google/cloud/bigquery/job/load.py
@@ -561,10 +561,12 @@ class LoadJobConfig(_JobConfig):
 
             SOURCE_COLUMN_MATCH_UNSPECIFIED: Unspecified column name match option.
             POSITION: matches by position. This assumes that the columns are ordered
-                the same way as the schema.
+            the same way as the schema.
             NAME: matches by name. This reads the header row as column names and
-                reorders columns to match the field names in the schema.
+            reorders columns to match the field names in the schema.
+
         See:
+
         https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#JobConfigurationLoad.FIELDS.source_column_match
         """
         value = self._get_sub_prop("sourceColumnMatch")

--- a/google/cloud/bigquery/job/load.py
+++ b/google/cloud/bigquery/job/load.py
@@ -15,7 +15,7 @@
 """Classes for load jobs."""
 
 import typing
-from typing import FrozenSet, List, Iterable, Optional
+from typing import FrozenSet, List, Iterable, Optional, Union
 
 from google.cloud.bigquery.encryption_configuration import EncryptionConfiguration
 from google.cloud.bigquery.enums import SourceColumnMatch
@@ -591,17 +591,17 @@ class LoadJobConfig(_JobConfig):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#JobConfigurationLoad.FIELDS.source_column_match
         """
         value = self._get_sub_prop("sourceColumnMatch")
-        if value is not None:
-            return SourceColumnMatch(value)
-        return None
+        return SourceColumnMatch(value) if value is not None else None
 
     @source_column_match.setter
-    def source_column_match(self, value: Optional[SourceColumnMatch]):
-        if value is not None and not isinstance(value, SourceColumnMatch):
+    def source_column_match(self, value: Union[SourceColumnMatch, str, None]):
+        if value is not None and not isinstance(value, (SourceColumnMatch, str)):
             raise TypeError(
-                "value must be a google.cloud.bigquery.enums.SourceColumnMatch or None"
+                "value must be a google.cloud.bigquery.enums.SourceColumnMatch, str, or None"
             )
-        self._set_sub_prop("sourceColumnMatch", value.value if value else None)
+        if isinstance(value, SourceColumnMatch):
+            value = value.value
+        self._set_sub_prop("sourceColumnMatch", value if value else None)
 
     @property
     def date_format(self) -> Optional[str]:
@@ -1018,7 +1018,7 @@ class LoadJob(_AsyncJob):
         return self.configuration.clustering_fields
 
     @property
-    def source_column_match(self):
+    def source_column_match(self) -> Optional[SourceColumnMatch]:
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.source_column_match`.
         """

--- a/google/cloud/bigquery/job/load.py
+++ b/google/cloud/bigquery/job/load.py
@@ -558,10 +558,11 @@ class LoadJobConfig(_JobConfig):
         position. This is done to keep the behavior backward-compatible.
 
         Acceptable values are:
-            SOURCE_COLUMN_MATCH_UNSPECIFIED - Unspecified column name match option.
-            POSITION - matches by position. This assumes that the columns are ordered
+
+            SOURCE_COLUMN_MATCH_UNSPECIFIED: Unspecified column name match option.
+            POSITION: matches by position. This assumes that the columns are ordered
                 the same way as the schema.
-            NAME - matches by name. This reads the header row as column names and
+            NAME: matches by name. This reads the header row as column names and
                 reorders columns to match the field names in the schema.
         See:
         https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#JobConfigurationLoad.FIELDS.source_column_match

--- a/tests/unit/job/test_load_config.py
+++ b/tests/unit/job/test_load_config.py
@@ -867,11 +867,14 @@ class TestLoadJobConfig(_Base):
         self.assertEqual(
             config._properties["load"]["sourceColumnMatch"], option_enum.value
         )
+        option_str = "NAME"
+        config.source_column_match = option_str
+        self.assertEqual(config._properties["load"]["sourceColumnMatch"], option_str)
 
     def test_source_column_match_setter_invalid_type(self):
         config = self._get_target_class()()
         with self.assertRaises(TypeError):
-            config.source_column_match = "INVALID_STRING_TYPE"
+            config.source_column_match = 3.14
 
     def test_date_format_missing(self):
         config = self._get_target_class()()

--- a/tests/unit/job/test_load_config.py
+++ b/tests/unit/job/test_load_config.py
@@ -828,6 +828,35 @@ class TestLoadJobConfig(_Base):
             config._properties["load"]["writeDisposition"], write_disposition
         )
 
+    def test_source_column_match_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.source_column_match)
+
+    def test_source_column_match_hit(self):
+        from google.cloud.bigquery.enums import SourceColumnMatch
+
+        option_enum = SourceColumnMatch.NAME
+        config = self._get_target_class()()
+        # Assume API stores the string value of the enum
+        config._properties["load"]["sourceColumnMatch"] = option_enum.value
+        self.assertEqual(config.source_column_match, option_enum)
+
+    def test_source_column_match_setter(self):
+        from google.cloud.bigquery.enums import SourceColumnMatch
+
+        option_enum = SourceColumnMatch.POSITION
+        config = self._get_target_class()()
+        config.source_column_match = option_enum
+        # Assert that the string value of the enum is stored
+        self.assertEqual(
+            config._properties["load"]["sourceColumnMatch"], option_enum.value
+        )
+
+    def test_source_column_match_setter_invalid_type(self):
+        config = self._get_target_class()()
+        with self.assertRaises(TypeError):
+            config.source_column_match = "INVALID_STRING_TYPE"
+
     def test_parquet_options_missing(self):
         config = self._get_target_class()()
         self.assertIsNone(config.parquet_options)

--- a/tests/unit/test_external_config.py
+++ b/tests/unit/test_external_config.py
@@ -939,9 +939,9 @@ class TestCSVOptions(unittest.TestCase):
         ec = external_config.CSVOptions()
         with self.assertRaisesRegex(
             TypeError,
-            "value must be a google.cloud.bigquery.enums.SourceColumnMatch or None",
+            "value must be a google.cloud.bigquery.enums.SourceColumnMatch, str, or None",
         ):
-            ec.source_column_match = "neither None or enum value"
+            ec.source_column_match = 3.14
 
 
 class TestGoogleSheetsOptions(unittest.TestCase):

--- a/tests/unit/test_external_config.py
+++ b/tests/unit/test_external_config.py
@@ -144,20 +144,6 @@ class TestExternalConfig(unittest.TestCase):
         want = {"sourceFormat": "", "schema": {"fields": []}}
         self.assertEqual(got, want)
 
-    def test_source_column_match_None(self):
-        ec = external_config.ExternalConfig("")
-        ec.source_column_match = None
-        expected = None
-        result = ec.source_column_match
-        self.assertEqual(expected, result)
-
-    def test_source_column_match_valid_input(self):
-        ec = external_config.ExternalConfig("")
-        ec.source_column_match = SourceColumnMatch.NAME
-        expected = "NAME"
-        result = ec.source_column_match
-        self.assertEqual(expected, result)
-
     def _verify_base(self, ec):
         self.assertEqual(ec.autodetect, True)
         self.assertEqual(ec.compression, "compression")
@@ -900,7 +886,7 @@ class BigtableOptions(unittest.TestCase):
         )
 
 
-class CSVOptions(unittest.TestCase):
+class TestCSVOptions(unittest.TestCase):
     SOURCE_COLUMN_MATCH = SourceColumnMatch.NAME
 
     def test_to_api_repr(self):
@@ -929,6 +915,28 @@ class CSVOptions(unittest.TestCase):
                 "sourceColumnMatch": self.SOURCE_COLUMN_MATCH,
             },
         )
+
+    def test_source_column_match_None(self):
+        ec = external_config.CSVOptions()
+        ec.source_column_match = None
+        expected = None
+        result = ec.source_column_match
+        self.assertEqual(expected, result)
+
+    def test_source_column_match_valid_input(self):
+        ec = external_config.CSVOptions()
+        ec.source_column_match = SourceColumnMatch.NAME
+        expected = "NAME"
+        result = ec.source_column_match
+        self.assertEqual(expected, result)
+
+    def test_source_column_match_invalid_input(self):
+        ec = external_config.CSVOptions()
+        with self.assertRaisesRegex(
+            TypeError,
+            "value must be a google.cloud.bigquery.enums.SourceColumnMatch or None",
+        ):
+            ec.source_column_match = "neither None or enum value"
 
 
 class TestGoogleSheetsOptions(unittest.TestCase):

--- a/tests/unit/test_external_config.py
+++ b/tests/unit/test_external_config.py
@@ -19,12 +19,14 @@ import unittest
 
 from google.cloud.bigquery import external_config
 from google.cloud.bigquery import schema
+from google.cloud.bigquery.enums import SourceColumnMatch
 
 import pytest
 
 
 class TestExternalConfig(unittest.TestCase):
     SOURCE_URIS = ["gs://foo", "gs://bar"]
+    SOURCE_COLUMN_MATCH = SourceColumnMatch.NAME
 
     BASE_RESOURCE = {
         "sourceFormat": "",
@@ -120,6 +122,20 @@ class TestExternalConfig(unittest.TestCase):
         got = ec.to_api_repr()
         want = {"sourceFormat": "", "schema": {"fields": []}}
         self.assertEqual(got, want)
+
+    def test_source_column_match_None(self):
+        ec = external_config.ExternalConfig("")
+        ec.source_column_match = None
+        expected = None
+        result = ec.source_column_match
+        self.assertEqual(expected, result)
+
+    def test_source_column_match_valid_input(self):
+        ec = external_config.ExternalConfig("")
+        ec.source_column_match = SourceColumnMatch.NAME
+        expected = "NAME"
+        result = ec.source_column_match
+        self.assertEqual(expected, result)
 
     def _verify_base(self, ec):
         self.assertEqual(ec.autodetect, True)
@@ -251,6 +267,7 @@ class TestExternalConfig(unittest.TestCase):
                     "allowJaggedRows": False,
                     "encoding": "encoding",
                     "preserveAsciiControlCharacters": False,
+                    "sourceColumnMatch": self.SOURCE_COLUMN_MATCH,
                 },
             },
         )
@@ -267,6 +284,10 @@ class TestExternalConfig(unittest.TestCase):
         self.assertEqual(ec.options.allow_jagged_rows, False)
         self.assertEqual(ec.options.encoding, "encoding")
         self.assertEqual(ec.options.preserve_ascii_control_characters, False)
+        self.assertEqual(
+            ec.options.source_column_match,
+            self.SOURCE_COLUMN_MATCH,
+        )
 
         got_resource = ec.to_api_repr()
 
@@ -288,6 +309,7 @@ class TestExternalConfig(unittest.TestCase):
         options.skip_leading_rows = 123
         options.allow_jagged_rows = False
         options.preserve_ascii_control_characters = False
+        options.source_column_match = self.SOURCE_COLUMN_MATCH
         ec.csv_options = options
 
         exp_resource = {
@@ -300,6 +322,7 @@ class TestExternalConfig(unittest.TestCase):
                 "allowJaggedRows": False,
                 "encoding": "encoding",
                 "preserveAsciiControlCharacters": False,
+                "sourceColumnMatch": self.SOURCE_COLUMN_MATCH,
             },
         }
 
@@ -852,6 +875,8 @@ class BigtableOptions(unittest.TestCase):
 
 
 class CSVOptions(unittest.TestCase):
+    SOURCE_COLUMN_MATCH = SourceColumnMatch.NAME
+
     def test_to_api_repr(self):
         options = external_config.CSVOptions()
         options.field_delimiter = "\t"
@@ -861,6 +886,7 @@ class CSVOptions(unittest.TestCase):
         options.allow_jagged_rows = False
         options.encoding = "UTF-8"
         options.preserve_ascii_control_characters = False
+        options.source_column_match = self.SOURCE_COLUMN_MATCH
 
         resource = options.to_api_repr()
 
@@ -874,6 +900,7 @@ class CSVOptions(unittest.TestCase):
                 "allowJaggedRows": False,
                 "encoding": "UTF-8",
                 "preserveAsciiControlCharacters": False,
+                "sourceColumnMatch": self.SOURCE_COLUMN_MATCH,
             },
         )
 

--- a/tests/unit/test_external_config.py
+++ b/tests/unit/test_external_config.py
@@ -935,6 +935,11 @@ class TestCSVOptions(unittest.TestCase):
         result = ec.source_column_match
         self.assertEqual(expected, result)
 
+        ec.source_column_match = "POSITION"
+        expected = "POSITION"
+        result = ec.source_column_match
+        self.assertEqual(expected, result)
+
     def test_source_column_match_invalid_input(self):
         ec = external_config.CSVOptions()
         with self.assertRaisesRegex(


### PR DESCRIPTION
This commit introduces new configuration options for BigQuery load jobs and external table definitions, aligning with recent updates to the underlying protos.

New options added:

- `source_column_name_match_option`: Controls how source columns are matched to the schema. (Applies to LoadJobConfig, ExternalConfig, LoadJob)

Changes include:
- Added corresponding properties (getters/setters) to `LoadJobConfig`, `LoadJob`, `ExternalConfig`, and `CSVOptions`.
- Updated docstrings and type hints for all new attributes.
- Updated unit tests to cover the new options, ensuring they are correctly handled during object initialization, serialization to API representation, and deserialization from API responses.