### PR TITLE
feat: adds date_format to load job and external config

### DIFF
--- a/google/cloud/bigquery/external_config.py
+++ b/google/cloud/bigquery/external_config.py
@@ -849,6 +849,20 @@ class ExternalConfig(object):
         self._properties["schema"] = prop
 
     @property
+    def date_format(self) -> Optional[str]:
+        """Optional[str]: Format used to parse DATE values. Supports C-style and SQL-style values.
+
+        See:
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#ExternalDataConfiguration.FIELDS.date_format
+        """
+        result = self._properties.get("dateFormat")
+        return typing.cast(str, result)
+
+    @date_format.setter
+    def date_format(self, value: Optional[str]):
+        self._properties["dateFormat"] = value
+
+    @property
     def connection_id(self):
         """Optional[str]: [Experimental] ID of a BigQuery Connection API
         resource.

--- a/google/cloud/bigquery/external_config.py
+++ b/google/cloud/bigquery/external_config.py
@@ -862,6 +862,7 @@ class ExternalConfig(object):
     def date_format(self, value: Optional[str]):
         self._properties["dateFormat"] = value
 
+    @property
     def time_zone(self) -> Optional[str]:
         """Optional[str]: Time zone used when parsing timestamp values that do not
         have specific time zone information (e.g. 2024-04-20 12:34:56). The expected

--- a/google/cloud/bigquery/job/load.py
+++ b/google/cloud/bigquery/job/load.py
@@ -549,6 +549,19 @@ class LoadJobConfig(_JobConfig):
         self._set_sub_prop("sourceFormat", value)
 
     @property
+    def date_format(self) -> Optional[str]:
+        """Optional[str]: Date format used for parsing DATE values.
+
+        See:
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#JobConfigurationLoad.FIELDS.date_format
+        """
+        return self._get_sub_prop("dateFormat")
+
+    @date_format.setter
+    def date_format(self, value: Optional[str]):
+        self._set_sub_prop("dateFormat", value)
+
+    @property
     def time_partitioning(self):
         """Optional[google.cloud.bigquery.table.TimePartitioning]: Specifies time-based
         partitioning for the destination table.
@@ -888,6 +901,13 @@ class LoadJob(_AsyncJob):
         :attr:`google.cloud.bigquery.job.LoadJobConfig.clustering_fields`.
         """
         return self.configuration.clustering_fields
+
+    @property
+    def date_format(self):
+        """See
+        :attr:`google.cloud.bigquery.job.LoadJobConfig.date_format`.
+        """
+        return self.configuration.date_format
 
     @property
     def schema_update_options(self):

--- a/google/cloud/bigquery/job/load.py
+++ b/google/cloud/bigquery/job/load.py
@@ -561,6 +561,7 @@ class LoadJobConfig(_JobConfig):
     def date_format(self, value: Optional[str]):
         self._set_sub_prop("dateFormat", value)
 
+    @property
     def time_zone(self) -> Optional[str]:
         """Optional[str]: Default time zone that will apply when parsing timestamp
         values that have no specific time zone.
@@ -922,6 +923,7 @@ class LoadJob(_AsyncJob):
         """
         return self.configuration.date_format
 
+    @property
     def time_zone(self):
         """See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.time_zone`.

--- a/tests/unit/job/test_load.py
+++ b/tests/unit/job/test_load.py
@@ -147,7 +147,6 @@ class TestLoadJob(_Base):
             )
         else:
             self.assertIsNone(job.reference_file_schema_uri)
-
         if "destinationEncryptionConfiguration" in config:
             self.assertIsNotNone(job.destination_encryption_configuration)
             self.assertEqual(
@@ -156,15 +155,14 @@ class TestLoadJob(_Base):
             )
         else:
             self.assertIsNone(job.destination_encryption_configuration)
-        if "timeZone" in config:
-            self.assertEqual(job.time_zone, config["timeZone"])
-        else:
-            self.assertIsNone(job.time_zone)
-
         if "dateFormat" in config:
             self.assertEqual(job.date_format, config["dateFormat"])
         else:
             self.assertIsNone(job.date_format)
+        if "timeZone" in config:
+            self.assertEqual(job.time_zone, config["timeZone"])
+        else:
+            self.assertIsNone(job.time_zone)
 
     def test_ctor(self):
         client = _make_client(project=self.PROJECT)

--- a/tests/unit/job/test_load_config.py
+++ b/tests/unit/job/test_load_config.py
@@ -828,6 +828,22 @@ class TestLoadJobConfig(_Base):
             config._properties["load"]["writeDisposition"], write_disposition
         )
 
+    def test_date_format_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.date_format)
+
+    def test_date_format_hit(self):
+        date_format = "%Y-%m-%d"
+        config = self._get_target_class()()
+        config._properties["load"]["dateFormat"] = date_format
+        self.assertEqual(config.date_format, date_format)
+
+    def test_date_format_setter(self):
+        date_format = "YYYY/MM/DD"
+        config = self._get_target_class()()
+        config.date_format = date_format
+        self.assertEqual(config._properties["load"]["dateFormat"], date_format)
+
     def test_parquet_options_missing(self):
         config = self._get_target_class()()
         self.assertIsNone(config.parquet_options)

--- a/tests/unit/job/test_load_config.py
+++ b/tests/unit/job/test_load_config.py
@@ -958,6 +958,7 @@ class TestLoadJobConfig(_Base):
             },
             "useAvroLogicalTypes": True,
             "writeDisposition": "WRITE_TRUNCATE",
+            "dateFormat": "%Y-%m-%d",
             "timeZone": "America/New_York",
             "parquetOptions": {"enableListInference": True},
             "columnNameCharacterMap": "V2",
@@ -999,6 +1000,7 @@ class TestLoadJobConfig(_Base):
         )
         self.assertTrue(config.use_avro_logical_types)
         self.assertEqual(config.write_disposition, WriteDisposition.WRITE_TRUNCATE)
+        self.assertEqual(config.date_format, "%Y-%m-%d")
         self.assertEqual(config.time_zone, "America/New_York")
         self.assertTrue(config.parquet_options.enable_list_inference)
         self.assertEqual(config.column_name_character_map, ColumnNameCharacterMap.V2)
@@ -1033,6 +1035,7 @@ class TestLoadJobConfig(_Base):
         )
         config.use_avro_logical_types = True
         config.write_disposition = WriteDisposition.WRITE_TRUNCATE
+        config.date_format = "%Y-%m-%d"
         config.time_zone = "America/New_York"
         parquet_options = ParquetOptions()
         parquet_options.enable_list_inference = True

--- a/tests/unit/test_external_config.py
+++ b/tests/unit/test_external_config.py
@@ -26,6 +26,8 @@ import pytest
 class TestExternalConfig(unittest.TestCase):
     SOURCE_URIS = ["gs://foo", "gs://bar"]
 
+    DATE_FORMAT = "MM/DD/YYYY"
+
     BASE_RESOURCE = {
         "sourceFormat": "",
         "sourceUris": SOURCE_URIS,
@@ -33,6 +35,7 @@ class TestExternalConfig(unittest.TestCase):
         "autodetect": True,
         "ignoreUnknownValues": False,
         "compression": "compression",
+        "dateFormat": DATE_FORMAT,
     }
 
     def test_from_api_repr_base(self):
@@ -79,6 +82,7 @@ class TestExternalConfig(unittest.TestCase):
         ec.connection_id = "path/to/connection"
         ec.schema = [schema.SchemaField("full_name", "STRING", mode="REQUIRED")]
 
+        ec.date_format = self.DATE_FORMAT
         exp_schema = {
             "fields": [{"name": "full_name", "type": "STRING", "mode": "REQUIRED"}]
         }
@@ -92,6 +96,7 @@ class TestExternalConfig(unittest.TestCase):
             "compression": "compression",
             "connectionId": "path/to/connection",
             "schema": exp_schema,
+            "dateFormat": self.DATE_FORMAT,
         }
         self.assertEqual(got_resource, exp_resource)
 
@@ -127,6 +132,8 @@ class TestExternalConfig(unittest.TestCase):
         self.assertEqual(ec.ignore_unknown_values, False)
         self.assertEqual(ec.max_bad_records, 17)
         self.assertEqual(ec.source_uris, self.SOURCE_URIS)
+
+        self.assertEqual(ec.date_format, self.DATE_FORMAT)
 
     def test_to_api_repr_source_format(self):
         ec = external_config.ExternalConfig("CSV")


### PR DESCRIPTION
This commit introduces new configuration options for BigQuery load jobs and external table definitions, aligning with recent updates to the underlying protos.

New options added:

`date_format`: Date format used for parsing DATE values. (Applies to `LoadJobConfig`, `LoadJob`, and `ExternalConfig`)

Changes include:

Added corresponding properties (getters/setters) to `LoadJobConfig`, `LoadJob`, and `ExternalConfig`.
Updated docstrings and type hints for all new attributes.
Updated unit tests to cover the new options, ensuring they are correctly handled during object initialization, serialization to API representation, and deserialization from API responses.