### PR TITLE
fix: include `io.IOBase` in the `PathType`

### DIFF
--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -139,7 +139,7 @@ ResumableTimeoutType = Union[
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
     # os.PathLike is only subscriptable in Python 3.9+, thus shielding with a condition.
-    PathType = Union[str, bytes, os.PathLike[str], os.PathLike[bytes]]
+    PathType = Union[str, bytes, os.PathLike[str], os.PathLike[bytes], io.IOBase]
 _DEFAULT_CHUNKSIZE = 100 * 1024 * 1024  # 100 MB
 _MAX_MULTIPART_SIZE = 5 * 1024 * 1024
 _DEFAULT_NUM_RETRIES = 6


### PR DESCRIPTION
Add `io.IOBase` to the PathType. 

Reasons:
* Our code allows and explicitly checks IOBase input: https://github.com/googleapis/python-bigquery/blob/fa76e310a16ea6cba0071ff1d767ca1c71514da7/google/cloud/bigquery/client.py#L4334
*  In Google3 we have this type too

There's no reason that `PathType` in the GitHub version does not include `io.IOBase`

fix: #452403174  🦕
