### PR TITLE
docs: specify the inherited-members directive for job classes

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -22,6 +22,7 @@ Job
 ===
 
 .. automodule:: google.cloud.bigquery.job
+   :inherited-members:
 
 .. toctree::
   :maxdepth: 2


### PR DESCRIPTION
It seems that versions of python earlier than 3.10 may have had issues processing inherited members annotations, and accidentally include inherited members by default.

As we recently worked to excise older versions of python in this repo, it seems we're now correctly processing sphinx directives, which means we no longer emit docstrings for inherited members.

This PR adds a minor sphinx directive to include inherited members for the job classes, and I've confirmed locally by running the `docsfx` nox job that the inherited members do now get included in the docfx_yaml output.

internal: b/432470466