### PR TITLE
chore: librarian release pull request: 20251107T183245Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,8 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:39628f6e89c9cad27973b9a39a50f7052bec0435ee58c7027b4fa6b655943e31
 libraries:
   - id: google-cloud-bigquery
-    version: 3.38.0
+    version: 3.39.0
+    last_generated_commit: ""
     apis: []
     source_roots:
       - .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 [1]: https://pypi.org/project/google-cloud-bigquery/#history
 
+## [3.39.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-bigquery-v3.38.0...google-cloud-bigquery-v3.39.0) (2025-11-07)
+
+
+### Documentation
+
+* remove experimental annotations from GA features (#2303) ([1f1f9d41e8a2c9016198d848ad3f1cbb88cf77b0](https://github.com/googleapis/google-cloud-python/commit/1f1f9d41e8a2c9016198d848ad3f1cbb88cf77b0))
+
+
+### Features
+
+* adds support for Python runtime 3.14 (#2322) ([6065e14c448cb430189982dd70025fa0575777ca](https://github.com/googleapis/google-cloud-python/commit/6065e14c448cb430189982dd70025fa0575777ca))
+* Add ExternalRuntimeOptions to BigQuery routine (#2311) ([fa76e310a16ea6cba0071ff1d767ca1c71514da7](https://github.com/googleapis/google-cloud-python/commit/fa76e310a16ea6cba0071ff1d767ca1c71514da7))
+
+
+### Bug Fixes
+
+* include `io.Base` in the `PathType` (#2323) ([b11e09cb6ee32e451b37eda66bece2220b9ceaba](https://github.com/googleapis/google-cloud-python/commit/b11e09cb6ee32e451b37eda66bece2220b9ceaba))
+* honor custom `retry` in `job.result()` (#2302) ([e118b029bbc89a5adbab83f39858c356c23665bf](https://github.com/googleapis/google-cloud-python/commit/e118b029bbc89a5adbab83f39858c356c23665bf))
+* remove ambiguous error codes from query retries (#2308) ([8bbd3d01026c493dfa5903b397d2b01c0e9bf43b](https://github.com/googleapis/google-cloud-python/commit/8bbd3d01026c493dfa5903b397d2b01c0e9bf43b))
+
 
 ## [3.38.0](https://github.com/googleapis/python-bigquery/compare/v3.37.0...v3.38.0) (2025-09-15)
 

--- a/google/cloud/bigquery/version.py
+++ b/google/cloud/bigquery/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "3.38.0"
+__version__ = "3.39.0"


### PR DESCRIPTION
Librarian Version: v0.5.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:39628f6e89c9cad27973b9a39a50f7052bec0435ee58c7027b4fa6b655943e31
<details><summary>google-cloud-bigquery: 3.39.0</summary>

## [3.39.0](https://github.com/googleapis/python-bigquery/compare/v3.38.0...v3.39.0) (2025-11-07)

### Features

* adds support for Python runtime 3.14 (#2322) ([6065e14c](https://github.com/googleapis/python-bigquery/commit/6065e14c))

* Add ExternalRuntimeOptions to BigQuery routine (#2311) ([fa76e310](https://github.com/googleapis/python-bigquery/commit/fa76e310))

### Bug Fixes

* include `io.Base` in the `PathType` (#2323) ([b11e09cb](https://github.com/googleapis/python-bigquery/commit/b11e09cb))

* honor custom `retry` in `job.result()` (#2302) ([e118b029](https://github.com/googleapis/python-bigquery/commit/e118b029))

* remove ambiguous error codes from query retries (#2308) ([8bbd3d01](https://github.com/googleapis/python-bigquery/commit/8bbd3d01))

### Documentation

* remove experimental annotations from GA features (#2303) ([1f1f9d41](https://github.com/googleapis/python-bigquery/commit/1f1f9d41))

</details>