### PR TITLE
fix: remove ambiguous error codes from query retries

### DIFF
--- a/google/cloud/bigquery/retry.py
+++ b/google/cloud/bigquery/retry.py
@@ -121,9 +121,6 @@ deadline on the retry object.
 """
 
 job_retry_reasons = (
-    "rateLimitExceeded",
-    "backendError",
-    "internalError",
     "jobBackendError",
     "jobInternalError",
     "jobRateLimitExceeded",


### PR DESCRIPTION
Context: internal issue b/445984807 comment 10.
🦕
