### PR TITLE
refactor: microgen - rename variables, edit docstrings

### DIFF
--- a/scripts/microgenerator/generate.py
+++ b/scripts/microgenerator/generate.py
@@ -258,6 +258,7 @@ class CodeAnalyzer(ast.NodeVisitor):
             # directly within the class body, not inside a method.
             elif isinstance(target, ast.Name) and not self._is_in_method:
                 self._add_attribute(target.id, self._get_type_str(node.annotation))
+            self._collect_types_from_node(node.annotation)
         self.generic_visit(node)
 
 

--- a/scripts/microgenerator/noxfile.py
+++ b/scripts/microgenerator/noxfile.py
@@ -16,7 +16,6 @@ from __future__ import absolute_import
 
 from functools import wraps
 import pathlib
-import os
 import nox
 import time
 
@@ -26,7 +25,7 @@ PYTYPE_VERSION = "pytype==2024.9.13"
 BLACK_VERSION = "black==23.7.0"
 BLACK_PATHS = (".",)
 
-DEFAULT_PYTHON_VERSION = "3.9"
+DEFAULT_PYTHON_VERSION = "3.13"
 UNIT_TEST_PYTHON_VERSIONS = ["3.9", "3.11", "3.12", "3.13"]
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
@@ -190,9 +189,8 @@ def lint(session):
     session.install("flake8", BLACK_VERSION)
     session.install("-e", ".")
     session.run("python", "-m", "pip", "freeze")
-    session.run("flake8", os.path.join("scripts"))
+    session.run("flake8", ".")
     session.run("flake8", "tests")
-    session.run("flake8", "benchmark")
     session.run("black", "--check", *BLACK_PATHS)
 
 

--- a/scripts/microgenerator/tests/unit/test_generate_analyzer.py
+++ b/scripts/microgenerator/tests/unit/test_generate_analyzer.py
@@ -94,7 +94,7 @@ class TestCodeAnalyzerImports:
 
 class TestCodeAnalyzerAttributes:
     @pytest.mark.parametrize(
-        "code_snippet, expected_structure",
+        "code_snippet, expected_analyzed_classes",
         [
             pytest.param(
                 """
@@ -242,19 +242,21 @@ class MyClass:
             ),
         ],
     )
-    def test_attribute_extraction(self, code_snippet: str, expected_structure: list):
+    def test_attribute_extraction(
+        self, code_snippet: str, expected_analyzed_classes: list
+    ):
         """Tests the extraction of class and instance attributes."""
         analyzer = CodeAnalyzer()
         tree = ast.parse(code_snippet)
         analyzer.visit(tree)
 
-        extracted = analyzer.structure
+        extracted = analyzer.analyzed_classes
         # Normalize attributes for order-independent comparison
         for item in extracted:
             if "attributes" in item:
                 item["attributes"].sort(key=lambda x: x["name"])
-        for item in expected_structure:
+        for item in expected_analyzed_classes:
             if "attributes" in item:
                 item["attributes"].sort(key=lambda x: x["name"])
 
-        assert extracted == expected_structure
+        assert extracted == expected_analyzed_classes

--- a/scripts/microgenerator/tests/unit/test_generate_analyzer.py
+++ b/scripts/microgenerator/tests/unit/test_generate_analyzer.py
@@ -93,7 +93,6 @@ class TestCodeAnalyzerImports:
 
 
 class TestCodeAnalyzerAttributes:
-
     @pytest.mark.parametrize(
         "code_snippet, expected_structure",
         [

--- a/scripts/microgenerator/tests/unit/test_generate_analyzer.py
+++ b/scripts/microgenerator/tests/unit/test_generate_analyzer.py
@@ -286,8 +286,8 @@ def test_codeanalyzer_finds_class():
     analyzer = CodeAnalyzer()
     tree = ast.parse(code)
     analyzer.visit(tree)
-    assert len(analyzer.structure) == 1
-    assert analyzer.structure[0]["class_name"] == "MyClass"
+    assert len(analyzer.analyzed_classes) == 1
+    assert analyzer.analyzed_classes[0]["class_name"] == "MyClass"
 
 
 def test_codeanalyzer_finds_multiple_classes():
@@ -304,8 +304,8 @@ def test_codeanalyzer_finds_multiple_classes():
     analyzer = CodeAnalyzer()
     tree = ast.parse(code)
     analyzer.visit(tree)
-    assert len(analyzer.structure) == 2
-    class_names = sorted([c["class_name"] for c in analyzer.structure])
+    assert len(analyzer.analyzed_classes) == 2
+    class_names = sorted([c["class_name"] for c in analyzer.analyzed_classes])
     assert class_names == ["ClassA", "ClassB"]
 
 
@@ -320,9 +320,9 @@ def test_codeanalyzer_finds_method():
     analyzer = CodeAnalyzer()
     tree = ast.parse(code)
     analyzer.visit(tree)
-    assert len(analyzer.structure) == 1
-    assert len(analyzer.structure[0]["methods"]) == 1
-    assert analyzer.structure[0]["methods"][0]["method_name"] == "my_method"
+    assert len(analyzer.analyzed_classes) == 1
+    assert len(analyzer.analyzed_classes[0]["methods"]) == 1
+    assert analyzer.analyzed_classes[0]["methods"][0]["method_name"] == "my_method"
 
 
 def test_codeanalyzer_finds_multiple_methods():
@@ -339,8 +339,8 @@ def test_codeanalyzer_finds_multiple_methods():
     analyzer = CodeAnalyzer()
     tree = ast.parse(code)
     analyzer.visit(tree)
-    assert len(analyzer.structure) == 1
-    method_names = sorted([m["method_name"] for m in analyzer.structure[0]["methods"]])
+    assert len(analyzer.analyzed_classes) == 1
+    method_names = sorted([m["method_name"] for m in analyzer.analyzed_classes[0]["methods"]])
     assert method_names == ["method_a", "method_b"]
 
 
@@ -354,7 +354,7 @@ def test_codeanalyzer_no_classes():
     analyzer = CodeAnalyzer()
     tree = ast.parse(code)
     analyzer.visit(tree)
-    assert len(analyzer.structure) == 0
+    assert len(analyzer.analyzed_classes) == 0
 
 
 def test_codeanalyzer_class_with_no_methods():
@@ -367,9 +367,9 @@ def test_codeanalyzer_class_with_no_methods():
     analyzer = CodeAnalyzer()
     tree = ast.parse(code)
     analyzer.visit(tree)
-    assert len(analyzer.structure) == 1
-    assert analyzer.structure[0]["class_name"] == "MyClass"
-    assert len(analyzer.structure[0]["methods"]) == 0
+    assert len(analyzer.analyzed_classes) == 1
+    assert analyzer.analyzed_classes[0]["class_name"] == "MyClass"
+    assert len(analyzer.analyzed_classes[0]["methods"]) == 0
 
 
 # --- Test Data for Parameterization ---
@@ -489,10 +489,10 @@ class TestCodeAnalyzerArgsReturns:
         "code_snippet, expected_args, expected_return", TYPE_TEST_CASES
     )
     def test_type_extraction(self, code_snippet, expected_args, expected_return):
-        structure, imports, types = parse_code(code_snippet)
+        analyzed_classes, imports, types = parse_code(code_snippet)
 
-        assert len(structure) == 1, "Should parse one class"
-        class_info = structure[0]
+        assert len(analyzed_classes) == 1, "Should parse one class"
+        class_info = analyzed_classes[0]
         assert class_info["class_name"] == "TestClass"
 
         assert len(class_info["methods"]) == 1, "Should find one method"

--- a/scripts/microgenerator/tests/unit/test_generate_parser.py
+++ b/scripts/microgenerator/tests/unit/test_generate_parser.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+from unittest import mock
+import textwrap as tw
+
+from scripts.microgenerator import generate
+
+
+# --- Tests for parse_code() ---
+def test_parse_code_empty():
+    analyzed_classes, imports, types = generate.parse_code("")
+    assert analyzed_classes == []
+    assert imports == set()
+    assert types == set()
+
+
+def test_parse_code_simple_class():
+    code = tw.dedent(
+        """
+        class MyClass:
+            pass
+    """
+    )
+    analyzed_classes, _, _ = generate.parse_code(code)
+    assert len(analyzed_classes) == 1
+    assert analyzed_classes[0]["class_name"] == "MyClass"
+
+
+def test_parse_code_simple_function():
+    code = tw.dedent(
+        """
+        def my_function():
+            pass
+    """
+    )
+
+    # In the microgenerator, the focus is parsing major classes (and their
+    # associated methods in the GAPIC generated code, not parsing top-level
+    # functions. Thus we do not expect it to capture this top-level function.
+    analyzed_classes, _, _ = generate.parse_code(code)
+    assert len(analyzed_classes) == 0
+
+
+def test_parse_code_invalid_syntax():
+    with pytest.raises(SyntaxError):
+        # incorrect indentation and missing trailing colon on func definition.
+        code = tw.dedent(
+            """
+            class MyClass:
+                pass
+              def func()
+                pass
+        """
+        )
+        generate.parse_code(code)
+
+
+def test_parse_code_with_imports_and_types():
+    code = tw.dedent(
+        """
+        import os
+        import sys as system
+        from typing import List, Optional, Dict
+        from . import my_module
+
+        class MyClass:
+            attr: Dict[str, int]
+            def method(self, x: List[str]) -> Optional[int]:
+                return None
+            def method2(self, y: 'MyClass') -> None:
+                pass
+    """
+    )
+    analyzed_classes, imports, types = generate.parse_code(code)
+
+    expected_imports = {
+        "import os",
+        "import sys as system",
+        "from typing import List, Optional, Dict",
+        "from . import my_module",
+    }
+    assert imports == expected_imports
+
+    expected_types = {
+        "Dict",
+        "str",
+        "int",
+        "List",
+        "Optional",
+        "MyClass",
+        "None",
+    }
+    assert types == expected_types
+    assert len(analyzed_classes) == 1
+
+
+# --- Tests for parse_file() ---
+# parse_file() wraps parse_code() and simply reads in content from a file
+# as a string using the built in open() function and passes the string intact
+# to parse_code().
+@mock.patch("builtins.open", new_callable=mock.mock_open)
+def test_parse_file_reads_and_parses(mock_file):
+    read_data = tw.dedent(
+        """
+        class TestClass:
+            pass
+    """
+    )
+    mock_file.return_value.read.return_value = read_data
+    analyzed_classes, _, _ = generate.parse_file("dummy/path/file.py")
+    mock_file.assert_called_once_with("dummy/path/file.py", "r", encoding="utf-8")
+    assert len(analyzed_classes) == 1
+    assert analyzed_classes[0]["class_name"] == "TestClass"
+
+
+@mock.patch("builtins.open", side_effect=FileNotFoundError)
+def test_parse_file_not_found(mock_file):
+    with pytest.raises(FileNotFoundError):
+        generate.parse_file("nonexistent.py")
+    mock_file.assert_called_once_with("nonexistent.py", "r", encoding="utf-8")
+
+
+@mock.patch("builtins.open", new_callable=mock.mock_open)
+def test_parse_file_syntax_error(mock_file):
+    mock_file.return_value.read.return_value = "a = ("
+    with pytest.raises(SyntaxError):
+        generate.parse_file("syntax_error.py")
+    mock_file.assert_called_once_with("syntax_error.py", "r", encoding="utf-8")
+
+
+@mock.patch(
+    "scripts.microgenerator.generate.parse_code", return_value=([], set(), set())
+)
+@mock.patch("builtins.open", new_callable=mock.mock_open)
+def test_parse_file_calls_parse_code(mock_file, mock_parse_code):
+    """This test simply confirms that parse_code() gets called internally.
+
+    Other parse_code tests ensure that it works as expected.
+    """
+    read_data = "some code"
+    mock_file.return_value.read.return_value = read_data
+    generate.parse_file("some_file.py")
+    mock_parse_code.assert_called_once_with(read_data)

--- a/scripts/microgenerator/utils.py
+++ b/scripts/microgenerator/utils.py
@@ -111,7 +111,7 @@ def write_code_to_file(output_path: str, content: str):
         print(f"  Ensuring output directory exists: {os.path.abspath(output_dir)}")
         os.makedirs(output_dir, exist_ok=True)
         if not os.path.isdir(output_dir):
-            print(f"  Error: Output directory was not created.", file=sys.stderr)
+            print("  Error: Output directory was not created.", file=sys.stderr)
             sys.exit(1)
 
     print(f"  Writing generated code to: {os.path.abspath(output_path)}")


### PR DESCRIPTION
This PR:

* refactors the names of several variables for additional clarity
* edits logic to capture `None` and typehints that were being missed (e.g. Dict in certain cases)
* updates noxfile.py so that tests will run
* adds tests for the `parse_code()` and `parse_file()` methods
* fixes a minor lint error
