### PR TITLE
fix: remove deepcopy while setting properties for _QueryResults

### DIFF
--- a/google/cloud/bigquery/query.py
+++ b/google/cloud/bigquery/query.py
@@ -1400,7 +1400,7 @@ class _QueryResults(object):
             api_response (Dict): Response returned from an API call
         """
         self._properties.clear()
-        self._properties.update(copy.deepcopy(api_response))
+        self._properties.update(api_response)
 
 
 def _query_param_from_api_repr(resource):


### PR DESCRIPTION
See internal issue 442629997

This deepcopy() is causing memory spike when people call `Client.query_and_wait()`.

Fixes #2279 🦕
