### PR TITLE
tests: temporarily pin pytest

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -95,7 +95,8 @@ def default(session, install_extras=True):
 
     # Install all test dependencies, then install local packages in-place.
     session.install(
-        "pytest",
+        # TODO(https://github.com/pytest-dev/pytest-xdist/issues/1273): Remove once this bug is fixed
+        "pytest<9",
         "google-cloud-testutils",
         "pytest-cov",
         "pytest-xdist",


### PR DESCRIPTION
Temporarily pin `pytest < 9` to resolve the following issue

```
        for invalid_view_value in invalid_view_values:
>           with self.subTest(invalid_view_value=invalid_view_value):

tests/unit/test_client.py:810: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/contextlib.py:144: in __exit__
    next(self.gen)
/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/contextlib.py:144: in __exit__
    next(self.gen)
.nox/unit-3-11/lib/python3.11/site-packages/_pytest/unittest.py:438: in addSubTest
    self.ihook.pytest_runtest_logreport(report=sub_report)
.nox/unit-3-11/lib/python3.11/site-packages/pluggy/_hooks.py:512: in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.nox/unit-3-11/lib/python3.11/site-packages/pluggy/_manager.py:120: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.nox/unit-3-11/lib/python3.11/site-packages/xdist/remote.py:289: in pytest_runtest_logreport
    self.sendevent("testreport", data=data)
.nox/unit-3-11/lib/python3.11/site-packages/xdist/remote.py:126: in sendevent
    self.channel.send((name, kwargs))
.nox/unit-3-11/lib/python3.11/site-packages/execnet/gateway_base.py:912: in send
    self.gateway._send(Message.CHANNEL_DATA, self.id, dumps_internal(item))
                                                      ^^^^^^^^^^^^^^^^^^^^
.nox/unit-3-11/lib/python3.11/site-packages/execnet/gateway_base.py:1629: in dumps_internal
    return _Serializer().save(obj)  # type: ignore[return-value]
           ^^^^^^^^^^^^^^^^^^^^^^^
.nox/unit-3-11/lib/python3.11/site-packages/execnet/gateway_base.py:1647: in save
    self._save(obj)
.nox/unit-3-11/lib/python3.11/site-packages/execnet/gateway_base.py:1667: in _save
    dispatch(self, obj)
.nox/unit-3-11/lib/python3.11/site-packages/execnet/gateway_base.py:1744: in save_tuple
    self._save(item)
.nox/unit-3-11/lib/python3.11/site-packages/execnet/gateway_base.py:1667: in _save
    dispatch(self, obj)
.nox/unit-3-11/lib/python3.11/site-packages/execnet/gateway_base.py:1740: in save_dict
    self._write_setitem(key, value)
.nox/unit-3-11/lib/python3.11/site-packages/execnet/gateway_base.py:1734: in _write_setitem
    self._save(value)
.nox/unit-3-11/lib/python3.11/site-packages/execnet/gateway_base.py:1667: in _save
    dispatch(self, obj)
.nox/unit-3-11/lib/python3.11/site-packages/execnet/gateway_base.py:1740: in save_dict
    self._write_setitem(key, value)
.nox/unit-3-11/lib/python3.11/site-packages/execnet/gateway_base.py:1734: in _write_setitem
    self._save(value)
.nox/unit-3-11/lib/python3.11/site-packages/execnet/gateway_base.py:1667: in _save
    dispatch(self, obj)
.nox/unit-3-11/lib/python3.11/site-packages/execnet/gateway_base.py:1740: in save_dict
    self._write_setitem(key, value)
.nox/unit-3-11/lib/python3.11/site-packages/execnet/gateway_base.py:1734: in _write_setitem
    self._save(value)
.nox/unit-3-11/lib/python3.11/site-packages/execnet/gateway_base.py:1667: in _save
    dispatch(self, obj)
.nox/unit-3-11/lib/python3.11/site-packages/execnet/gateway_base.py:1740: in save_dict
    self._write_setitem(key, value)
.nox/unit-3-11/lib/python3.11/site-packages/execnet/gateway_base.py:1734: in _write_setitem
    self._save(value)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <execnet.gateway_base._Serializer object at 0x7fc425a0c710>
obj = <object object at 0x7fc425bcb920>

    def _save(self, obj: object) -> None:
        tp = type(obj)
        try:
            dispatch = self._dispatch[tp]
        except KeyError:
            methodname = "save_" + tp.__name__
            meth: Callable[[_Serializer, object], None] | None = getattr(
                self.__class__, methodname, None
            )
            if meth is None:
>               raise DumpError(f"can't serialize {tp}") from None
E               execnet.gateway_base.DumpError: can't serialize <class 'object'>
```

The upstream issue is tracked in https://github.com/pytest-dev/pytest-xdist/issues/1273