### PR TITLE
fix: adds magics.context.project to eliminate issues with unit tests …

### DIFF
--- a/tests/unit/test_magics.py
+++ b/tests/unit/test_magics.py
@@ -986,6 +986,7 @@ def test_bigquery_magic_dryrun_option_sets_job_config(monkeypatch):
         google.auth.credentials.Credentials, instance=True
     )
 
+    magics.context.project = "project-from-context"
     run_query_patch = mock.patch(
         "google.cloud.bigquery.magics.magics._run_query", autospec=True
     )
@@ -1007,6 +1008,7 @@ def test_bigquery_magic_dryrun_option_returns_query_job(monkeypatch):
     magics.context.credentials = mock.create_autospec(
         google.auth.credentials.Credentials, instance=True
     )
+    magics.context.project = "project-from-context"
     query_job_mock = mock.create_autospec(
         google.cloud.bigquery.job.QueryJob, instance=True
     )
@@ -1035,6 +1037,7 @@ def test_bigquery_magic_dryrun_option_variable_error_message(
         google.auth.credentials.Credentials, instance=True
     )
 
+    magics.context.project = "project-from-context"
     ipython_ns_cleanup.append((ip, "q_job"))
 
     run_query_patch = mock.patch(
@@ -1064,6 +1067,7 @@ def test_bigquery_magic_dryrun_option_saves_query_job_to_variable(
     magics.context.credentials = mock.create_autospec(
         google.auth.credentials.Credentials, instance=True
     )
+    magics.context.project = "project-from-context"
     query_job_mock = mock.create_autospec(
         google.cloud.bigquery.job.QueryJob, instance=True
     )
@@ -1098,6 +1102,7 @@ def test_bigquery_magic_saves_query_job_to_variable_on_error(
         google.auth.credentials.Credentials, instance=True
     )
 
+    magics.context.project = "project-from-context"
     ipython_ns_cleanup.append((ip, "result"))
 
     client_query_patch = mock.patch(


### PR DESCRIPTION
Adds `magics.context.project` to eliminate issues with unit tests in an upcoming PR.

Several magics unit tests fail with an error message.

If the test does not have knowledge of the project, it attempts to initiate a login sequence to be able to get the project identifier. The login cannot complete because the process is running in an ipython interpreter and pytest does not capture any input. This change provides an explicit reference to a project to avoid that process.

```
Please visit this URL to authorize this application: 

[REDACTED DUE TO SPACE REASONS]

self = <_pytest.capture.DontReadFromInput object at 0x7f55d6821bd0>, size = -1
    def read(self, size: int = -1) -> str:
>       raise OSError(
            "pytest: reading from stdin while output is captured!  Consider using `-s`.")
E       OSError: pytest: reading from stdin while output is captured!  Consider using `-s`.
.nox/unit-3-11/lib/python3.11/site-packages/_pytest/capture.py:229: OSError
```

